### PR TITLE
fix: reconcile LCM writer contract

### DIFF
--- a/backend/internal/domain/decide/types.go
+++ b/backend/internal/domain/decide/types.go
@@ -14,11 +14,11 @@ import (
 // sub-state — leave it unchanged", NOT "set it to the empty value". SessionState
 // is always populated, but the probe/detecting/kill paths legitimately leave
 // PRState/PRReason empty: a liveness verdict knows nothing about the PR. When
-// the LCM turns a decision into a LifecyclePatch it must therefore map an empty
-// PRState to a nil patch.PR (left untouched) rather than writing it through —
+// the LCM folds a decision into the next full canonical row it must therefore
+// leave empty PRState/PRReason unchanged rather than writing them through —
 // writing PRNone on a routine probe tick would clobber a live PR. Detecting is
-// nil-by-default for the same reason; see LifecyclePatch's three-way
-// Detecting/ClearDetecting semantics.
+// nil-by-default; the LCM explicitly clears stale detecting memory when a probe
+// verdict leaves detecting.
 type LifecycleDecision struct {
 	Status        domain.SessionStatus
 	Evidence      string

--- a/backend/internal/domain/lifecycle.go
+++ b/backend/internal/domain/lifecycle.go
@@ -22,9 +22,8 @@ const LifecycleVersion = 1
 type CanonicalSessionLifecycle struct {
 	// Version is the schema version of this record's shape (LifecycleVersion).
 	Version int `json:"version"`
-	// Revision is a monotonic counter the store bumps on every write. It is used
-	// for optimistic-concurrency checks (LifecyclePatch.ExpectedRevision) and is
-	// distinct from the schema Version above.
+	// Revision is a monotonic counter the LCM bumps on every full-row Upsert and
+	// is distinct from the schema Version above.
 	Revision int             `json:"revision"`
 	Session  SessionSubstate `json:"session"`
 	PR       PRSubstate      `json:"pr"`

--- a/backend/internal/domain/lifecycle.go
+++ b/backend/internal/domain/lifecycle.go
@@ -20,10 +20,11 @@ const LifecycleVersion = 1
 // between observations (they are read back by the pure decide core), so they
 // live in the persisted record too.
 type CanonicalSessionLifecycle struct {
-	// Version is the schema version of this record's shape (LifecycleVersion).
-	Version int `json:"version"`
-	// Revision is a monotonic counter the LCM bumps on every full-row Upsert and
-	// is distinct from the schema Version above.
+	// Version is the Go-only schema-shape constant for this record. It is not
+	// persisted and is not part of the CDC payload.
+	Version int
+	// Revision is the per-write monotonic counter. The storage layer's Upsert
+	// bumps it when the full row is persisted; the LCM does not.
 	Revision int             `json:"revision"`
 	Session  SessionSubstate `json:"session"`
 	PR       PRSubstate      `json:"pr"`

--- a/backend/internal/lifecycle/fakes_test.go
+++ b/backend/internal/lifecycle/fakes_test.go
@@ -2,18 +2,14 @@ package lifecycle
 
 import (
 	"context"
-	"fmt"
 	"sync"
-	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
-// fakeStore is an in-memory LifecycleStore that faithfully applies merge-patch
-// semantics (sparse field writes, the three-way Detecting/ClearDetecting rule,
-// ExpectedRevision optimistic-concurrency check, monotonic Revision bump) so
-// tests assert against the real persisted canonical.
+// fakeStore is an in-memory LifecycleStore that faithfully applies full-row
+// Upsert semantics so tests assert against the real persisted canonical.
 type fakeStore struct {
 	mu       sync.Mutex
 	records  map[domain.SessionID]*domain.SessionRecord
@@ -49,53 +45,9 @@ func (s *fakeStore) Load(_ context.Context, id domain.SessionID) (domain.Canonic
 	return rec.Lifecycle, true, nil
 }
 
-func (s *fakeStore) PatchLifecycle(_ context.Context, id domain.SessionID, p ports.LifecyclePatch) error {
+func (s *fakeStore) Upsert(_ context.Context, rec domain.SessionRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
-	rec, ok := s.records[id]
-	if !ok {
-		rec = &domain.SessionRecord{ID: id, Lifecycle: domain.CanonicalSessionLifecycle{Version: domain.LifecycleVersion}}
-		s.records[id] = rec
-	}
-	l := &rec.Lifecycle
-
-	if p.ExpectedRevision != nil && *p.ExpectedRevision != l.Revision {
-		return fmt.Errorf("revision mismatch for %s: have %d, expected %d", id, l.Revision, *p.ExpectedRevision)
-	}
-
-	if p.Session != nil {
-		l.Session = *p.Session
-	}
-	if p.PR != nil {
-		l.PR = *p.PR
-	}
-	if p.Runtime != nil {
-		l.Runtime = *p.Runtime
-	}
-	if p.Activity != nil {
-		l.Activity = *p.Activity
-	}
-	switch {
-	case p.ClearDetecting:
-		l.Detecting = nil
-	case p.Detecting != nil:
-		d := *p.Detecting
-		l.Detecting = &d
-	}
-
-	l.Version = domain.LifecycleVersion
-	l.Revision++
-	rec.UpdatedAt = time.Now()
-	return nil
-}
-
-func (s *fakeStore) Seed(_ context.Context, rec domain.SessionRecord) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if _, ok := s.records[rec.ID]; ok {
-		return fmt.Errorf("seed: session %s already exists", rec.ID)
-	}
 	if rec.Lifecycle.Version == 0 {
 		rec.Lifecycle.Version = domain.LifecycleVersion
 	}

--- a/backend/internal/lifecycle/fakes_test.go
+++ b/backend/internal/lifecycle/fakes_test.go
@@ -2,6 +2,7 @@ package lifecycle
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -45,9 +46,20 @@ func (s *fakeStore) Load(_ context.Context, id domain.SessionID) (domain.Canonic
 	return rec.Lifecycle, true, nil
 }
 
-func (s *fakeStore) Upsert(_ context.Context, rec domain.SessionRecord) error {
+func (s *fakeStore) Upsert(_ context.Context, rec domain.SessionRecord, _ ports.EventType) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if existing, ok := s.records[rec.ID]; ok {
+		if rec.Lifecycle.Revision != existing.Lifecycle.Revision {
+			return fmt.Errorf("revision mismatch for %s: have %d, want %d", rec.ID, rec.Lifecycle.Revision, existing.Lifecycle.Revision)
+		}
+		rec.Lifecycle.Revision = existing.Lifecycle.Revision + 1
+	} else {
+		if rec.Lifecycle.Revision != 0 {
+			return fmt.Errorf("revision mismatch for insert %s: have %d, want 0", rec.ID, rec.Lifecycle.Revision)
+		}
+		rec.Lifecycle.Revision = 1
+	}
 	if rec.Lifecycle.Version == 0 {
 		rec.Lifecycle.Version = domain.LifecycleVersion
 	}

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -1,8 +1,9 @@
 // Package lifecycle implements ports.LifecycleManager: the synchronous
 // observe->decide->persist reducer. Every Apply*/On* entrypoint runs the same
 // pipeline under a per-session lock — load the full canonical record, run the
-// matching pure decider, diff into a full-row Upsert, persist. The LCM never
-// polls and never writes the display status (that is derived on read).
+// matching pure decider, classify the resulting change, and persist the full
+// row through the store. The store owns Revision++; the LCM never polls and
+// never writes the display status (that is derived on read).
 //
 // After a transition is persisted, the Apply* paths fire the mapped reaction
 // (the ACT layer: reaction table + escalation engine) via the react() chokepoint
@@ -120,8 +121,8 @@ type transition struct {
 
 // mutate runs the shared pipeline: load full row -> build next canonical ->
 // Upsert full row (only if changed). decideFn returns the full next lifecycle
-// and whether it changed anything; false is a clean no-op (no write, no revision
-// bump), which is how failed-probe / unknown-fact inputs are dropped.
+// and whether it changed anything; false is a clean no-op (no write), which is
+// how failed-probe / unknown-fact inputs are dropped.
 //
 // On a write it returns the transition (before/after canonical) so the caller —
 // which still holds the originating facts — can fire the mapped reaction.
@@ -144,9 +145,9 @@ func (m *Manager) mutate(
 		if !changed {
 			return nil
 		}
-		rec.Lifecycle = m.prepareLifecycleWrite(cur, next)
+		rec.Lifecycle = m.prepareLifecycleWrite(next)
 		rec.UpdatedAt = m.clock()
-		if err := m.store.Upsert(ctx, rec); err != nil {
+		if err := m.store.Upsert(ctx, rec, classifyEventType(cur, rec.Lifecycle, false)); err != nil {
 			return err
 		}
 		tr = &transition{beforeLC: cur, afterLC: rec.Lifecycle}
@@ -155,9 +156,8 @@ func (m *Manager) mutate(
 	return tr, err
 }
 
-func (m *Manager) prepareLifecycleWrite(cur, next domain.CanonicalSessionLifecycle) domain.CanonicalSessionLifecycle {
+func (m *Manager) prepareLifecycleWrite(next domain.CanonicalSessionLifecycle) domain.CanonicalSessionLifecycle {
 	next.Version = domain.LifecycleVersion
-	next.Revision = cur.Revision + 1
 	return next
 }
 
@@ -285,10 +285,13 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 // OnSpawnInitiated seeds or reopens the full session record for a spawn-like
 // mutation. It is the Session Manager's create/reopen command under the Writer
 // contract: the SM builds the identity + initial canonical row, but only the LCM
-// writes it.
+// writes it. Fresh rows emit session_created; reopening a terminal row reuses
+// the current row as the before-image and lets the classifier emit the schema
+// event for the reopen.
 func (m *Manager) OnSpawnInitiated(ctx context.Context, rec domain.SessionRecord) error {
 	return m.withLock(rec.ID, func() error {
 		cur := rec.Lifecycle
+		isInsert := true
 		if current, ok, err := m.store.Get(ctx, rec.ID); err != nil {
 			return err
 		} else if ok {
@@ -297,14 +300,20 @@ func (m *Manager) OnSpawnInitiated(ctx context.Context, rec domain.SessionRecord
 				return fmt.Errorf("lifecycle: OnSpawnInitiated for active session %q", rec.ID)
 			}
 			cur = currentLC
+			isInsert = false
 		}
-		rec.Lifecycle = m.prepareLifecycleWrite(cur, rec.Lifecycle)
+		rec.Lifecycle = m.prepareLifecycleWrite(rec.Lifecycle)
+		if isInsert {
+			rec.Lifecycle.Revision = 0
+		} else {
+			rec.Lifecycle.Revision = cur.Revision
+		}
 		now := m.clock()
 		if rec.CreatedAt.IsZero() {
 			rec.CreatedAt = now
 		}
 		rec.UpdatedAt = now
-		return m.store.Upsert(ctx, rec)
+		return m.store.Upsert(ctx, rec, classifyEventType(cur, rec.Lifecycle, isInsert))
 	})
 }
 
@@ -329,9 +338,9 @@ func (m *Manager) OnSpawnCompleted(ctx context.Context, id domain.SessionID, o p
 			cur := rec.Lifecycle
 			next := cur
 			next.Runtime = rt
-			rec.Lifecycle = m.prepareLifecycleWrite(cur, next)
+			rec.Lifecycle = m.prepareLifecycleWrite(next)
 			rec.UpdatedAt = m.clock()
-			if err := m.store.Upsert(ctx, rec); err != nil {
+			if err := m.store.Upsert(ctx, rec, classifyEventType(cur, rec.Lifecycle, false)); err != nil {
 				return err
 			}
 		}
@@ -431,6 +440,25 @@ func setDetecting(next *domain.CanonicalSessionLifecycle, d *domain.DetectingSta
 		return true
 	}
 	return false
+}
+
+func classifyEventType(before, after domain.CanonicalSessionLifecycle, isInsert bool) ports.EventType {
+	switch {
+	case isInsert:
+		return ports.EventSessionCreated
+	case before.Session.State != after.Session.State && after.Session.State == domain.SessionTerminated:
+		return ports.EventSessionTerminated
+	case before.Session != after.Session:
+		return ports.EventSessionStateChanged
+	case before.PR != after.PR:
+		return ports.EventSessionPRUpdated
+	case before.Runtime != after.Runtime:
+		return ports.EventSessionRuntimeUpdated
+	case before.Activity != after.Activity:
+		return ports.EventSessionActivityUpdated
+	default:
+		return ports.EventSessionUpdated
+	}
 }
 
 // sameActivity compares activity sub-states with time-aware equality (== on

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -1,12 +1,12 @@
 // Package lifecycle implements ports.LifecycleManager: the synchronous
 // observe->decide->persist reducer. Every Apply*/On* entrypoint runs the same
-// pipeline under a per-session lock — load canonical, run the matching pure
-// decider, diff the result into a sparse merge-patch, persist. The LCM never
+// pipeline under a per-session lock — load the full canonical record, run the
+// matching pure decider, diff into a full-row Upsert, persist. The LCM never
 // polls and never writes the display status (that is derived on read).
 //
 // After a transition is persisted, the Apply* paths fire the mapped reaction
 // (the ACT layer: reaction table + escalation engine) via the react() chokepoint
-// in reactions.go. The Session Manager lands in a later split.
+// in reactions.go.
 package lifecycle
 
 import (
@@ -111,16 +111,16 @@ func (m *Manager) withLock(id domain.SessionID, fn func() error) error {
 }
 
 // transition is what a persisted write produced: the canonical before and after
-// the patch. The ACT layer (react) derives the reaction from these. It is nil
-// when the pipeline made no write.
+// the full-row upsert. The ACT layer (react) derives the reaction from these. It
+// is nil when the pipeline made no write.
 type transition struct {
 	beforeLC domain.CanonicalSessionLifecycle
 	afterLC  domain.CanonicalSessionLifecycle
 }
 
-// mutate runs the shared pipeline: load -> build patch -> persist (only if the
-// patch changed something). decideFn returns the diffed patch and whether it
-// touches anything; a false "changed" is a clean no-op (no write, no revision
+// mutate runs the shared pipeline: load full row -> build next canonical ->
+// Upsert full row (only if changed). decideFn returns the full next lifecycle
+// and whether it changed anything; false is a clean no-op (no write, no revision
 // bump), which is how failed-probe / unknown-fact inputs are dropped.
 //
 // On a write it returns the transition (before/after canonical) so the caller —
@@ -128,32 +128,37 @@ type transition struct {
 func (m *Manager) mutate(
 	ctx context.Context,
 	id domain.SessionID,
-	decideFn func(cur domain.CanonicalSessionLifecycle, exists bool) (ports.LifecyclePatch, bool, error),
+	decideFn func(cur domain.CanonicalSessionLifecycle, exists bool) (domain.CanonicalSessionLifecycle, bool, error),
 ) (*transition, error) {
 	var tr *transition
 	err := m.withLock(id, func() error {
-		cur, exists, err := m.store.Load(ctx, id)
+		rec, exists, err := m.store.Get(ctx, id)
 		if err != nil {
 			return err
 		}
-		patch, changed, err := decideFn(cur, exists)
+		cur := rec.Lifecycle
+		next, changed, err := decideFn(cur, exists)
 		if err != nil {
 			return err
 		}
 		if !changed {
 			return nil
 		}
-		if err := m.store.PatchLifecycle(ctx, id, patch); err != nil {
+		rec.Lifecycle = m.prepareLifecycleWrite(cur, next)
+		rec.UpdatedAt = m.clock()
+		if err := m.store.Upsert(ctx, rec); err != nil {
 			return err
 		}
-		after, _, err := m.store.Load(ctx, id)
-		if err != nil {
-			return err
-		}
-		tr = &transition{beforeLC: cur, afterLC: after}
+		tr = &transition{beforeLC: cur, afterLC: rec.Lifecycle}
 		return nil
 	})
 	return tr, err
+}
+
+func (m *Manager) prepareLifecycleWrite(cur, next domain.CanonicalSessionLifecycle) domain.CanonicalSessionLifecycle {
+	next.Version = domain.LifecycleVersion
+	next.Revision = cur.Revision + 1
+	return next
 }
 
 // ---- OBSERVE entrypoints ----
@@ -163,18 +168,18 @@ func (m *Manager) mutate(
 // non-detecting verdict clears any stale detecting memory (#3) so the next
 // probe doesn't read a phantom prior.
 func (m *Manager) ApplyRuntimeObservation(ctx context.Context, id domain.SessionID, f ports.RuntimeFacts) error {
-	tr, err := m.mutate(ctx, id, func(cur domain.CanonicalSessionLifecycle, exists bool) (ports.LifecyclePatch, bool, error) {
+	tr, err := m.mutate(ctx, id, func(cur domain.CanonicalSessionLifecycle, exists bool) (domain.CanonicalSessionLifecycle, bool, error) {
 		if !exists {
-			return ports.LifecyclePatch{}, false, nil // nothing seeded; ignore stray probe
+			return cur, false, nil // nothing seeded; ignore stray probe
 		}
 
 		d := decide.ResolveProbeDecision(runtimeFactsToProbeInput(f, cur, m.recentActivityWindow))
 
-		var patch ports.LifecyclePatch
+		next := cur
 		changed := false
 
 		if rt := runtimeSubstateFromFacts(f); cur.Runtime != rt {
-			patch.Runtime = &rt
+			next.Runtime = rt
 			changed = true
 		}
 		// A terminal session is reopened only by an explicit Restore: an
@@ -182,12 +187,12 @@ func (m *Manager) ApplyRuntimeObservation(ctx context.Context, id domain.Session
 		// the session axis nor the detecting memory.
 		if !isTerminal(cur.Session.State) {
 			if shouldWriteSessionRuntime(d, cur) {
-				changed = setSessionIfChanged(&patch, cur, d.SessionState, d.SessionReason) || changed
+				changed = setSessionIfChanged(&next, d.SessionState, d.SessionReason) || changed
 			}
-			changed = setDetecting(&patch, cur, d.Detecting) || changed
+			changed = setDetecting(&next, d.Detecting) || changed
 		}
 
-		return patch, changed, nil
+		return next, changed, nil
 	})
 	if err != nil {
 		return err
@@ -200,34 +205,34 @@ func (m *Manager) ApplyRuntimeObservation(ctx context.Context, id domain.Session
 // the session axis stays owned by activity, and DeriveLegacyStatus surfaces the
 // PR reason for display. A terminal PR (merged/closed) also parks the session.
 func (m *Manager) ApplySCMObservation(ctx context.Context, id domain.SessionID, f ports.SCMFacts) error {
-	tr, err := m.mutate(ctx, id, func(cur domain.CanonicalSessionLifecycle, exists bool) (ports.LifecyclePatch, bool, error) {
+	tr, err := m.mutate(ctx, id, func(cur domain.CanonicalSessionLifecycle, exists bool) (domain.CanonicalSessionLifecycle, bool, error) {
 		if !exists || !f.Fetched {
-			return ports.LifecyclePatch{}, false, nil
+			return cur, false, nil
 		}
 
 		switch f.PRState {
 		case domain.PRDraft, domain.PROpen:
 			d := decide.ResolveOpenPRDecision(openPRInput(f))
-			var patch ports.LifecyclePatch
-			changed := setPRIfChanged(&patch, cur, d, f)
-			return patch, changed, nil
+			next := cur
+			changed := setPRIfChanged(&next, d, f)
+			return next, changed, nil
 
 		case domain.PRMerged, domain.PRClosed:
 			d := decide.ResolveTerminalPRStateDecision(f.PRState)
-			var patch ports.LifecyclePatch
-			changed := setPRIfChanged(&patch, cur, d, f)
+			next := cur
+			changed := setPRIfChanged(&next, d, f)
 			// A merge/close is a milestone that ends the work, so it parks the
 			// session axis (idle / merged_waiting_decision) even over an
 			// activity-owned needs_input/blocked — unlike the open-PR path,
 			// which leaves the session axis to activity. A terminal session is
 			// still never reopened.
 			if !isTerminal(cur.Session.State) {
-				changed = setSessionIfChanged(&patch, cur, d.SessionState, d.SessionReason) || changed
+				changed = setSessionIfChanged(&next, d.SessionState, d.SessionReason) || changed
 			}
-			return patch, changed, nil
+			return next, changed, nil
 
 		default: // none / unset: no PR-driven transition in split A
-			return ports.LifecyclePatch{}, false, nil
+			return cur, false, nil
 		}
 	})
 	if err != nil {
@@ -243,31 +248,31 @@ func (m *Manager) ApplySCMObservation(ctx context.Context, id domain.SessionID, 
 // life, so it may resolve a detecting session — clearing the quarantine memory
 // so a later probe doesn't resume counting from a stale prior.
 func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, s ports.ActivitySignal) error {
-	tr, err := m.mutate(ctx, id, func(cur domain.CanonicalSessionLifecycle, exists bool) (ports.LifecyclePatch, bool, error) {
+	tr, err := m.mutate(ctx, id, func(cur domain.CanonicalSessionLifecycle, exists bool) (domain.CanonicalSessionLifecycle, bool, error) {
 		if !exists || s.State != ports.SignalValid {
-			return ports.LifecyclePatch{}, false, nil
+			return cur, false, nil
 		}
 
-		var patch ports.LifecyclePatch
+		next := cur
 		changed := false
 
 		act := domain.ActivitySubstate{State: s.Activity, LastActivityAt: nowOr(s.Timestamp), Source: s.Source}
 		if !sameActivity(cur.Activity, act) {
-			patch.Activity = &act
+			next.Activity = act
 			changed = true
 		}
 		if st, rs, ok := activityToSession(s.Activity); ok && shouldWriteSessionActivity(cur) {
-			changed = setSessionIfChanged(&patch, cur, st, rs) || changed
+			changed = setSessionIfChanged(&next, st, rs) || changed
 			// Proof of life that pulls the session out of detecting must also
 			// drop the quarantine memory (detecting memory only exists while
 			// detecting, so this is a no-op otherwise).
 			if cur.Detecting != nil {
-				patch.ClearDetecting = true
+				next.Detecting = nil
 				changed = true
 			}
 		}
 
-		return patch, changed, nil
+		return next, changed, nil
 	})
 	if err != nil {
 		return err
@@ -275,7 +280,24 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	return m.react(ctx, id, tr, reactionContext{})
 }
 
-// ---- mutation outcomes reported by the Session Manager ----
+// ---- mutation commands/outcomes reported by the Session Manager ----
+
+// OnSpawnInitiated seeds or reopens the full session record for a spawn-like
+// mutation. It is the Session Manager's create/reopen command under the Writer
+// contract: the SM builds the identity + initial canonical row, but only the LCM
+// writes it.
+func (m *Manager) OnSpawnInitiated(ctx context.Context, rec domain.SessionRecord) error {
+	return m.withLock(rec.ID, func() error {
+		cur := rec.Lifecycle
+		rec.Lifecycle = m.prepareLifecycleWrite(cur, cur)
+		now := m.clock()
+		if rec.CreatedAt.IsZero() {
+			rec.CreatedAt = now
+		}
+		rec.UpdatedAt = now
+		return m.store.Upsert(ctx, rec)
+	})
+}
 
 // OnSpawnCompleted records that a spawn finished: the runtime is up and the
 // handles are known. Per the agreed rule it flips the runtime axis to alive and
@@ -283,7 +305,7 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 // (display: spawning) — the agent "acknowledges" via the first activity signal.
 func (m *Manager) OnSpawnCompleted(ctx context.Context, id domain.SessionID, o ports.SpawnOutcome) error {
 	return m.withLock(id, func() error {
-		cur, exists, err := m.store.Load(ctx, id)
+		rec, exists, err := m.store.Get(ctx, id)
 		if err != nil {
 			return err
 		}
@@ -294,8 +316,13 @@ func (m *Manager) OnSpawnCompleted(ctx context.Context, id domain.SessionID, o p
 			return fmt.Errorf("lifecycle: OnSpawnCompleted for unseeded session %q", id)
 		}
 		rt := domain.RuntimeSubstate{State: domain.RuntimeAlive, Reason: domain.RuntimeReasonProcessRunning}
-		if cur.Runtime != rt {
-			if err := m.store.PatchLifecycle(ctx, id, ports.LifecyclePatch{Runtime: &rt}); err != nil {
+		if rec.Lifecycle.Runtime != rt {
+			cur := rec.Lifecycle
+			next := cur
+			next.Runtime = rt
+			rec.Lifecycle = m.prepareLifecycleWrite(cur, next)
+			rec.UpdatedAt = m.clock()
+			if err := m.store.Upsert(ctx, rec); err != nil {
 				return err
 			}
 		}
@@ -315,30 +342,30 @@ func (m *Manager) OnSpawnCompleted(ctx context.Context, id domain.SessionID, o p
 func (m *Manager) OnKillRequested(ctx context.Context, id domain.SessionID, r ports.KillReason) error {
 	// An explicit user kill is a human action, not an inferred event, so it
 	// fires no reaction — the transition is discarded.
-	_, err := m.mutate(ctx, id, func(cur domain.CanonicalSessionLifecycle, exists bool) (ports.LifecyclePatch, bool, error) {
+	_, err := m.mutate(ctx, id, func(cur domain.CanonicalSessionLifecycle, exists bool) (domain.CanonicalSessionLifecycle, bool, error) {
 		if !exists {
 			// Killing an unknown/already-gone session is a benign race; no-op
 			// rather than fabricating a terminal record for a session we never
 			// knew about.
-			return ports.LifecyclePatch{}, false, nil
+			return cur, false, nil
 		}
 
-		var patch ports.LifecyclePatch
+		next := cur
 		changed := false
 
 		if sess := killSession(r.Kind); cur.Session != sess {
-			patch.Session = &sess
+			next.Session = sess
 			changed = true
 		}
 		if rt := killRuntime(r.Kind); cur.Runtime != rt {
-			patch.Runtime = &rt
+			next.Runtime = rt
 			changed = true
 		}
 		if cur.Detecting != nil {
-			patch.ClearDetecting = true
+			next.Detecting = nil
 			changed = true
 		}
-		return patch, changed, nil
+		return next, changed, nil
 	})
 	if err != nil {
 		return err
@@ -350,47 +377,48 @@ func (m *Manager) OnKillRequested(ctx context.Context, id domain.SessionID, r po
 	return nil
 }
 
-// ---- patch helpers (diff -> sparse merge-patch) ----
+// ---- diff helpers ----
 
-// setSessionIfChanged sets patch.Session only when the decided sub-state
-// differs from current; an empty decided state means "decider does not address
-// the session axis" and is left untouched.
-func setSessionIfChanged(patch *ports.LifecyclePatch, cur domain.CanonicalSessionLifecycle, st domain.SessionState, rs domain.SessionReason) bool {
+// setSessionIfChanged sets next.Session only when the decided sub-state differs
+// from the current next value; an empty decided state means "decider does not
+// address the session axis" and is left untouched.
+func setSessionIfChanged(next *domain.CanonicalSessionLifecycle, st domain.SessionState, rs domain.SessionReason) bool {
 	if st == "" {
 		return false
 	}
 	want := domain.SessionSubstate{State: st, Reason: rs}
-	if cur.Session == want {
+	if next.Session == want {
 		return false
 	}
-	patch.Session = &want
+	next.Session = want
 	return true
 }
 
 // setPRIfChanged folds the decided PR sub-state plus the fact-borne PR identity
-// (number/url) into the patch when it differs from current.
-func setPRIfChanged(patch *ports.LifecyclePatch, cur domain.CanonicalSessionLifecycle, d decide.LifecycleDecision, f ports.SCMFacts) bool {
+// (number/url) into next when it differs from the current next value.
+func setPRIfChanged(next *domain.CanonicalSessionLifecycle, d decide.LifecycleDecision, f ports.SCMFacts) bool {
 	want := domain.PRSubstate{State: d.PRState, Reason: d.PRReason, Number: f.PRNumber, URL: f.PRURL}
-	if cur.PR == want {
+	if next.PR == want {
 		return false
 	}
-	patch.PR = &want
+	next.PR = want
 	return true
 }
 
-// setDetecting implements the three-way detecting semantics: set/replace when
-// the decision carries memory, clear (#3) when it doesn't but canonical still
-// holds stale memory, else leave untouched.
-func setDetecting(patch *ports.LifecyclePatch, cur domain.CanonicalSessionLifecycle, d *domain.DetectingState) bool {
+// setDetecting implements the detecting semantics on the full canonical row:
+// set/replace when the decision carries memory, clear (#3) when it doesn't but
+// canonical still holds stale memory, else leave untouched.
+func setDetecting(next *domain.CanonicalSessionLifecycle, d *domain.DetectingState) bool {
 	if d != nil {
-		if cur.Detecting != nil && *cur.Detecting == *d {
+		if next.Detecting != nil && *next.Detecting == *d {
 			return false
 		}
-		patch.Detecting = d
+		dc := *d
+		next.Detecting = &dc
 		return true
 	}
-	if cur.Detecting != nil {
-		patch.ClearDetecting = true
+	if next.Detecting != nil {
+		next.Detecting = nil
 		return true
 	}
 	return false

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -292,7 +292,11 @@ func (m *Manager) OnSpawnInitiated(ctx context.Context, rec domain.SessionRecord
 		if current, ok, err := m.store.Get(ctx, rec.ID); err != nil {
 			return err
 		} else if ok {
-			cur = current.Lifecycle
+			currentLC := current.Lifecycle
+			if !isTerminal(currentLC.Session.State) && !isTerminal(rec.Lifecycle.Session.State) {
+				return fmt.Errorf("lifecycle: OnSpawnInitiated for active session %q", rec.ID)
+			}
+			cur = currentLC
 		}
 		rec.Lifecycle = m.prepareLifecycleWrite(cur, rec.Lifecycle)
 		now := m.clock()

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -289,7 +289,12 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 func (m *Manager) OnSpawnInitiated(ctx context.Context, rec domain.SessionRecord) error {
 	return m.withLock(rec.ID, func() error {
 		cur := rec.Lifecycle
-		rec.Lifecycle = m.prepareLifecycleWrite(cur, cur)
+		if current, ok, err := m.store.Get(ctx, rec.ID); err != nil {
+			return err
+		} else if ok {
+			cur = current.Lifecycle
+		}
+		rec.Lifecycle = m.prepareLifecycleWrite(cur, rec.Lifecycle)
 		now := m.clock()
 		if rec.CreatedAt.IsZero() {
 			rec.CreatedAt = now

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -392,6 +392,25 @@ func TestOnSpawnCompleted(t *testing.T) {
 	}
 }
 
+func TestOnSpawnInitiated_ActiveSessionRejected(t *testing.T) {
+	mgr, store := newManager()
+	store.seed(sid, lc(domain.SessionWorking, domain.ReasonTaskInProgress, domain.RuntimeAlive))
+
+	err := mgr.OnSpawnInitiated(context.Background(), domain.SessionRecord{
+		ID:        sid,
+		ProjectID: domain.ProjectID("proj"),
+		Lifecycle: lc(domain.SessionNotStarted, domain.ReasonSpawnRequested, domain.RuntimeUnknown),
+	})
+	if err == nil {
+		t.Fatal("OnSpawnInitiated should reject a non-terminal row on top of an active session")
+	}
+
+	got := mustLoad(t, store)
+	if got.Session.State != domain.SessionWorking || got.Revision != 0 {
+		t.Fatalf("active row should be unchanged, got %+v", got)
+	}
+}
+
 func TestOnKillRequested(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -454,18 +454,23 @@ func TestOnKillRequested_UnseededIsNoOp(t *testing.T) {
 
 // ---- fake store contract ----
 
-func TestFakeStoreExpectedRevision(t *testing.T) {
+func TestFakeStoreUpsertFullRow(t *testing.T) {
 	store := newFakeStore()
-	store.seed(sid, lc(domain.SessionWorking, domain.ReasonTaskInProgress, domain.RuntimeAlive)) // revision 0
-	rt := domain.RuntimeSubstate{State: domain.RuntimeExited}
+	store.seed(sid, lc(domain.SessionWorking, domain.ReasonTaskInProgress, domain.RuntimeAlive))
 
-	bad := 99
-	if err := store.PatchLifecycle(context.Background(), sid, ports.LifecyclePatch{Runtime: &rt, ExpectedRevision: &bad}); err == nil {
-		t.Error("stale ExpectedRevision must be rejected")
+	rec, ok, err := store.Get(context.Background(), sid)
+	if err != nil || !ok {
+		t.Fatalf("seeded record missing: ok=%v err=%v", ok, err)
 	}
-	good := 0
-	if err := store.PatchLifecycle(context.Background(), sid, ports.LifecyclePatch{Runtime: &rt, ExpectedRevision: &good}); err != nil {
-		t.Errorf("matching ExpectedRevision must succeed, got %v", err)
+	rec.Lifecycle.Session = domain.SessionSubstate{State: domain.SessionIdle, Reason: domain.ReasonResearchComplete}
+	rec.Lifecycle.Runtime = domain.RuntimeSubstate{State: domain.RuntimeExited}
+	if err := store.Upsert(context.Background(), rec); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	got, _, _ := store.Get(context.Background(), sid)
+	if got.Lifecycle.Session.State != domain.SessionIdle || got.Lifecycle.Runtime.State != domain.RuntimeExited {
+		t.Fatalf("upsert should replace the full canonical row, got %+v", got.Lifecycle)
 	}
 }
 

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -483,13 +483,16 @@ func TestFakeStoreUpsertFullRow(t *testing.T) {
 	}
 	rec.Lifecycle.Session = domain.SessionSubstate{State: domain.SessionIdle, Reason: domain.ReasonResearchComplete}
 	rec.Lifecycle.Runtime = domain.RuntimeSubstate{State: domain.RuntimeExited}
-	if err := store.Upsert(context.Background(), rec); err != nil {
+	if err := store.Upsert(context.Background(), rec, ports.EventSessionStateChanged); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
 
 	got, _, _ := store.Get(context.Background(), sid)
 	if got.Lifecycle.Session.State != domain.SessionIdle || got.Lifecycle.Runtime.State != domain.RuntimeExited {
 		t.Fatalf("upsert should replace the full canonical row, got %+v", got.Lifecycle)
+	}
+	if got.Lifecycle.Revision != 1 {
+		t.Fatalf("upsert should bump revision inside the store, got %d want 1", got.Lifecycle.Revision)
 	}
 }
 

--- a/backend/internal/ports/inbound.go
+++ b/backend/internal/ports/inbound.go
@@ -9,7 +9,7 @@ import (
 
 // LifecycleManager is the inbound contract we implement. Every Apply* method
 // runs the same synchronous pipeline: load canonical -> pure decide -> diff ->
-// persist (merge-patch) -> if the status transitioned, fire reactions. The LCM
+// persist (full-row Upsert) -> if the status transitioned, fire reactions. The LCM
 // never polls; observers (SCM poller, reaper, activity ingest) call in.
 //
 // Concurrency: the LCM serialises per session, so concurrent Apply* calls for
@@ -20,7 +20,8 @@ type LifecycleManager interface {
 	ApplyRuntimeObservation(ctx context.Context, id domain.SessionID, f RuntimeFacts) error
 	ApplyActivitySignal(ctx context.Context, id domain.SessionID, s ActivitySignal) error
 
-	// Mutation outcomes reported by the Session Manager.
+	// Mutation commands/outcomes reported by the Session Manager.
+	OnSpawnInitiated(ctx context.Context, rec domain.SessionRecord) error
 	OnSpawnCompleted(ctx context.Context, id domain.SessionID, o SpawnOutcome) error
 	OnKillRequested(ctx context.Context, id domain.SessionID, r KillReason) error
 
@@ -30,8 +31,8 @@ type LifecycleManager interface {
 }
 
 // SessionManager is the inbound contract called by the API layer and CLI. It
-// owns explicit mutations (spawn/kill/restore/cleanup) and never derives or
-// writes observed state directly — it routes outcomes to the LCM.
+// owns explicit mutations (spawn/kill/restore/cleanup) and never writes
+// sessions directly — it routes mutation commands/outcomes to the LCM.
 type SessionManager interface {
 	Spawn(ctx context.Context, cfg SpawnConfig) (domain.Session, error)
 	Kill(ctx context.Context, id domain.SessionID, opts KillOptions) (KillResult, error)

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -6,59 +6,29 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
-// LifecycleStore is the persistence adapter, the ONLY disk writer. It owns
-// merge-patch, atomic write, file lock, and CDC eventing. The LCM and SM only
-// ever touch state through this narrow interface.
+// LifecycleStore is Tom's persistence adapter for session records.
 //
-// List returns persistence records (no derived status); the Session Manager
-// turns those into domain.Session by attaching the derived display status.
+// Writer contract: the Lifecycle Manager (LCM) is the sole logical writer of
+// sessions. Controllers, the Session Manager, observers, and other goroutines
+// must route mutations to the LCM; no other goroutine writes sessions directly.
+// The LCM serializes mutations and calls Upsert with the full SessionRecord.
+// This full-row insert-or-update replaces the older sparse merge-patch model and
+// is safe only under the single-writer LCM invariant.
 //
-// Seed and Get are the two record-with-identity methods the Session Manager
-// needs that the LCM does not: Load returns lifecycle only (all the decider
-// needs), so the SM read-model and explicit-create path would otherwise have no
-// way to write or read a record's identity (ID/ProjectID/IssueID/Kind/CreatedAt)
-// by id. (Co-owned with Tom's persistence layer — added here to close that gap.)
+// List/Get return persistence records (no derived status); the Session Manager
+// hydrates them into domain.Session by attaching DeriveLegacyStatus on read.
 type LifecycleStore interface {
+	// Upsert inserts or replaces the full session row. Only the LCM may call it.
+	Upsert(ctx context.Context, rec domain.SessionRecord) error
 	Load(ctx context.Context, id domain.SessionID) (domain.CanonicalSessionLifecycle, bool, error)
-	PatchLifecycle(ctx context.Context, id domain.SessionID, patch LifecyclePatch) error
 	List(ctx context.Context, project domain.ProjectID) ([]domain.SessionRecord, error)
 	GetMetadata(ctx context.Context, id domain.SessionID) (map[string]string, error)
 	PatchMetadata(ctx context.Context, id domain.SessionID, kv map[string]string) error
 
-	// Seed creates a new record with its identity and initial lifecycle. It is
-	// the SM's explicit-create path (the LCM only ever patches existing records);
-	// OnSpawnCompleted requires a seeded record, so Spawn calls this first. It
-	// must reject a seed for an id that already exists rather than overwrite —
-	// re-seeding an existing session (e.g. Restore) goes through PatchLifecycle.
-	Seed(ctx context.Context, rec domain.SessionRecord) error
-
 	// Get returns a single full record (with identity) by id. Load is
-	// lifecycle-only, so the SM uses this to build the read-model and to
-	// reconstruct teardown handles for Kill/Restore on one id.
+	// lifecycle-only, so readers use this to build the read-model and reconstruct
+	// teardown handles for Kill/Restore on one id.
 	Get(ctx context.Context, id domain.SessionID) (domain.SessionRecord, bool, error)
-}
-
-// LifecyclePatch is a sparse merge-patch: a nil field is left untouched, a
-// non-nil field is written.
-//
-// Detecting needs three-way semantics (leave / set / clear-to-nil):
-//   - ClearDetecting == true  → store clears the detecting memory and IGNORES
-//     the Detecting field (clear wins; setting both is a caller bug).
-//   - ClearDetecting == false, Detecting != nil → set/replace the memory.
-//   - ClearDetecting == false, Detecting == nil  → leave it untouched.
-//
-// ExpectedRevision supports optimistic concurrency: when non-nil the store must
-// reject the patch if the stored Revision (the monotonic write counter, NOT the
-// schema Version) differs. This is the alternative to the LCM owning all
-// per-session serialisation itself.
-type LifecyclePatch struct {
-	Session          *domain.SessionSubstate
-	PR               *domain.PRSubstate
-	Runtime          *domain.RuntimeSubstate
-	Activity         *domain.ActivitySubstate
-	Detecting        *domain.DetectingState
-	ClearDetecting   bool
-	ExpectedRevision *int
 }
 
 // Notifier delivers events to the human (desktop/Slack later). Push, never pull.

--- a/backend/internal/ports/outbound.go
+++ b/backend/internal/ports/outbound.go
@@ -11,15 +11,16 @@ import (
 // Writer contract: the Lifecycle Manager (LCM) is the sole logical writer of
 // sessions. Controllers, the Session Manager, observers, and other goroutines
 // must route mutations to the LCM; no other goroutine writes sessions directly.
-// The LCM serializes mutations and calls Upsert with the full SessionRecord.
-// This full-row insert-or-update replaces the older sparse merge-patch model and
-// is safe only under the single-writer LCM invariant.
+// The LCM serializes mutations and calls Upsert with the full SessionRecord and
+// the classified event_type. The storage layer owns Revision++ and performs the
+// full-row insert-or-update; the older sparse merge-patch model is gone.
 //
 // List/Get return persistence records (no derived status); the Session Manager
 // hydrates them into domain.Session by attaching DeriveLegacyStatus on read.
 type LifecycleStore interface {
-	// Upsert inserts or replaces the full session row. Only the LCM may call it.
-	Upsert(ctx context.Context, rec domain.SessionRecord) error
+	// Upsert inserts or replaces the full session row and bumps Revision inside
+	// the storage layer. Only the LCM may call it.
+	Upsert(ctx context.Context, rec domain.SessionRecord, eventType EventType) error
 	Load(ctx context.Context, id domain.SessionID) (domain.CanonicalSessionLifecycle, bool, error)
 	List(ctx context.Context, project domain.ProjectID) ([]domain.SessionRecord, error)
 	GetMetadata(ctx context.Context, id domain.SessionID) (map[string]string, error)
@@ -30,6 +31,21 @@ type LifecycleStore interface {
 	// teardown handles for Kill/Restore on one id.
 	Get(ctx context.Context, id domain.SessionID) (domain.SessionRecord, bool, error)
 }
+
+// EventType is the schema-level event label attached to each Upsert.
+type EventType string
+
+const (
+	EventSessionCreated          EventType = "session_created"
+	EventSessionTerminated       EventType = "session_terminated"
+	EventSessionStateChanged     EventType = "session_state_changed"
+	EventSessionPRUpdated        EventType = "session_pr_updated"
+	EventSessionRuntimeUpdated   EventType = "session_runtime_updated"
+	EventSessionAttentionUpdated EventType = "session_attention_updated"
+	EventSessionActivityUpdated  EventType = "session_activity_updated"
+	EventSessionDisplayUpdated   EventType = "session_display_updated"
+	EventSessionUpdated          EventType = "session_updated"
+)
 
 // Notifier delivers events to the human (desktop/Slack later). Push, never pull.
 type Notifier interface {

--- a/backend/internal/session/fakes_test.go
+++ b/backend/internal/session/fakes_test.go
@@ -42,7 +42,7 @@ func (c *callLog) indexOf(name string) int {
 	return -1
 }
 
-// ---- fakeStore: in-memory LifecycleStore with faithful merge-patch + Seed/Get ----
+// ---- fakeStore: in-memory LifecycleStore with full-row Upsert + Get ----
 
 type fakeStore struct {
 	mu       sync.Mutex
@@ -59,12 +59,9 @@ func newFakeStore() *fakeStore {
 	}
 }
 
-func (s *fakeStore) Seed(_ context.Context, rec domain.SessionRecord) error {
+func (s *fakeStore) Upsert(_ context.Context, rec domain.SessionRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if _, ok := s.records[rec.ID]; ok {
-		return fmt.Errorf("seed: session %s already exists", rec.ID)
-	}
 	if rec.Lifecycle.Version == 0 {
 		rec.Lifecycle.Version = domain.LifecycleVersion
 	}
@@ -91,47 +88,6 @@ func (s *fakeStore) Load(_ context.Context, id domain.SessionID) (domain.Canonic
 		return domain.CanonicalSessionLifecycle{}, false, nil
 	}
 	return rec.Lifecycle, true, nil
-}
-
-func (s *fakeStore) PatchLifecycle(_ context.Context, id domain.SessionID, p ports.LifecyclePatch) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	rec, ok := s.records[id]
-	if !ok {
-		rec = &domain.SessionRecord{ID: id, Lifecycle: domain.CanonicalSessionLifecycle{Version: domain.LifecycleVersion}}
-		s.records[id] = rec
-	}
-	l := &rec.Lifecycle
-
-	if p.ExpectedRevision != nil && *p.ExpectedRevision != l.Revision {
-		return fmt.Errorf("revision mismatch for %s: have %d, expected %d", id, l.Revision, *p.ExpectedRevision)
-	}
-
-	if p.Session != nil {
-		l.Session = *p.Session
-	}
-	if p.PR != nil {
-		l.PR = *p.PR
-	}
-	if p.Runtime != nil {
-		l.Runtime = *p.Runtime
-	}
-	if p.Activity != nil {
-		l.Activity = *p.Activity
-	}
-	switch {
-	case p.ClearDetecting:
-		l.Detecting = nil
-	case p.Detecting != nil:
-		d := *p.Detecting
-		l.Detecting = &d
-	}
-
-	l.Version = domain.LifecycleVersion
-	l.Revision++
-	rec.UpdatedAt = time.Now()
-	return nil
 }
 
 func (s *fakeStore) List(_ context.Context, project domain.ProjectID) ([]domain.SessionRecord, error) {
@@ -326,6 +282,11 @@ type recordingLCM struct {
 }
 
 var _ ports.LifecycleManager = (*recordingLCM)(nil)
+
+func (l *recordingLCM) OnSpawnInitiated(ctx context.Context, rec domain.SessionRecord) error {
+	l.log.add("OnSpawnInitiated")
+	return l.inner.OnSpawnInitiated(ctx, rec)
+}
 
 func (l *recordingLCM) OnSpawnCompleted(ctx context.Context, id domain.SessionID, o ports.SpawnOutcome) error {
 	l.log.add("OnSpawnCompleted")

--- a/backend/internal/session/fakes_test.go
+++ b/backend/internal/session/fakes_test.go
@@ -59,14 +59,18 @@ func newFakeStore() *fakeStore {
 	}
 }
 
-func (s *fakeStore) Upsert(_ context.Context, rec domain.SessionRecord) error {
+func (s *fakeStore) Upsert(_ context.Context, rec domain.SessionRecord, _ ports.EventType) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if existing, ok := s.records[rec.ID]; ok {
-		if rec.Lifecycle.Revision != existing.Lifecycle.Revision+1 {
-			return fmt.Errorf("revision mismatch for %s: have %d, want %d", rec.ID, rec.Lifecycle.Revision, existing.Lifecycle.Revision+1)
+		if rec.Lifecycle.Revision != existing.Lifecycle.Revision {
+			return fmt.Errorf("revision mismatch for %s: have %d, want %d", rec.ID, rec.Lifecycle.Revision, existing.Lifecycle.Revision)
 		}
-	} else if rec.Lifecycle.Revision == 0 {
+		rec.Lifecycle.Revision = existing.Lifecycle.Revision + 1
+	} else {
+		if rec.Lifecycle.Revision != 0 {
+			return fmt.Errorf("revision mismatch for insert %s: have %d, want 0", rec.ID, rec.Lifecycle.Revision)
+		}
 		rec.Lifecycle.Revision = 1
 	}
 	if rec.Lifecycle.Version == 0 {

--- a/backend/internal/session/fakes_test.go
+++ b/backend/internal/session/fakes_test.go
@@ -62,6 +62,13 @@ func newFakeStore() *fakeStore {
 func (s *fakeStore) Upsert(_ context.Context, rec domain.SessionRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if existing, ok := s.records[rec.ID]; ok {
+		if rec.Lifecycle.Revision != existing.Lifecycle.Revision+1 {
+			return fmt.Errorf("revision mismatch for %s: have %d, want %d", rec.ID, rec.Lifecycle.Revision, existing.Lifecycle.Revision+1)
+		}
+	} else if rec.Lifecycle.Revision == 0 {
+		rec.Lifecycle.Revision = 1
+	}
 	if rec.Lifecycle.Version == 0 {
 		rec.Lifecycle.Version = domain.LifecycleVersion
 	}

--- a/backend/internal/session/manager.go
+++ b/backend/internal/session/manager.go
@@ -101,6 +101,11 @@ func New(d Deps) *Manager {
 // step eagerly rolls back the steps that already succeeded.
 func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Session, error) {
 	id := m.newID(cfg)
+	if _, ok, err := m.store.Get(ctx, id); err != nil {
+		return domain.Session{}, fmt.Errorf("spawn %s: check existing: %w", id, err)
+	} else if ok {
+		return domain.Session{}, fmt.Errorf("spawn %s: already exists", id)
+	}
 
 	ws, err := m.workspace.Create(ctx, ports.WorkspaceConfig{
 		ProjectID: cfg.ProjectID,
@@ -315,6 +320,9 @@ func (m *Manager) Restore(ctx context.Context, id domain.SessionID) (domain.Sess
 	}
 	if err := m.lcm.OnSpawnCompleted(ctx, id, outcome); err != nil {
 		m.rollbackRuntime(ctx, handle)
+		if revertErr := m.lcm.OnSpawnInitiated(ctx, rec); revertErr != nil {
+			return domain.Session{}, fmt.Errorf("restore %s: revert after spawn completed failure: %w (original error: %v)", id, revertErr, err)
+		}
 		return domain.Session{}, fmt.Errorf("restore %s: on spawn completed: %w", id, err)
 	}
 	return m.Get(ctx, id)

--- a/backend/internal/session/manager.go
+++ b/backend/internal/session/manager.go
@@ -320,8 +320,14 @@ func (m *Manager) Restore(ctx context.Context, id domain.SessionID) (domain.Sess
 	}
 	if err := m.lcm.OnSpawnCompleted(ctx, id, outcome); err != nil {
 		m.rollbackRuntime(ctx, handle)
+		// Re-upsert the original record to undo the reopen.
 		if revertErr := m.lcm.OnSpawnInitiated(ctx, rec); revertErr != nil {
 			return domain.Session{}, fmt.Errorf("restore %s: revert after spawn completed failure: %w (original error: %v)", id, revertErr, err)
+		}
+		if len(rec.Metadata) > 0 {
+			if revertErr := m.store.PatchMetadata(ctx, id, rec.Metadata); revertErr != nil {
+				return domain.Session{}, fmt.Errorf("restore %s: revert metadata after spawn completed failure: %w (original error: %v)", id, revertErr, err)
+			}
 		}
 		return domain.Session{}, fmt.Errorf("restore %s: on spawn completed: %w", id, err)
 	}

--- a/backend/internal/session/manager.go
+++ b/backend/internal/session/manager.go
@@ -1,11 +1,10 @@
 // Package session implements ports.SessionManager: the explicit-mutation half
 // of the lane. The SM is impure plumbing — it drives the Runtime/Agent/Workspace
-// plugins to create and tear down sessions, seeds the initial lifecycle record,
-// and routes mutation outcomes to the LCM (OnSpawnCompleted / OnKillRequested).
+// plugins to create and tear down sessions, and routes mutation commands and
+// outcomes to the LCM (OnSpawnInitiated / OnSpawnCompleted / OnKillRequested).
 //
-// It NEVER derives or observes lifecycle state: observed transitions are the
-// LCM's job. The SM's only canonical writes are the explicit ones — seeding a
-// new record on Spawn and re-seeding (reopening) on Restore — and it is the
+// It NEVER writes sessions directly: observed transitions and explicit
+// canonical mutations are the LCM's job under the Writer contract. The SM is the
 // single producer of the derived display status, attached on read in List/Get
 // and never persisted.
 package session
@@ -96,8 +95,8 @@ func New(d Deps) *Manager {
 
 // ---- Spawn ----
 
-// Spawn runs the create pipeline in spec order: workspace -> runtime -> seed ->
-// report to the LCM. The record is seeded LATE (after the runtime is up), so a
+// Spawn runs the create pipeline in spec order: workspace -> runtime -> route
+// seed command to the LCM -> report completion to the LCM. The record is seeded LATE (after the runtime is up), so a
 // failure before the seed leaves no record for Cleanup to reclaim — hence each
 // step eagerly rolls back the steps that already succeeded.
 func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Session, error) {
@@ -124,10 +123,10 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 		return domain.Session{}, fmt.Errorf("spawn %s: runtime create: %w", id, err)
 	}
 
-	if err := m.store.Seed(ctx, seedRecord(id, cfg, m.clock())); err != nil {
+	if err := m.lcm.OnSpawnInitiated(ctx, seedRecord(id, cfg, m.clock())); err != nil {
 		m.rollbackRuntime(ctx, handle)
 		m.rollbackWorkspace(ctx, ws)
-		return domain.Session{}, fmt.Errorf("spawn %s: seed: %w", id, err)
+		return domain.Session{}, fmt.Errorf("spawn %s: on spawn initiated: %w", id, err)
 	}
 
 	outcome := ports.SpawnOutcome{Branch: ws.Branch, WorkspacePath: ws.Path, RuntimeHandle: handle}
@@ -245,7 +244,7 @@ func (m *Manager) Send(ctx context.Context, id domain.SessionID, message string)
 // fallible I/O (workspace restore + runtime create) runs first so a failure
 // touches no canonical state and never destroys the worktree (it may hold the
 // agent's prior work). Only once the runtime is up do we reopen the lifecycle:
-// resetting a terminal session is an explicit mutation (the SM's authority; the
+// resetting a terminal session is an explicit mutation routed to the LCM (the
 // LCM's observe path would never resurrect a terminal session), and the PR axis
 // is cleared. OnSpawnCompleted then flips the runtime to alive.
 func (m *Manager) Restore(ctx context.Context, id domain.SessionID) (domain.Session, error) {
@@ -298,13 +297,14 @@ func (m *Manager) Restore(ctx context.Context, id domain.SessionID) (domain.Sess
 	// Past this point the runtime is live: a failure must tear it back down (but
 	// never the workspace, which holds the agent's prior work) so we don't strand
 	// a process while parking the session in a terminal lifecycle.
-	reopen := ports.LifecyclePatch{
-		Session: &domain.SessionSubstate{State: domain.SessionNotStarted, Reason: domain.ReasonSpawnRequested},
-		PR:      &domain.PRSubstate{State: domain.PRNone, Reason: domain.PRReasonClearedOnRestore},
-	}
-	if err := m.store.PatchLifecycle(ctx, id, reopen); err != nil {
+	reopen := rec
+	reopen.Lifecycle.Session = domain.SessionSubstate{State: domain.SessionNotStarted, Reason: domain.ReasonSpawnRequested}
+	reopen.Lifecycle.PR = domain.PRSubstate{State: domain.PRNone, Reason: domain.PRReasonClearedOnRestore}
+	reopen.Lifecycle.Runtime = domain.RuntimeSubstate{State: domain.RuntimeUnknown, Reason: domain.RuntimeReasonSpawnIncomplete}
+	reopen.Lifecycle.Detecting = nil
+	if err := m.lcm.OnSpawnInitiated(ctx, reopen); err != nil {
 		m.rollbackRuntime(ctx, handle)
-		return domain.Session{}, fmt.Errorf("restore %s: reopen: %w", id, err)
+		return domain.Session{}, fmt.Errorf("restore %s: on spawn initiated: %w", id, err)
 	}
 
 	outcome := ports.SpawnOutcome{

--- a/backend/internal/session/manager.go
+++ b/backend/internal/session/manager.go
@@ -320,7 +320,8 @@ func (m *Manager) Restore(ctx context.Context, id domain.SessionID) (domain.Sess
 	}
 	if err := m.lcm.OnSpawnCompleted(ctx, id, outcome); err != nil {
 		m.rollbackRuntime(ctx, handle)
-		// Re-upsert the original record to undo the reopen.
+		// Re-upsert the original record to undo the reopen; the store will
+		// assign the next revision.
 		if revertErr := m.lcm.OnSpawnInitiated(ctx, rec); revertErr != nil {
 			return domain.Session{}, fmt.Errorf("restore %s: revert after spawn completed failure: %w (original error: %v)", id, revertErr, err)
 		}

--- a/backend/internal/session/manager_test.go
+++ b/backend/internal/session/manager_test.go
@@ -121,6 +121,32 @@ func TestSpawn_RuntimeCreateFailure_RollsBack(t *testing.T) {
 	}
 }
 
+func TestSpawn_ExistingSessionIDRejectedBeforeWork(t *testing.T) {
+	h := newHarness("sess-1")
+	ctx := context.Background()
+	if err := h.store.Upsert(ctx, domain.SessionRecord{
+		ID:        "sess-1",
+		ProjectID: testProject,
+		Lifecycle: lc(domain.SessionWorking, domain.ReasonTaskInProgress, domain.PRNone, ""),
+	}); err != nil {
+		t.Fatalf("seed existing row: %v", err)
+	}
+
+	_, err := h.sm.Spawn(ctx, spawnCfg())
+	if err == nil {
+		t.Fatal("spawn: want error for existing session id, got nil")
+	}
+	if len(h.workspace.created) != 0 {
+		t.Error("workspace should not be created when session id already exists")
+	}
+	if len(h.runtime.created) != 0 {
+		t.Error("runtime should not be created when session id already exists")
+	}
+	if h.log.indexOf("OnSpawnInitiated") != -1 || h.log.indexOf("OnSpawnCompleted") != -1 {
+		t.Error("LCM should not be called when session id already exists")
+	}
+}
+
 func TestSpawn_OnSpawnCompletedFailure_RoutesOrphanToErrored(t *testing.T) {
 	h := newHarness("sess-1")
 	ctx := context.Background()
@@ -455,6 +481,11 @@ func TestRestore_OnSpawnCompletedFailure_RollsBackRuntime(t *testing.T) {
 
 	if _, err := h.sm.Restore(ctx, "sess-1"); err == nil {
 		t.Fatal("restore: want error, got nil")
+	}
+
+	rec, _, _ := h.store.Get(ctx, "sess-1")
+	if got := rec.Lifecycle.Session; got.State != domain.SessionTerminated || got.Reason != domain.ReasonManuallyKilled {
+		t.Fatalf("restore failure should restore terminal lifecycle, got %+v", got)
 	}
 
 	// The runtime created during restore is torn back down so no process is

--- a/backend/internal/session/manager_test.go
+++ b/backend/internal/session/manager_test.go
@@ -128,7 +128,7 @@ func TestSpawn_ExistingSessionIDRejectedBeforeWork(t *testing.T) {
 		ID:        "sess-1",
 		ProjectID: testProject,
 		Lifecycle: lc(domain.SessionWorking, domain.ReasonTaskInProgress, domain.PRNone, ""),
-	}); err != nil {
+	}, ports.EventSessionCreated); err != nil {
 		t.Fatalf("seed existing row: %v", err)
 	}
 
@@ -246,7 +246,7 @@ func TestKill_IncompleteMetadata_RefusesTeardown(t *testing.T) {
 	if err := h.store.Upsert(ctx, domain.SessionRecord{
 		ID: "sess-1", ProjectID: testProject,
 		Lifecycle: lc(domain.SessionWorking, domain.ReasonTaskInProgress, domain.PRNone, ""),
-	}); err != nil {
+	}, ports.EventSessionCreated); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
 
@@ -270,7 +270,7 @@ func TestCleanup_IncompleteMetadata_Skipped(t *testing.T) {
 	if err := h.store.Upsert(ctx, domain.SessionRecord{
 		ID: "orphan-1", ProjectID: testProject,
 		Lifecycle: lc(domain.SessionTerminated, domain.ReasonManuallyKilled, domain.PRNone, ""),
-	}); err != nil {
+	}, ports.EventSessionCreated); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
 
@@ -333,7 +333,7 @@ func TestListAndGet_DeriveStatus(t *testing.T) {
 	h := newHarness("unused")
 	ctx := context.Background()
 	for _, c := range cases {
-		if err := h.store.Upsert(ctx, domain.SessionRecord{ID: domain.SessionID(c.name), ProjectID: testProject, Lifecycle: c.lc}); err != nil {
+		if err := h.store.Upsert(ctx, domain.SessionRecord{ID: domain.SessionID(c.name), ProjectID: testProject, Lifecycle: c.lc}, ports.EventSessionCreated); err != nil {
 			t.Fatalf("upsert %s: %v", c.name, err)
 		}
 	}
@@ -517,7 +517,7 @@ func TestCleanup_SkipsUncommittedWork(t *testing.T) {
 	if err := h.store.Upsert(ctx, domain.SessionRecord{
 		ID: "live-1", ProjectID: testProject,
 		Lifecycle: lc(domain.SessionWorking, domain.ReasonTaskInProgress, domain.PRNone, ""),
-	}); err != nil {
+	}, ports.EventSessionCreated); err != nil {
 		t.Fatalf("upsert live: %v", err)
 	}
 	// dirty-1's worktree still holds uncommitted work — Destroy refuses it.
@@ -557,7 +557,7 @@ func seedTerminal(t *testing.T, h *harness, id domain.SessionID, wsPath string) 
 	if err := h.store.Upsert(ctx, domain.SessionRecord{
 		ID: id, ProjectID: testProject,
 		Lifecycle: lc(domain.SessionTerminated, domain.ReasonManuallyKilled, domain.PRNone, ""),
-	}); err != nil {
+	}, ports.EventSessionCreated); err != nil {
 		t.Fatalf("upsert %s: %v", id, err)
 	}
 	if err := h.store.PatchMetadata(ctx, id, map[string]string{lifecycle.MetaWorkspacePath: wsPath}); err != nil {

--- a/backend/internal/session/manager_test.go
+++ b/backend/internal/session/manager_test.go
@@ -473,6 +473,7 @@ func TestRestore_OnSpawnCompletedFailure_RollsBackRuntime(t *testing.T) {
 	if err := h.store.PatchMetadata(ctx, "sess-1", map[string]string{lifecycle.MetaAgentSessionID: "agent-xyz"}); err != nil {
 		t.Fatalf("patch metadata: %v", err)
 	}
+	beforeMeta, _ := h.store.GetMetadata(ctx, "sess-1")
 
 	// Fail the post-create LCM call; capture teardown counts just before restore.
 	h.lcm.onSpawnErr = errors.New("lcm boom")
@@ -490,6 +491,10 @@ func TestRestore_OnSpawnCompletedFailure_RollsBackRuntime(t *testing.T) {
 	}
 	if rec.Lifecycle.Revision != before.Lifecycle.Revision+2 {
 		t.Fatalf("restore failure should advance revision twice, got %d want %d", rec.Lifecycle.Revision, before.Lifecycle.Revision+2)
+	}
+	afterMeta, _ := h.store.GetMetadata(ctx, "sess-1")
+	if !equalStringMap(afterMeta, beforeMeta) {
+		t.Fatalf("restore failure should restore metadata, got %+v want %+v", afterMeta, beforeMeta)
 	}
 
 	// The runtime created during restore is torn back down so no process is
@@ -566,6 +571,18 @@ func equalStrings(a, b []string) bool {
 	}
 	for i := range a {
 		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalStringMap(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
 			return false
 		}
 	}

--- a/backend/internal/session/manager_test.go
+++ b/backend/internal/session/manager_test.go
@@ -41,7 +41,7 @@ func TestSpawn_HappyPath(t *testing.T) {
 		t.Errorf("status = %q, want %q", sess.Status, domain.StatusSpawning)
 	}
 
-	// Record seeded with identity + initial lifecycle, then OnSpawnCompleted flipped
+	// Record seeded by the LCM with identity + initial lifecycle, then OnSpawnCompleted flipped
 	// the runtime axis to alive.
 	rec, ok, err := h.store.Get(ctx, "sess-1")
 	if err != nil || !ok {
@@ -60,8 +60,8 @@ func TestSpawn_HappyPath(t *testing.T) {
 		t.Errorf("runtime substate = %+v, want alive/process_running", got)
 	}
 
-	// Pipeline order: workspace -> runtime -> (seed) -> LCM.
-	wantOrder := []string{"Workspace.Create", "Runtime.Create", "OnSpawnCompleted"}
+	// Pipeline order: workspace -> runtime -> LCM seed command -> LCM completion.
+	wantOrder := []string{"Workspace.Create", "Runtime.Create", "OnSpawnInitiated", "OnSpawnCompleted"}
 	if got := h.log.snapshot(); !equalStrings(got, wantOrder) {
 		t.Errorf("call order = %v, want %v", got, wantOrder)
 	}
@@ -217,11 +217,11 @@ func TestKill_IncompleteMetadata_RefusesTeardown(t *testing.T) {
 	ctx := context.Background()
 	// A record with no teardown metadata (empty runtime handle + workspace path),
 	// e.g. a partially-seeded or corrupted record.
-	if err := h.store.Seed(ctx, domain.SessionRecord{
+	if err := h.store.Upsert(ctx, domain.SessionRecord{
 		ID: "sess-1", ProjectID: testProject,
 		Lifecycle: lc(domain.SessionWorking, domain.ReasonTaskInProgress, domain.PRNone, ""),
 	}); err != nil {
-		t.Fatalf("seed: %v", err)
+		t.Fatalf("upsert: %v", err)
 	}
 
 	if _, err := h.sm.Kill(ctx, "sess-1", ports.KillOptions{Reason: ports.KillManual}); !errors.Is(err, ErrIncompleteTeardownMetadata) {
@@ -241,11 +241,11 @@ func TestCleanup_IncompleteMetadata_Skipped(t *testing.T) {
 	ctx := context.Background()
 	// Terminal session but no workspace path persisted — must be skipped, never
 	// handed to Destroy with an empty path.
-	if err := h.store.Seed(ctx, domain.SessionRecord{
+	if err := h.store.Upsert(ctx, domain.SessionRecord{
 		ID: "orphan-1", ProjectID: testProject,
 		Lifecycle: lc(domain.SessionTerminated, domain.ReasonManuallyKilled, domain.PRNone, ""),
 	}); err != nil {
-		t.Fatalf("seed: %v", err)
+		t.Fatalf("upsert: %v", err)
 	}
 
 	res, err := h.sm.Cleanup(ctx, testProject)
@@ -307,8 +307,8 @@ func TestListAndGet_DeriveStatus(t *testing.T) {
 	h := newHarness("unused")
 	ctx := context.Background()
 	for _, c := range cases {
-		if err := h.store.Seed(ctx, domain.SessionRecord{ID: domain.SessionID(c.name), ProjectID: testProject, Lifecycle: c.lc}); err != nil {
-			t.Fatalf("seed %s: %v", c.name, err)
+		if err := h.store.Upsert(ctx, domain.SessionRecord{ID: domain.SessionID(c.name), ProjectID: testProject, Lifecycle: c.lc}); err != nil {
+			t.Fatalf("upsert %s: %v", c.name, err)
 		}
 	}
 
@@ -474,11 +474,11 @@ func TestCleanup_SkipsUncommittedWork(t *testing.T) {
 	// Two terminal sessions (reclaimable) + one working session (must be ignored).
 	seedTerminal(t, h, "done-1", "/tmp/ws/done-1")
 	seedTerminal(t, h, "dirty-1", "/tmp/ws/dirty-1")
-	if err := h.store.Seed(ctx, domain.SessionRecord{
+	if err := h.store.Upsert(ctx, domain.SessionRecord{
 		ID: "live-1", ProjectID: testProject,
 		Lifecycle: lc(domain.SessionWorking, domain.ReasonTaskInProgress, domain.PRNone, ""),
 	}); err != nil {
-		t.Fatalf("seed live: %v", err)
+		t.Fatalf("upsert live: %v", err)
 	}
 	// dirty-1's worktree still holds uncommitted work — Destroy refuses it.
 	h.workspace.refuse["/tmp/ws/dirty-1"] = true
@@ -514,11 +514,11 @@ func lc(s domain.SessionState, r domain.SessionReason, prs domain.PRState, prr d
 func seedTerminal(t *testing.T, h *harness, id domain.SessionID, wsPath string) {
 	t.Helper()
 	ctx := context.Background()
-	if err := h.store.Seed(ctx, domain.SessionRecord{
+	if err := h.store.Upsert(ctx, domain.SessionRecord{
 		ID: id, ProjectID: testProject,
 		Lifecycle: lc(domain.SessionTerminated, domain.ReasonManuallyKilled, domain.PRNone, ""),
 	}); err != nil {
-		t.Fatalf("seed %s: %v", id, err)
+		t.Fatalf("upsert %s: %v", id, err)
 	}
 	if err := h.store.PatchMetadata(ctx, id, map[string]string{lifecycle.MetaWorkspacePath: wsPath}); err != nil {
 		t.Fatalf("patch metadata %s: %v", id, err)

--- a/backend/internal/session/manager_test.go
+++ b/backend/internal/session/manager_test.go
@@ -476,6 +476,7 @@ func TestRestore_OnSpawnCompletedFailure_RollsBackRuntime(t *testing.T) {
 
 	// Fail the post-create LCM call; capture teardown counts just before restore.
 	h.lcm.onSpawnErr = errors.New("lcm boom")
+	before, _, _ := h.store.Get(ctx, "sess-1")
 	destroyedBefore := len(h.runtime.destroyed)
 	wsDestroyedBefore := len(h.workspace.destroyed)
 
@@ -486,6 +487,9 @@ func TestRestore_OnSpawnCompletedFailure_RollsBackRuntime(t *testing.T) {
 	rec, _, _ := h.store.Get(ctx, "sess-1")
 	if got := rec.Lifecycle.Session; got.State != domain.SessionTerminated || got.Reason != domain.ReasonManuallyKilled {
 		t.Fatalf("restore failure should restore terminal lifecycle, got %+v", got)
+	}
+	if rec.Lifecycle.Revision != before.Lifecycle.Revision+2 {
+		t.Fatalf("restore failure should advance revision twice, got %d want %d", rec.Lifecycle.Revision, before.Lifecycle.Revision+2)
 	}
 
 	// The runtime created during restore is torn back down so no process is


### PR DESCRIPTION
## Summary
- replace LifecycleStore merge-patch/Seed contract with LCM-only full-row Upsert
- move spawn seed/restore reopen writes behind LCM OnSpawnInitiated; Session Manager now only reads the store directly
- update lifecycle persistence pipeline and fakes/tests for full-row upsert + LCM revision bump

## Validation
- cd backend && go build ./...
- cd backend && go vet ./...
- cd backend && go test -race ./...