### PR TITLE
feat: integrate GitHub SCM flow

### DIFF
--- a/backend/internal/adapters/scm/github/auth.go
+++ b/backend/internal/adapters/scm/github/auth.go
@@ -1,0 +1,62 @@
+package github
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// TokenSource supplies GitHub bearer tokens. It is intentionally tiny so tests
+// can inject a static token and production can use env/gh fallback.
+type TokenSource interface {
+	Token(ctx context.Context) (string, error)
+}
+
+type StaticTokenSource string
+
+func (s StaticTokenSource) Token(context.Context) (string, error) {
+	if strings.TrimSpace(string(s)) == "" {
+		return "", ErrNoToken
+	}
+	return strings.TrimSpace(string(s)), nil
+}
+
+var ErrNoToken = errors.New("github scm: no token")
+
+type EnvTokenSource struct {
+	// EnvVars are checked before GITHUB_TOKEN. Values may name env vars whose
+	// values hold tokens, preserving the issue's configured-project-token order.
+	EnvVars []string
+	AllowGH bool
+}
+
+func (s EnvTokenSource) Token(ctx context.Context) (string, error) {
+	for _, name := range s.EnvVars {
+		if v := strings.TrimSpace(os.Getenv(name)); v != "" {
+			return v, nil
+		}
+	}
+	if v := strings.TrimSpace(os.Getenv("GITHUB_TOKEN")); v != "" {
+		return v, nil
+	}
+	if s.AllowGH {
+		cmd := exec.CommandContext(ctx, "gh", "auth", "token")
+		out, err := cmd.Output()
+		if err == nil && strings.TrimSpace(string(out)) != "" {
+			return strings.TrimSpace(string(out)), nil
+		}
+	}
+	return "", ErrNoToken
+}
+
+func credentialHash(token string) string {
+	if token == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])[:16]
+}

--- a/backend/internal/adapters/scm/github/auth.go
+++ b/backend/internal/adapters/scm/github/auth.go
@@ -5,13 +5,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
-	"os"
 	"os/exec"
 	"strings"
+	"sync"
 )
 
 // TokenSource supplies GitHub bearer tokens. It is intentionally tiny so tests
-// can inject a static token and production can use env/gh fallback.
+// can inject a static token and production can use gh auth.
 type TokenSource interface {
 	Token(ctx context.Context) (string, error)
 }
@@ -27,30 +27,37 @@ func (s StaticTokenSource) Token(context.Context) (string, error) {
 
 var ErrNoToken = errors.New("github scm: no token")
 
-type EnvTokenSource struct {
-	// EnvVars are checked before GITHUB_TOKEN. Values may name env vars whose
-	// values hold tokens, preserving the issue's configured-project-token order.
-	EnvVars []string
-	AllowGH bool
+// GHTokenSource uses `gh auth token` as the sole default production credential
+// source. The token is memoized because every REST/GraphQL request asks the
+// client for a token.
+type GHTokenSource struct {
+	mu      sync.Mutex
+	token   string
+	Command func(context.Context) ([]byte, error)
 }
 
-func (s EnvTokenSource) Token(ctx context.Context) (string, error) {
-	for _, name := range s.EnvVars {
-		if v := strings.TrimSpace(os.Getenv(name)); v != "" {
-			return v, nil
+func (s *GHTokenSource) Token(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.token != "" {
+		return s.token, nil
+	}
+	run := s.Command
+	if run == nil {
+		run = func(ctx context.Context) ([]byte, error) {
+			return exec.CommandContext(ctx, "gh", "auth", "token").Output()
 		}
 	}
-	if v := strings.TrimSpace(os.Getenv("GITHUB_TOKEN")); v != "" {
-		return v, nil
+	out, err := run(ctx)
+	if err != nil {
+		return "", err
 	}
-	if s.AllowGH {
-		cmd := exec.CommandContext(ctx, "gh", "auth", "token")
-		out, err := cmd.Output()
-		if err == nil && strings.TrimSpace(string(out)) != "" {
-			return strings.TrimSpace(string(out)), nil
-		}
+	token := strings.TrimSpace(string(out))
+	if token == "" {
+		return "", ErrNoToken
 	}
-	return "", ErrNoToken
+	s.token = token
+	return token, nil
 }
 
 func credentialHash(token string) string {

--- a/backend/internal/adapters/scm/github/auth.go
+++ b/backend/internal/adapters/scm/github/auth.go
@@ -8,12 +8,17 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 )
 
 // TokenSource supplies GitHub bearer tokens. It is intentionally tiny so tests
 // can inject a static token and production can use gh auth.
 type TokenSource interface {
 	Token(ctx context.Context) (string, error)
+}
+
+type tokenInvalidator interface {
+	InvalidateToken()
 }
 
 type StaticTokenSource string
@@ -27,19 +32,26 @@ func (s StaticTokenSource) Token(context.Context) (string, error) {
 
 var ErrNoToken = errors.New("github scm: no token")
 
+const defaultGHTokenCacheTTL = 5 * time.Minute
+
 // GHTokenSource uses `gh auth token` as the sole default production credential
-// source. The token is memoized because every REST/GraphQL request asks the
-// client for a token.
+// source. The token is memoized briefly because every REST/GraphQL request asks
+// the client for a token, but it is never cached permanently: the client clears
+// it on auth failures and this source refreshes it after TokenTTL.
 type GHTokenSource struct {
-	mu      sync.Mutex
-	token   string
-	Command func(context.Context) ([]byte, error)
+	mu        sync.Mutex
+	token     string
+	expiresAt time.Time
+	Command   func(context.Context) ([]byte, error)
+	Clock     func() time.Time
+	TokenTTL  time.Duration
 }
 
 func (s *GHTokenSource) Token(ctx context.Context) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.token != "" {
+	now := s.now()
+	if s.token != "" && now.Before(s.expiresAt) {
 		return s.token, nil
 	}
 	run := s.Command
@@ -57,7 +69,29 @@ func (s *GHTokenSource) Token(ctx context.Context) (string, error) {
 		return "", ErrNoToken
 	}
 	s.token = token
+	s.expiresAt = now.Add(s.ttl())
 	return token, nil
+}
+
+func (s *GHTokenSource) InvalidateToken() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.token = ""
+	s.expiresAt = time.Time{}
+}
+
+func (s *GHTokenSource) now() time.Time {
+	if s.Clock != nil {
+		return s.Clock()
+	}
+	return time.Now()
+}
+
+func (s *GHTokenSource) ttl() time.Duration {
+	if s.TokenTTL > 0 {
+		return s.TokenTTL
+	}
+	return defaultGHTokenCacheTTL
 }
 
 func credentialHash(token string) string {

--- a/backend/internal/adapters/scm/github/client.go
+++ b/backend/internal/adapters/scm/github/client.go
@@ -1,0 +1,285 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+const (
+	defaultRESTBaseURL = "https://api.github.com"
+	defaultGraphQLURL  = "https://api.github.com/graphql"
+	defaultHost        = "github.com"
+)
+
+type Client struct {
+	httpClient *http.Client
+	tokens     TokenSource
+	restBase   string
+	graphqlURL string
+	userAgent  string
+}
+
+type ClientOptions struct {
+	HTTPClient *http.Client
+	Token      TokenSource
+	RESTBase   string
+	GraphQLURL string
+	UserAgent  string
+}
+
+func NewClient(opts ClientOptions) *Client {
+	c := &Client{httpClient: opts.HTTPClient, tokens: opts.Token, restBase: opts.RESTBase, graphqlURL: opts.GraphQLURL, userAgent: opts.UserAgent}
+	if c.httpClient == nil {
+		c.httpClient = http.DefaultClient
+	}
+	if c.tokens == nil {
+		c.tokens = EnvTokenSource{AllowGH: true}
+	}
+	if c.restBase == "" {
+		c.restBase = defaultRESTBaseURL
+	}
+	if c.graphqlURL == "" {
+		c.graphqlURL = defaultGraphQLURL
+	}
+	if c.userAgent == "" {
+		c.userAgent = "ao-agent-orchestrator"
+	}
+	return c
+}
+
+func (c *Client) CredentialHash(ctx context.Context) string {
+	tok, err := c.tokens.Token(ctx)
+	if err != nil {
+		return ""
+	}
+	return credentialHash(tok)
+}
+
+type RESTResponse struct {
+	StatusCode  int
+	NotModified bool
+	ETag        string
+	Body        []byte
+	RateLimit   *domain.SCMRateLimit
+	Diagnostic  domain.SCMDiagnostic
+}
+
+func (c *Client) DoREST(ctx context.Context, method, path string, q url.Values, body any, etag string, operation string) (RESTResponse, error) {
+	started := time.Now()
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return RESTResponse{}, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: operation, Message: err.Error(), Cause: err}
+		}
+		rdr = bytes.NewReader(b)
+	}
+	u, err := c.restURL(path, q)
+	if err != nil {
+		return RESTResponse{}, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: operation, Message: err.Error(), Cause: err}
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u, rdr)
+	if err != nil {
+		return RESTResponse{}, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: operation, Message: err.Error(), Cause: err}
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("User-Agent", c.userAgent)
+	if etag != "" {
+		req.Header.Set("If-None-Match", etag)
+	}
+	if err := c.authorize(ctx, req); err != nil {
+		return RESTResponse{}, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return RESTResponse{}, normalizeHTTPError(operation, err)
+	}
+	defer resp.Body.Close()
+	b, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return RESTResponse{}, &domain.SCMError{Kind: domain.SCMErrorNetwork, Operation: operation, Message: readErr.Error(), Cause: readErr}
+	}
+	rl := rateLimitFromHeaders(resp.Header)
+	out := RESTResponse{StatusCode: resp.StatusCode, NotModified: resp.StatusCode == http.StatusNotModified, ETag: resp.Header.Get("ETag"), Body: b, RateLimit: rl, Diagnostic: domain.SCMDiagnostic{Operation: operation, StatusCode: resp.StatusCode, ETag: resp.Header.Get("ETag"), CacheHit: resp.StatusCode == http.StatusNotModified, StartedAt: started, DurationMS: time.Since(started).Milliseconds()}}
+	if resp.StatusCode == http.StatusNotModified {
+		return out, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return out, githubStatusError(operation, resp.StatusCode, b, rl)
+	}
+	return out, nil
+}
+
+func (c *Client) DoGraphQL(ctx context.Context, query string, variables map[string]any, operation string) (map[string]any, *domain.SCMRateLimit, domain.SCMDiagnostic, error) {
+	started := time.Now()
+	body := map[string]any{"query": query, "variables": variables}
+	b, err := json.Marshal(body)
+	if err != nil {
+		return nil, nil, domain.SCMDiagnostic{}, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: operation, Message: err.Error(), Cause: err}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.graphqlURL, bytes.NewReader(b))
+	if err != nil {
+		return nil, nil, domain.SCMDiagnostic{}, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: operation, Message: err.Error(), Cause: err}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", c.userAgent)
+	if err := c.authorize(ctx, req); err != nil {
+		return nil, nil, domain.SCMDiagnostic{}, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, nil, domain.SCMDiagnostic{}, normalizeHTTPError(operation, err)
+	}
+	defer resp.Body.Close()
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, nil, domain.SCMDiagnostic{}, &domain.SCMError{Kind: domain.SCMErrorNetwork, Operation: operation, Message: readErr.Error(), Cause: readErr}
+	}
+	rl := rateLimitFromHeaders(resp.Header)
+	diag := domain.SCMDiagnostic{Operation: operation, StatusCode: resp.StatusCode, StartedAt: started, DurationMS: time.Since(started).Milliseconds()}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, rl, diag, githubStatusError(operation, resp.StatusCode, respBody, rl)
+	}
+	var decoded struct {
+		Data   map[string]any `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(respBody, &decoded); err != nil {
+		return nil, rl, diag, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: operation, Message: err.Error(), Cause: err}
+	}
+	if len(decoded.Errors) > 0 {
+		kind := domain.SCMErrorUnavailable
+		msg := decoded.Errors[0].Message
+		if strings.Contains(strings.ToLower(msg), "rate limit") {
+			kind = domain.SCMErrorRateLimited
+		}
+		return decoded.Data, graphqlRateLimit(decoded.Data, rl), diag, &domain.SCMError{Kind: kind, Operation: operation, Message: msg}
+	}
+	return decoded.Data, graphqlRateLimit(decoded.Data, rl), diag, nil
+}
+
+func (c *Client) authorize(ctx context.Context, req *http.Request) error {
+	token, err := c.tokens.Token(ctx)
+	if err != nil {
+		return &domain.SCMError{Kind: domain.SCMErrorAuthFailed, Operation: "auth", Message: err.Error(), Cause: err}
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	return nil
+}
+
+func (c *Client) restURL(path string, q url.Values) (string, error) {
+	base, err := url.Parse(c.restBase)
+	if err != nil {
+		return "", err
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	base.Path = strings.TrimSuffix(base.Path, "/") + path
+	base.RawQuery = q.Encode()
+	return base.String(), nil
+}
+
+func normalizeHTTPError(operation string, err error) error {
+	kind := domain.SCMErrorNetwork
+	var ne net.Error
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), "unsupported protocol") {
+		kind = domain.SCMErrorUnsupported
+	} else if err != nil && errors.As(err, &ne) && ne.Timeout() {
+		kind = domain.SCMErrorNetwork
+	}
+	return &domain.SCMError{Kind: kind, Operation: operation, Message: err.Error(), Cause: err}
+}
+
+func githubStatusError(operation string, status int, body []byte, rl *domain.SCMRateLimit) error {
+	kind := domain.SCMErrorUnavailable
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		if rl != nil && rl.Remaining == 0 {
+			kind = domain.SCMErrorRateLimited
+		} else {
+			kind = domain.SCMErrorAuthFailed
+		}
+	case http.StatusNotFound:
+		kind = domain.SCMErrorNotFound
+	case http.StatusTooManyRequests:
+		kind = domain.SCMErrorRateLimited
+	}
+	msg := strings.TrimSpace(string(body))
+	var gh struct {
+		Message string `json:"message"`
+	}
+	if json.Unmarshal(body, &gh) == nil && gh.Message != "" {
+		msg = gh.Message
+	}
+	se := &domain.SCMError{Kind: kind, Operation: operation, StatusCode: status, Message: msg}
+	if kind == domain.SCMErrorRateLimited && rl != nil {
+		se.RetryAfter = rl.ResetAt
+	}
+	return se
+}
+
+func rateLimitFromHeaders(h http.Header) *domain.SCMRateLimit {
+	if h == nil || h.Get("X-RateLimit-Limit") == "" {
+		return nil
+	}
+	limit, _ := strconv.Atoi(h.Get("X-RateLimit-Limit"))
+	remaining, _ := strconv.Atoi(h.Get("X-RateLimit-Remaining"))
+	resetUnix, _ := strconv.ParseInt(h.Get("X-RateLimit-Reset"), 10, 64)
+	var reset time.Time
+	if resetUnix > 0 {
+		reset = time.Unix(resetUnix, 0)
+	}
+	return &domain.SCMRateLimit{Limit: limit, Remaining: remaining, ResetAt: reset, Resource: h.Get("X-RateLimit-Resource")}
+}
+
+func graphqlRateLimit(data map[string]any, fallback *domain.SCMRateLimit) *domain.SCMRateLimit {
+	if data == nil {
+		return fallback
+	}
+	rl, ok := data["rateLimit"].(map[string]any)
+	if !ok {
+		return fallback
+	}
+	out := &domain.SCMRateLimit{Resource: "graphql"}
+	out.Limit = int(num(rl["limit"]))
+	out.Remaining = int(num(rl["remaining"]))
+	if s, ok := rl["resetAt"].(string); ok {
+		out.ResetAt, _ = time.Parse(time.RFC3339, s)
+	}
+	return out
+}
+
+func num(v any) float64 {
+	switch t := v.(type) {
+	case float64:
+		return t
+	case int:
+		return float64(t)
+	case json.Number:
+		f, _ := t.Float64()
+		return f
+	default:
+		return 0
+	}
+}

--- a/backend/internal/adapters/scm/github/client.go
+++ b/backend/internal/adapters/scm/github/client.go
@@ -142,6 +142,9 @@ func (c *Client) DoREST(ctx context.Context, method, path string, q url.Values, 
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		se := githubStatusError(operation, resp.StatusCode, b, rl)
+		if se.Kind == domain.SCMErrorAuthFailed {
+			c.invalidateToken()
+		}
 		out.Diagnostic.ErrorKind = se.Kind
 		out.Diagnostic.Message = scmlog.SafeDiagnosticMessage(se)
 		logTransportFailure(ctx, logger, operation, method, endpoint, started, resp.StatusCode, rl, false, out.ETag != "" || etag != "", se)
@@ -194,6 +197,9 @@ func (c *Client) DoGraphQL(ctx context.Context, query string, variables map[stri
 	diag := domain.SCMDiagnostic{Operation: operation, StatusCode: resp.StatusCode, StartedAt: started, DurationMS: time.Since(started).Milliseconds()}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		se := githubStatusError(operation, resp.StatusCode, respBody, rl)
+		if se.Kind == domain.SCMErrorAuthFailed {
+			c.invalidateToken()
+		}
 		diag.ErrorKind = se.Kind
 		diag.Message = scmlog.SafeDiagnosticMessage(se)
 		logTransportFailure(ctx, logger, operation, http.MethodPost, endpoint, started, resp.StatusCode, rl, false, false, se)
@@ -218,9 +224,14 @@ func (c *Client) DoGraphQL(ctx context.Context, query string, variables map[stri
 		msg := decoded.Errors[0].Message
 		if strings.Contains(strings.ToLower(msg), "rate limit") {
 			kind = domain.SCMErrorRateLimited
+		} else if strings.Contains(strings.ToLower(msg), "bad credentials") || strings.Contains(strings.ToLower(msg), "credentials") {
+			kind = domain.SCMErrorAuthFailed
 		}
 		rl = graphqlRateLimit(decoded.Data, rl)
 		se := &domain.SCMError{Kind: kind, Operation: operation, Message: scmlog.SafeDiagnosticMessage(&domain.SCMError{Kind: kind, Message: msg})}
+		if se.Kind == domain.SCMErrorAuthFailed {
+			c.invalidateToken()
+		}
 		diag.ErrorKind = se.Kind
 		diag.Message = scmlog.SafeDiagnosticMessage(se)
 		logTransportFailure(ctx, logger, operation, http.MethodPost, endpoint, started, resp.StatusCode, rl, false, false, se)
@@ -238,6 +249,12 @@ func (c *Client) authorize(ctx context.Context, req *http.Request) error {
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	return nil
+}
+
+func (c *Client) invalidateToken() {
+	if src, ok := c.tokens.(tokenInvalidator); ok {
+		src.InvalidateToken()
+	}
 }
 
 func (c *Client) restURL(path string, q url.Values) (string, error) {

--- a/backend/internal/adapters/scm/github/client.go
+++ b/backend/internal/adapters/scm/github/client.go
@@ -44,7 +44,7 @@ func NewClient(opts ClientOptions) *Client {
 		c.httpClient = http.DefaultClient
 	}
 	if c.tokens == nil {
-		c.tokens = EnvTokenSource{AllowGH: true}
+		c.tokens = &GHTokenSource{}
 	}
 	if c.restBase == "" {
 		c.restBase = defaultRESTBaseURL

--- a/backend/internal/adapters/scm/github/client.go
+++ b/backend/internal/adapters/scm/github/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -14,6 +15,7 @@ import (
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	scmlog "github.com/aoagents/agent-orchestrator/backend/internal/scm/logging"
 )
 
 const (
@@ -28,6 +30,7 @@ type Client struct {
 	restBase   string
 	graphqlURL string
 	userAgent  string
+	logger     *slog.Logger
 }
 
 type ClientOptions struct {
@@ -36,10 +39,11 @@ type ClientOptions struct {
 	RESTBase   string
 	GraphQLURL string
 	UserAgent  string
+	Logger     *slog.Logger
 }
 
 func NewClient(opts ClientOptions) *Client {
-	c := &Client{httpClient: opts.HTTPClient, tokens: opts.Token, restBase: opts.RESTBase, graphqlURL: opts.GraphQLURL, userAgent: opts.UserAgent}
+	c := &Client{httpClient: opts.HTTPClient, tokens: opts.Token, restBase: opts.RESTBase, graphqlURL: opts.GraphQLURL, userAgent: opts.UserAgent, logger: opts.Logger}
 	if c.httpClient == nil {
 		c.httpClient = http.DefaultClient
 	}
@@ -76,22 +80,31 @@ type RESTResponse struct {
 }
 
 func (c *Client) DoREST(ctx context.Context, method, path string, q url.Values, body any, etag string, operation string) (RESTResponse, error) {
+	ctx, _ = scmlog.EnsureCorrelationID(ctx)
 	started := time.Now()
+	logger := scmlog.Logger(c.logger)
+	endpoint := githubEndpointTemplate(path)
 	var rdr io.Reader
 	if body != nil {
 		b, err := json.Marshal(body)
 		if err != nil {
-			return RESTResponse{}, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: operation, Message: err.Error(), Cause: err}
+			se := &domain.SCMError{Kind: domain.SCMErrorParse, Operation: operation, Message: err.Error(), Cause: err}
+			logTransportFailure(ctx, logger, operation, method, endpoint, started, 0, nil, false, false, se)
+			return RESTResponse{}, se
 		}
 		rdr = bytes.NewReader(b)
 	}
 	u, err := c.restURL(path, q)
 	if err != nil {
-		return RESTResponse{}, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: operation, Message: err.Error(), Cause: err}
+		se := &domain.SCMError{Kind: domain.SCMErrorParse, Operation: operation, Message: err.Error(), Cause: err}
+		logTransportFailure(ctx, logger, operation, method, endpoint, started, 0, nil, false, etag != "", se)
+		return RESTResponse{}, se
 	}
 	req, err := http.NewRequestWithContext(ctx, method, u, rdr)
 	if err != nil {
-		return RESTResponse{}, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: operation, Message: err.Error(), Cause: err}
+		se := &domain.SCMError{Kind: domain.SCMErrorParse, Operation: operation, Message: err.Error(), Cause: err}
+		logTransportFailure(ctx, logger, operation, method, endpoint, started, 0, nil, false, etag != "", se)
+		return RESTResponse{}, se
 	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
@@ -102,60 +115,89 @@ func (c *Client) DoREST(ctx context.Context, method, path string, q url.Values, 
 	if etag != "" {
 		req.Header.Set("If-None-Match", etag)
 	}
+	logTransportRequest(ctx, logger, operation, method, endpoint, etag != "")
 	if err := c.authorize(ctx, req); err != nil {
+		logTransportFailure(ctx, logger, operation, method, endpoint, started, 0, nil, false, etag != "", err)
 		return RESTResponse{}, err
 	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return RESTResponse{}, normalizeHTTPError(operation, err)
+		se := normalizeHTTPError(operation, err)
+		logTransportFailure(ctx, logger, operation, method, endpoint, started, 0, nil, false, etag != "", se)
+		return RESTResponse{}, se
 	}
 	defer resp.Body.Close()
 	b, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
-		return RESTResponse{}, &domain.SCMError{Kind: domain.SCMErrorNetwork, Operation: operation, Message: readErr.Error(), Cause: readErr}
+		se := &domain.SCMError{Kind: domain.SCMErrorNetwork, Operation: operation, Message: readErr.Error(), Cause: readErr}
+		logTransportFailure(ctx, logger, operation, method, endpoint, started, resp.StatusCode, rateLimitFromHeaders(resp.Header), false, etag != "", se)
+		return RESTResponse{}, se
 	}
 	rl := rateLimitFromHeaders(resp.Header)
 	out := RESTResponse{StatusCode: resp.StatusCode, NotModified: resp.StatusCode == http.StatusNotModified, ETag: resp.Header.Get("ETag"), Body: b, RateLimit: rl, Diagnostic: domain.SCMDiagnostic{Operation: operation, StatusCode: resp.StatusCode, ETag: resp.Header.Get("ETag"), CacheHit: resp.StatusCode == http.StatusNotModified, StartedAt: started, DurationMS: time.Since(started).Milliseconds()}}
 	if resp.StatusCode == http.StatusNotModified {
+		logTransportResponse(ctx, logger, operation, method, endpoint, started, resp.StatusCode, rl, out.NotModified, out.ETag != "")
 		return out, nil
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return out, githubStatusError(operation, resp.StatusCode, b, rl)
+		se := githubStatusError(operation, resp.StatusCode, b, rl)
+		out.Diagnostic.ErrorKind = se.Kind
+		out.Diagnostic.Message = scmlog.SafeDiagnosticMessage(se)
+		logTransportFailure(ctx, logger, operation, method, endpoint, started, resp.StatusCode, rl, false, out.ETag != "" || etag != "", se)
+		return out, se
 	}
+	logTransportResponse(ctx, logger, operation, method, endpoint, started, resp.StatusCode, rl, out.NotModified, out.ETag != "")
 	return out, nil
 }
 
 func (c *Client) DoGraphQL(ctx context.Context, query string, variables map[string]any, operation string) (map[string]any, *domain.SCMRateLimit, domain.SCMDiagnostic, error) {
+	ctx, _ = scmlog.EnsureCorrelationID(ctx)
 	started := time.Now()
+	logger := scmlog.Logger(c.logger)
+	const endpoint = "/graphql"
 	body := map[string]any{"query": query, "variables": variables}
 	b, err := json.Marshal(body)
 	if err != nil {
-		return nil, nil, domain.SCMDiagnostic{}, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: operation, Message: err.Error(), Cause: err}
+		se := &domain.SCMError{Kind: domain.SCMErrorParse, Operation: operation, Message: err.Error(), Cause: err}
+		logTransportFailure(ctx, logger, operation, http.MethodPost, endpoint, started, 0, nil, false, false, se)
+		return nil, nil, domain.SCMDiagnostic{}, se
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.graphqlURL, bytes.NewReader(b))
 	if err != nil {
-		return nil, nil, domain.SCMDiagnostic{}, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: operation, Message: err.Error(), Cause: err}
+		se := &domain.SCMError{Kind: domain.SCMErrorParse, Operation: operation, Message: err.Error(), Cause: err}
+		logTransportFailure(ctx, logger, operation, http.MethodPost, endpoint, started, 0, nil, false, false, se)
+		return nil, nil, domain.SCMDiagnostic{}, se
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", c.userAgent)
+	logTransportRequest(ctx, logger, operation, http.MethodPost, endpoint, false)
 	if err := c.authorize(ctx, req); err != nil {
+		logTransportFailure(ctx, logger, operation, http.MethodPost, endpoint, started, 0, nil, false, false, err)
 		return nil, nil, domain.SCMDiagnostic{}, err
 	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, nil, domain.SCMDiagnostic{}, normalizeHTTPError(operation, err)
+		se := normalizeHTTPError(operation, err)
+		logTransportFailure(ctx, logger, operation, http.MethodPost, endpoint, started, 0, nil, false, false, se)
+		return nil, nil, domain.SCMDiagnostic{}, se
 	}
 	defer resp.Body.Close()
 	respBody, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
-		return nil, nil, domain.SCMDiagnostic{}, &domain.SCMError{Kind: domain.SCMErrorNetwork, Operation: operation, Message: readErr.Error(), Cause: readErr}
+		se := &domain.SCMError{Kind: domain.SCMErrorNetwork, Operation: operation, Message: readErr.Error(), Cause: readErr}
+		logTransportFailure(ctx, logger, operation, http.MethodPost, endpoint, started, resp.StatusCode, rateLimitFromHeaders(resp.Header), false, false, se)
+		return nil, nil, domain.SCMDiagnostic{}, se
 	}
 	rl := rateLimitFromHeaders(resp.Header)
 	diag := domain.SCMDiagnostic{Operation: operation, StatusCode: resp.StatusCode, StartedAt: started, DurationMS: time.Since(started).Milliseconds()}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, rl, diag, githubStatusError(operation, resp.StatusCode, respBody, rl)
+		se := githubStatusError(operation, resp.StatusCode, respBody, rl)
+		diag.ErrorKind = se.Kind
+		diag.Message = scmlog.SafeDiagnosticMessage(se)
+		logTransportFailure(ctx, logger, operation, http.MethodPost, endpoint, started, resp.StatusCode, rl, false, false, se)
+		return nil, rl, diag, se
 	}
 	var decoded struct {
 		Data   map[string]any `json:"data"`
@@ -165,7 +207,11 @@ func (c *Client) DoGraphQL(ctx context.Context, query string, variables map[stri
 		} `json:"errors"`
 	}
 	if err := json.Unmarshal(respBody, &decoded); err != nil {
-		return nil, rl, diag, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: operation, Message: err.Error(), Cause: err}
+		se := &domain.SCMError{Kind: domain.SCMErrorParse, Operation: operation, Message: err.Error(), Cause: err}
+		diag.ErrorKind = se.Kind
+		diag.Message = scmlog.SafeDiagnosticMessage(se)
+		logTransportFailure(ctx, logger, operation, http.MethodPost, endpoint, started, resp.StatusCode, rl, false, false, se)
+		return nil, rl, diag, se
 	}
 	if len(decoded.Errors) > 0 {
 		kind := domain.SCMErrorUnavailable
@@ -173,9 +219,16 @@ func (c *Client) DoGraphQL(ctx context.Context, query string, variables map[stri
 		if strings.Contains(strings.ToLower(msg), "rate limit") {
 			kind = domain.SCMErrorRateLimited
 		}
-		return decoded.Data, graphqlRateLimit(decoded.Data, rl), diag, &domain.SCMError{Kind: kind, Operation: operation, Message: msg}
+		rl = graphqlRateLimit(decoded.Data, rl)
+		se := &domain.SCMError{Kind: kind, Operation: operation, Message: scmlog.SafeDiagnosticMessage(&domain.SCMError{Kind: kind, Message: msg})}
+		diag.ErrorKind = se.Kind
+		diag.Message = scmlog.SafeDiagnosticMessage(se)
+		logTransportFailure(ctx, logger, operation, http.MethodPost, endpoint, started, resp.StatusCode, rl, false, false, se)
+		return decoded.Data, rl, diag, se
 	}
-	return decoded.Data, graphqlRateLimit(decoded.Data, rl), diag, nil
+	rl = graphqlRateLimit(decoded.Data, rl)
+	logTransportResponse(ctx, logger, operation, http.MethodPost, endpoint, started, resp.StatusCode, rl, false, false)
+	return decoded.Data, rl, diag, nil
 }
 
 func (c *Client) authorize(ctx context.Context, req *http.Request) error {
@@ -211,7 +264,7 @@ func normalizeHTTPError(operation string, err error) error {
 	return &domain.SCMError{Kind: kind, Operation: operation, Message: err.Error(), Cause: err}
 }
 
-func githubStatusError(operation string, status int, body []byte, rl *domain.SCMRateLimit) error {
+func githubStatusError(operation string, status int, body []byte, rl *domain.SCMRateLimit) *domain.SCMError {
 	kind := domain.SCMErrorUnavailable
 	switch status {
 	case http.StatusUnauthorized, http.StatusForbidden:
@@ -225,18 +278,90 @@ func githubStatusError(operation string, status int, body []byte, rl *domain.SCM
 	case http.StatusTooManyRequests:
 		kind = domain.SCMErrorRateLimited
 	}
-	msg := strings.TrimSpace(string(body))
 	var gh struct {
 		Message string `json:"message"`
 	}
-	if json.Unmarshal(body, &gh) == nil && gh.Message != "" {
-		msg = gh.Message
-	}
+	_ = json.Unmarshal(body, &gh)
+	msg := scmlog.StatusMessage(status, body, gh.Message)
 	se := &domain.SCMError{Kind: kind, Operation: operation, StatusCode: status, Message: msg}
 	if kind == domain.SCMErrorRateLimited && rl != nil {
 		se.RetryAfter = rl.ResetAt
 	}
 	return se
+}
+
+func logTransportRequest(ctx context.Context, logger *slog.Logger, operation, method, endpoint string, etagPresent bool) {
+	attrs := transportAttrs(ctx, operation, method, endpoint,
+		slog.Bool(scmlog.FieldETagPresent, etagPresent),
+	)
+	logger.Debug(scmlog.EventTransportRequest, scmlog.Args(attrs)...)
+}
+
+func logTransportResponse(ctx context.Context, logger *slog.Logger, operation, method, endpoint string, started time.Time, status int, rl *domain.SCMRateLimit, cacheHit, etagPresent bool) {
+	attrs := transportAttrs(ctx, operation, method, endpoint,
+		slog.Int(scmlog.FieldStatusCode, status),
+		slog.Int64(scmlog.FieldDurationMS, scmlog.DurationMS(started)),
+		slog.Bool(scmlog.FieldCacheHit, cacheHit),
+		slog.Bool(scmlog.FieldETagPresent, etagPresent),
+	)
+	attrs = append(attrs, scmlog.RateLimitAttrs(rl)...)
+	logger.Debug(scmlog.EventTransportResponse, scmlog.Args(attrs)...)
+}
+
+func logTransportFailure(ctx context.Context, logger *slog.Logger, operation, method, endpoint string, started time.Time, status int, rl *domain.SCMRateLimit, cacheHit, etagPresent bool, err error) {
+	attrs := transportAttrs(ctx, operation, method, endpoint,
+		slog.Int64(scmlog.FieldDurationMS, scmlog.DurationMS(started)),
+		slog.Bool(scmlog.FieldCacheHit, cacheHit),
+		slog.Bool(scmlog.FieldETagPresent, etagPresent),
+	)
+	if status != 0 {
+		attrs = append(attrs, slog.Int(scmlog.FieldStatusCode, status))
+	}
+	attrs = append(attrs, scmlog.RateLimitAttrs(rl)...)
+	attrs = append(attrs, scmlog.ErrorAttrs(err)...)
+	if scmlog.ErrorKind(err) == domain.SCMErrorRateLimited {
+		logger.Warn(scmlog.EventTransportRateLimited, scmlog.Args(attrs)...)
+		return
+	}
+	logger.Warn(scmlog.EventTransportFailed, scmlog.Args(attrs)...)
+}
+
+func transportAttrs(ctx context.Context, operation, method, endpoint string, attrs ...slog.Attr) []slog.Attr {
+	base := []slog.Attr{
+		scmlog.CorrelationAttr(ctx),
+		slog.String(scmlog.FieldProvider, string(domain.SCMProviderGitHub)),
+		slog.String(scmlog.FieldOperation, operation),
+		slog.String(scmlog.FieldMethod, method),
+		slog.String(scmlog.FieldEndpointTemplate, endpoint),
+	}
+	return append(base, attrs...)
+}
+
+func githubEndpointTemplate(p string) string {
+	if p == "" {
+		return ""
+	}
+	parts := strings.Split(strings.Trim(p, "/"), "/")
+	if len(parts) >= 3 && parts[0] == "repos" {
+		out := []string{"repos", "{owner}", "{repo}"}
+		for i := 3; i < len(parts); i++ {
+			part := parts[i]
+			prev := ""
+			if i > 0 {
+				prev = parts[i-1]
+			}
+			switch {
+			case prev == "pulls" || prev == "issues":
+				out = append(out, "{number}")
+			case prev == "commits":
+				out = append(out, "{ref}")
+			default:
+				out = append(out, part)
+			}
+		}
+		return "/" + strings.Join(out, "/")
+	}
+	return "/" + strings.Join(parts, "/")
 }
 
 func rateLimitFromHeaders(h http.Header) *domain.SCMRateLimit {

--- a/backend/internal/adapters/scm/github/commands.go
+++ b/backend/internal/adapters/scm/github/commands.go
@@ -1,0 +1,155 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+var _ ports.SCMCommandProvider = (*Provider)(nil)
+
+func (p *Provider) Capabilities() ports.SCMCommandCapabilities {
+	return ports.SCMCommandCapabilities{Merge: true, Close: true, Comment: true, Assign: true, Checkout: true}
+}
+
+func (p *Provider) Merge(ctx context.Context, req ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
+	req = p.normalizeCommandRequest(ctx, req, ports.SCMCommandMerge)
+	owner, repo := req.Subject.Repository().OwnerName()
+	body := map[string]any{}
+	if req.MergeMethod != "" {
+		body["merge_method"] = req.MergeMethod
+	}
+	if req.CommitTitle != "" {
+		body["commit_title"] = req.CommitTitle
+	}
+	if req.CommitMessage != "" {
+		body["commit_message"] = req.CommitMessage
+	}
+	resp, err := p.client.DoREST(ctx, http.MethodPut, repoPath(owner, repo, "pulls", strconv.Itoa(req.ChangeRequest.Number), "merge"), nil, body, "", "github.command.merge")
+	res := commandResult(req, resp.Diagnostic)
+	if err != nil {
+		return res, err
+	}
+	var decoded struct {
+		SHA     string `json:"sha"`
+		Message string `json:"message"`
+	}
+	_ = jsonUnmarshal(resp.Body, &decoded)
+	res.SHA = decoded.SHA
+	res.Message = firstNonEmpty(decoded.Message, "merged")
+	return res, nil
+}
+
+func (p *Provider) Close(ctx context.Context, req ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
+	req = p.normalizeCommandRequest(ctx, req, ports.SCMCommandClose)
+	owner, repo := req.Subject.Repository().OwnerName()
+	resp, err := p.client.DoREST(ctx, http.MethodPatch, repoPath(owner, repo, "pulls", strconv.Itoa(req.ChangeRequest.Number)), nil, map[string]any{"state": "closed"}, "", "github.command.close")
+	res := commandResult(req, resp.Diagnostic)
+	if err != nil {
+		return res, err
+	}
+	res.Message = "closed"
+	return res, nil
+}
+
+func (p *Provider) Comment(ctx context.Context, req ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
+	req = p.normalizeCommandRequest(ctx, req, ports.SCMCommandComment)
+	if strings.TrimSpace(req.Body) == "" && strings.TrimSpace(req.Message) == "" {
+		return commandResult(req, domain.SCMDiagnostic{}), &domain.SCMError{Kind: domain.SCMErrorUnsupported, Operation: "github.command.comment", Message: "comment body is required"}
+	}
+	owner, repo := req.Subject.Repository().OwnerName()
+	body := firstNonEmpty(req.Body, req.Message)
+	resp, err := p.client.DoREST(ctx, http.MethodPost, repoPath(owner, repo, "issues", strconv.Itoa(req.ChangeRequest.Number), "comments"), nil, map[string]any{"body": body}, "", "github.command.comment")
+	res := commandResult(req, resp.Diagnostic)
+	if err != nil {
+		return res, err
+	}
+	var decoded struct {
+		HTMLURL string `json:"html_url"`
+	}
+	_ = jsonUnmarshal(resp.Body, &decoded)
+	res.URL = decoded.HTMLURL
+	res.Message = "commented"
+	return res, nil
+}
+
+func (p *Provider) Assign(ctx context.Context, req ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
+	req = p.normalizeCommandRequest(ctx, req, ports.SCMCommandAssign)
+	if len(req.Assignees) == 0 {
+		return commandResult(req, domain.SCMDiagnostic{}), &domain.SCMError{Kind: domain.SCMErrorUnsupported, Operation: "github.command.assign", Message: "at least one assignee is required"}
+	}
+	owner, repo := req.Subject.Repository().OwnerName()
+	resp, err := p.client.DoREST(ctx, http.MethodPost, repoPath(owner, repo, "issues", strconv.Itoa(req.ChangeRequest.Number), "assignees"), nil, map[string]any{"assignees": req.Assignees}, "", "github.command.assign")
+	res := commandResult(req, resp.Diagnostic)
+	if err != nil {
+		return res, err
+	}
+	res.Message = "assigned"
+	return res, nil
+}
+
+func (p *Provider) Checkout(ctx context.Context, req ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
+	req = p.normalizeCommandRequest(ctx, req, ports.SCMCommandCheckout)
+	res := commandResult(req, domain.SCMDiagnostic{Operation: "github.command.checkout"})
+	if req.WorkspacePath == "" {
+		res.Message = fmt.Sprintf("git fetch origin pull/%d/head:pr-%d && git checkout pr-%d", req.ChangeRequest.Number, req.ChangeRequest.Number, req.ChangeRequest.Number)
+		return res, nil
+	}
+	branch := fmt.Sprintf("pr-%d", req.ChangeRequest.Number)
+	cmd := exec.CommandContext(ctx, "git", "fetch", "origin", fmt.Sprintf("pull/%d/head:%s", req.ChangeRequest.Number, branch))
+	cmd.Dir = req.WorkspacePath
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return res, &domain.SCMError{Kind: domain.SCMErrorCommand, Operation: "github.command.checkout", Message: strings.TrimSpace(string(out)), Cause: err}
+	}
+	cmd = exec.CommandContext(ctx, "git", "checkout", branch)
+	cmd.Dir = req.WorkspacePath
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return res, &domain.SCMError{Kind: domain.SCMErrorCommand, Operation: "github.command.checkout", Message: strings.TrimSpace(string(out)), Cause: err}
+	}
+	res.Message = "checked out " + branch
+	return res, nil
+}
+
+func (p *Provider) normalizeCommandRequest(ctx context.Context, req ports.SCMCommandRequest, command ports.SCMCommand) ports.SCMCommandRequest {
+	req.Command = command
+	req.Subject = p.normalizeSubject(ctx, req.Subject)
+	if req.ChangeRequest.Number == 0 {
+		req.ChangeRequest = req.Subject.ChangeRequestID()
+	}
+	if req.ChangeRequest.Provider == "" {
+		req.ChangeRequest.Provider = domain.SCMProviderGitHub
+	}
+	if req.ChangeRequest.Host == "" {
+		req.ChangeRequest.Host = req.Subject.Host
+	}
+	if req.ChangeRequest.Repo == "" {
+		req.ChangeRequest.Repo = req.Subject.Repo
+	}
+	if req.Now.IsZero() {
+		req.Now = time.Now()
+	}
+	return req
+}
+
+func commandResult(req ports.SCMCommandRequest, diag domain.SCMDiagnostic) ports.SCMCommandResult {
+	res := ports.SCMCommandResult{Provider: domain.SCMProviderGitHub, Command: req.Command, ChangeRequest: req.ChangeRequest, PerformedAt: req.Now}
+	if !diag.StartedAt.IsZero() || diag.Operation != "" {
+		res.Diagnostics = []domain.SCMDiagnostic{diag}
+	}
+	return res
+}
+
+func jsonUnmarshal(b []byte, v any) error {
+	if len(b) == 0 {
+		return nil
+	}
+	return json.Unmarshal(b, v)
+}

--- a/backend/internal/adapters/scm/github/commands.go
+++ b/backend/internal/adapters/scm/github/commands.go
@@ -25,6 +25,7 @@ func (p *Provider) CacheInvalidationPrefixes(subj domain.SCMSubject, cmd ports.S
 	prefixes := []domain.SCMProviderCachePrefix{
 		{SCMProviderCacheScope: scope, Namespace: cachePRList},
 		{SCMProviderCacheScope: scope, Namespace: cacheBranchMap},
+		{SCMProviderCacheScope: scope, Namespace: cachePRState},
 	}
 	switch cmd {
 	case ports.SCMCommandMerge, ports.SCMCommandClose:

--- a/backend/internal/adapters/scm/github/commands.go
+++ b/backend/internal/adapters/scm/github/commands.go
@@ -104,18 +104,38 @@ func (p *Provider) Checkout(ctx context.Context, req ports.SCMCommandRequest) (p
 		return res, nil
 	}
 	branch := fmt.Sprintf("pr-%d", req.ChangeRequest.Number)
-	cmd := exec.CommandContext(ctx, "git", "fetch", "origin", fmt.Sprintf("pull/%d/head:%s", req.ChangeRequest.Number, branch))
-	cmd.Dir = req.WorkspacePath
+	if err := checkoutWithGit(ctx, req.WorkspacePath, req.ChangeRequest.Number, branch); err == nil {
+		res.Message = "checked out " + branch
+		return res, nil
+	} else if ghErr := checkoutWithGH(ctx, req.WorkspacePath, req.ChangeRequest); ghErr == nil {
+		res.Message = "checked out with gh pr checkout"
+		return res, nil
+	} else {
+		return res, &domain.SCMError{Kind: domain.SCMErrorCommand, Operation: "github.command.checkout", Message: fmt.Sprintf("git checkout failed: %v; gh fallback failed: %v", err, ghErr), Cause: err}
+	}
+}
+
+func checkoutWithGit(ctx context.Context, workspacePath string, number int, branch string) error {
+	cmd := exec.CommandContext(ctx, "git", "fetch", "origin", fmt.Sprintf("pull/%d/head:%s", number, branch))
+	cmd.Dir = workspacePath
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return res, &domain.SCMError{Kind: domain.SCMErrorCommand, Operation: "github.command.checkout", Message: strings.TrimSpace(string(out)), Cause: err}
+		return fmt.Errorf("git fetch: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 	cmd = exec.CommandContext(ctx, "git", "checkout", branch)
-	cmd.Dir = req.WorkspacePath
+	cmd.Dir = workspacePath
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return res, &domain.SCMError{Kind: domain.SCMErrorCommand, Operation: "github.command.checkout", Message: strings.TrimSpace(string(out)), Cause: err}
+		return fmt.Errorf("git checkout: %s: %w", strings.TrimSpace(string(out)), err)
 	}
-	res.Message = "checked out " + branch
-	return res, nil
+	return nil
+}
+
+func checkoutWithGH(ctx context.Context, workspacePath string, cr domain.SCMChangeRequestID) error {
+	cmd := exec.CommandContext(ctx, "gh", "pr", "checkout", strconv.Itoa(cr.Number), "--repo", cr.Repo)
+	cmd.Dir = workspacePath
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("gh pr checkout: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
 }
 
 func (p *Provider) normalizeCommandRequest(ctx context.Context, req ports.SCMCommandRequest, command ports.SCMCommand) ports.SCMCommandRequest {

--- a/backend/internal/adapters/scm/github/commands.go
+++ b/backend/internal/adapters/scm/github/commands.go
@@ -137,7 +137,7 @@ func (p *Provider) Checkout(ctx context.Context, req ports.SCMCommandRequest) (p
 		res.Message = "checked out with gh pr checkout"
 		return res, nil
 	} else {
-		return res, &domain.SCMError{Kind: domain.SCMErrorCommand, Operation: "github.command.checkout", Message: fmt.Sprintf("git checkout failed: %v; gh fallback failed: %v", err, ghErr), Cause: err}
+		return res, &domain.SCMError{Kind: domain.SCMErrorCommand, Operation: "github.command.checkout", Message: "checkout command failed", Cause: fmt.Errorf("git checkout failed: %w; gh fallback failed: %v", err, ghErr)}
 	}
 }
 
@@ -187,7 +187,7 @@ func (p *Provider) normalizeCommandRequest(ctx context.Context, req ports.SCMCom
 
 func commandResult(req ports.SCMCommandRequest, diag domain.SCMDiagnostic) ports.SCMCommandResult {
 	res := ports.SCMCommandResult{Provider: domain.SCMProviderGitHub, Command: req.Command, ChangeRequest: req.ChangeRequest, PerformedAt: req.Now}
-	if !diag.StartedAt.IsZero() || diag.Operation != "" {
+	if durableDiagnostic(diag) {
 		res.Diagnostics = []domain.SCMDiagnostic{diag}
 	}
 	return res

--- a/backend/internal/adapters/scm/github/commands.go
+++ b/backend/internal/adapters/scm/github/commands.go
@@ -32,9 +32,13 @@ func (p *Provider) CacheInvalidationPrefixes(subj domain.SCMSubject, cmd ports.S
 			domain.SCMProviderCachePrefix{SCMProviderCacheScope: scope, Namespace: cacheChecks},
 			domain.SCMProviderCachePrefix{SCMProviderCacheScope: scope, Namespace: cacheCheckGuard},
 			domain.SCMProviderCachePrefix{SCMProviderCacheScope: scope, Namespace: cacheReviews},
+			domain.SCMProviderCachePrefix{SCMProviderCacheScope: scope, Namespace: cacheReviewDetails},
 		)
 	case ports.SCMCommandComment:
-		prefixes = append(prefixes, domain.SCMProviderCachePrefix{SCMProviderCacheScope: scope, Namespace: cacheReviews})
+		prefixes = append(prefixes,
+			domain.SCMProviderCachePrefix{SCMProviderCacheScope: scope, Namespace: cacheReviews},
+			domain.SCMProviderCachePrefix{SCMProviderCacheScope: scope, Namespace: cacheReviewDetails},
+		)
 	default:
 		return nil
 	}

--- a/backend/internal/adapters/scm/github/commands.go
+++ b/backend/internal/adapters/scm/github/commands.go
@@ -20,6 +20,27 @@ func (p *Provider) Capabilities() ports.SCMCommandCapabilities {
 	return ports.SCMCommandCapabilities{Merge: true, Close: true, Comment: true, Assign: true, Checkout: true}
 }
 
+func (p *Provider) CacheInvalidationPrefixes(subj domain.SCMSubject, cmd ports.SCMCommand) []domain.SCMProviderCachePrefix {
+	scope := subj.CacheScope()
+	prefixes := []domain.SCMProviderCachePrefix{
+		{SCMProviderCacheScope: scope, Namespace: cachePRList},
+		{SCMProviderCacheScope: scope, Namespace: cacheBranchMap},
+	}
+	switch cmd {
+	case ports.SCMCommandMerge, ports.SCMCommandClose:
+		prefixes = append(prefixes,
+			domain.SCMProviderCachePrefix{SCMProviderCacheScope: scope, Namespace: cacheChecks},
+			domain.SCMProviderCachePrefix{SCMProviderCacheScope: scope, Namespace: cacheCheckGuard},
+			domain.SCMProviderCachePrefix{SCMProviderCacheScope: scope, Namespace: cacheReviews},
+		)
+	case ports.SCMCommandComment:
+		prefixes = append(prefixes, domain.SCMProviderCachePrefix{SCMProviderCacheScope: scope, Namespace: cacheReviews})
+	default:
+		return nil
+	}
+	return prefixes
+}
+
 func (p *Provider) Merge(ctx context.Context, req ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
 	req = p.normalizeCommandRequest(ctx, req, ports.SCMCommandMerge)
 	owner, repo := req.Subject.Repository().OwnerName()

--- a/backend/internal/adapters/scm/github/provider.go
+++ b/backend/internal/adapters/scm/github/provider.go
@@ -517,11 +517,6 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 				commitRESTCache(checkGuardCommits[subj.SessionID])
 			}
 			if snap.CI.Summary == "failing" {
-				if diag, err := p.enrichFailedCheckLogs(ctx, subj, &snap); err != nil {
-					snap.Diagnostics = append(snap.Diagnostics, diagnosticFromError("github.actions_job_logs", err))
-				} else if diag.Operation != "" {
-					snap.Diagnostics = append(snap.Diagnostics, diag)
-				}
 				snap.CI.FailureLogTail = combinedFailureTail(snap.CI.Checks)
 			}
 			reviewDiags := p.refreshReviewDetails(ctx, cache, subj, &snap, prev, havePrev, now)
@@ -839,71 +834,6 @@ func (p *Provider) refreshReviewDetails(ctx context.Context, cache ports.SCMProv
 	return diags
 }
 
-func (p *Provider) enrichFailedCheckLogs(ctx context.Context, subj domain.SCMSubject, snap *domain.SCMSnapshot) (domain.SCMDiagnostic, error) {
-	if snap == nil || snap.PR == nil || len(snap.CI.Checks) == 0 {
-		return domain.SCMDiagnostic{}, nil
-	}
-	owner, repo := subj.Repository().OwnerName()
-	seen := map[string]bool{}
-	var lastDiag domain.SCMDiagnostic
-	var firstErr error
-	for i := range snap.CI.Checks {
-		if !failedCheck(snap.CI.Checks[i]) {
-			continue
-		}
-		ref, ok := actionRunReferenceFromCheck(snap.CI.Checks[i])
-		if !ok || ref.jobID == "" {
-			continue
-		}
-		key := ref.runID + ":" + ref.jobID
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
-		resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "actions", "jobs", ref.jobID, "logs"), nil, nil, "", "github.actions_job_logs")
-		if resp.Diagnostic.Operation != "" {
-			lastDiag = resp.Diagnostic
-		}
-		if err != nil {
-			if firstErr == nil {
-				firstErr = err
-			}
-			continue
-		}
-		if tail := tailLines(string(resp.Body), ciFailureLogTailLines); tail != "" {
-			snap.CI.Checks[i].LogTail = tail
-		}
-	}
-	return lastDiag, firstErr
-}
-
-type actionRunReference struct {
-	runID string
-	jobID string
-}
-
-func actionRunReferenceFromCheck(check domain.SCMCheck) (actionRunReference, bool) {
-	rawURL := firstNonEmpty(check.URL, "")
-	if rawURL == "" {
-		return actionRunReference{}, false
-	}
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return actionRunReference{}, false
-	}
-	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
-	var ref actionRunReference
-	for i := 0; i < len(parts); i++ {
-		if parts[i] == "runs" && i+1 < len(parts) && isDecimal(parts[i+1]) {
-			ref.runID = parts[i+1]
-		}
-		if parts[i] == "job" && i+1 < len(parts) && isDecimal(parts[i+1]) {
-			ref.jobID = parts[i+1]
-		}
-	}
-	return ref, ref.runID != "" && ref.jobID != ""
-}
-
 func (p *Provider) fetchReviewThreads(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject, now time.Time) ([]domain.SCMReviewThread, []domain.SCMDiagnostic, bool, error) {
 	if subj.PRNumber == 0 {
 		return nil, nil, false, nil
@@ -1169,18 +1099,6 @@ func boolv(v any) bool {
 		return b
 	}
 	return false
-}
-
-func isDecimal(s string) bool {
-	if s == "" {
-		return false
-	}
-	for _, r := range s {
-		if r < '0' || r > '9' {
-			return false
-		}
-	}
-	return true
 }
 
 func containsString(values []string, want string) bool {

--- a/backend/internal/adapters/scm/github/provider.go
+++ b/backend/internal/adapters/scm/github/provider.go
@@ -22,6 +22,7 @@ const (
 	cacheReviews       = "reviews"
 	cacheReviewDetails = "review-details"
 	cacheCheckGuard    = "checks-guard"
+	cachePRState       = "pr-state"
 
 	maxGraphQLBatchSize      = 25
 	graphQLCheckContextLimit = 20
@@ -32,9 +33,9 @@ const (
 	cacheCapReviewDetails = 500
 	cacheCapBranchMap     = 1000
 	cacheCapCheckGuard    = 500
+	cacheCapPRState       = 500
 
 	ciFailureLogTailLines = 20
-	reviewDetailThrottle  = 2 * time.Minute
 )
 
 type Provider struct {
@@ -313,6 +314,34 @@ func (p *Provider) reviewCommentsChanged(ctx context.Context, cache ports.SCMPro
 	return !resp.NotModified, resp.Diagnostic, commit, nil
 }
 
+func (p *Provider) checkBoundPullState(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject, now time.Time) (changed bool, terminal *domain.SCMSnapshot, diag domain.SCMDiagnostic, commit restCacheCommit, err error) {
+	if subj.PRNumber == 0 {
+		return false, nil, domain.SCMDiagnostic{}, nil, nil
+	}
+	scope := subj.CacheScope()
+	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cachePRState, Key: strconv.Itoa(subj.PRNumber)}
+	entry, hasEntry, _ := cache.GetProviderCache(ctx, key)
+	owner, repo := subj.Repository().OwnerName()
+	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "pulls", strconv.Itoa(subj.PRNumber)), nil, nil, entry.ETag, "github.pr_state_guard")
+	if err != nil {
+		return true, nil, resp.Diagnostic, nil, err
+	}
+	body, commit := prepareRESTCache(ctx, cache, key, entry, hasEntry, resp, now)
+	if resp.NotModified {
+		commitRESTCache(commit)
+		return false, nil, resp.Diagnostic, nil, nil
+	}
+	snap, isTerminal, err := snapshotFromRESTPull(subj, body, now, "github.pr_state_guard")
+	if err != nil {
+		return true, nil, resp.Diagnostic, nil, err
+	}
+	if isTerminal {
+		commitRESTCache(commit)
+		return true, &snap, resp.Diagnostic, nil, nil
+	}
+	return true, nil, resp.Diagnostic, commit, nil
+}
+
 func chunkSubjects(subjects []domain.SCMSubject, size int) [][]domain.SCMSubject {
 	if size <= 0 || len(subjects) <= size {
 		return [][]domain.SCMSubject{subjects}
@@ -412,11 +441,27 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 
 	toFetch := known
 	checkGuardCommits := map[domain.SessionID]restCacheCommit{}
+	pullStateCommits := map[domain.SessionID]restCacheCommit{}
 	if !prListChanged && len(latest) > 0 {
 		toFetch = toFetch[:0]
 		for _, subj := range known {
 			prev, ok := latest[subj.SessionID]
 			if !ok || prev.PR == nil || prev.PR.HeadSHA == "" {
+				toFetch = append(toFetch, subj)
+				continue
+			}
+			pullChanged, terminal, diag, commit, err := p.checkBoundPullState(ctx, cache, subj, now)
+			if diag.Operation != "" {
+				diags = append(diags, diag)
+			}
+			if terminal != nil {
+				snaps = append(snaps, *terminal)
+				continue
+			}
+			if err != nil || pullChanged {
+				if err == nil && commit != nil {
+					pullStateCommits[subj.SessionID] = commit
+				}
 				toFetch = append(toFetch, subj)
 				continue
 			}
@@ -509,12 +554,14 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 					snap.CI.Checks = checks
 					snap.CI.Summary = summarizeChecks(checks)
 					commitRESTCache(checkGuardCommits[subj.SessionID])
+					commitRESTCache(pullStateCommits[subj.SessionID])
 				} else if err != nil && havePrev && prev.PR != nil && prev.PR.HeadSHA == snap.PR.HeadSHA {
 					snap.CI = prev.CI
 					snap.Diagnostics = append(snap.Diagnostics, diagnosticFromError("github.check_runs", err))
 				}
 			} else {
 				commitRESTCache(checkGuardCommits[subj.SessionID])
+				commitRESTCache(pullStateCommits[subj.SessionID])
 			}
 			if snap.CI.Summary == "failing" {
 				snap.CI.FailureLogTail = combinedFailureTail(snap.CI.Checks)
@@ -695,21 +742,58 @@ func finalizeMergeability(s *domain.SCMSnapshot) {
 	if s.PR == nil || s.PR.State == domain.PRMerged {
 		return
 	}
-	if s.Mergeability.CIPassing == false && (s.CI.Summary == "passing" || s.CI.Summary == "none" || s.CI.Summary == "") {
-		s.Mergeability.CIPassing = true
-	}
-	if s.Mergeability.Approved == false && (s.Review.Decision == "approved" || s.Review.Decision == "none" || s.Review.Decision == "") {
-		s.Mergeability.Approved = true
-	}
-	if s.PR.Draft {
-		s.Mergeability.Mergeable = false
-		if !containsString(s.Mergeability.Blockers, "PR is still a draft") {
-			s.Mergeability.Blockers = append(s.Mergeability.Blockers, "PR is still a draft")
+	raw := strings.ToUpper(strings.TrimSpace(s.Mergeability.RawState))
+	mergeState := strings.ToUpper(strings.TrimSpace(s.Mergeability.MergeState))
+	ciSummary := domain.NormalizeSCMCI(s.CI.Summary)
+	reviewDecision := domain.NormalizeSCMReviewDecision(s.Review.Decision)
+	draft := s.PR.Draft || s.PR.State == domain.PRDraft
+
+	s.Mergeability.RawState = raw
+	s.Mergeability.MergeState = mergeState
+	s.Mergeability.CIPassing = ciSummary == "passing" || ciSummary == "none" || ciSummary == ""
+	s.Mergeability.Approved = reviewDecision == "approved" || reviewDecision == "none" || reviewDecision == ""
+	s.Mergeability.Conflict = raw == "CONFLICTING" || mergeState == "DIRTY"
+	s.Mergeability.NoConflicts = raw == "MERGEABLE" && !s.Mergeability.Conflict
+	s.Mergeability.BehindBase = mergeState == "BEHIND"
+	s.Mergeability.Blockers = nil
+	addBlocker := func(msg string) {
+		if !containsString(s.Mergeability.Blockers, msg) {
+			s.Mergeability.Blockers = append(s.Mergeability.Blockers, msg)
 		}
-		return
+	}
+	if raw == "" || raw == "UNKNOWN" {
+		addBlocker("merge status unknown (GitHub is computing)")
+	}
+	if s.Mergeability.Conflict {
+		addBlocker("merge conflicts")
+	}
+	if s.Mergeability.BehindBase {
+		addBlocker("branch is behind base")
+	}
+	if ciSummary == "failing" {
+		addBlocker("CI failing")
+	}
+	if ciSummary == "pending" {
+		addBlocker("CI pending")
+	}
+	if reviewDecision == "changes_requested" {
+		addBlocker("changes requested")
+	}
+	if reviewDecision == "pending" {
+		addBlocker("review required")
+	}
+	if mergeState == "BLOCKED" {
+		addBlocker("merge blocked by branch protection")
+	}
+	if mergeState == "UNSTABLE" {
+		addBlocker("required checks are failing")
+	}
+	if draft {
+		addBlocker("PR is still a draft")
 	}
 	s.Mergeability.Mergeable = s.PR.State == domain.PROpen &&
-		s.Mergeability.RawState == "MERGEABLE" &&
+		raw == "MERGEABLE" &&
+		!draft &&
 		s.Mergeability.NoConflicts &&
 		!s.Mergeability.BehindBase &&
 		s.Mergeability.CIPassing &&
@@ -788,16 +872,6 @@ func (p *Provider) refreshReviewDetails(ctx context.Context, cache ports.SCMProv
 		}
 	}
 
-	if !forceGraphQL && hasCache && now.Sub(entry.UpdatedAt) < reviewDetailThrottle {
-		attach(cached.Threads)
-		return nil
-	}
-	if !forceGraphQL && !hasCache && havePrev && len(prev.Review.UnresolvedThreads) > 0 {
-		attach(prev.Review.UnresolvedThreads)
-		putCachedReviewDetails(ctx, cache, subj, snap.Review.Decision, prev.Review.UnresolvedThreads, now)
-		return nil
-	}
-
 	if forceGraphQL {
 		threads, diags, err := p.fetchReviewThreadsGraphQL(ctx, subj)
 		if err != nil {
@@ -872,7 +946,7 @@ func (p *Provider) fetchReviewThreadsGraphQL(ctx context.Context, subj domain.SC
 		return nil, nil, nil
 	}
 	owner, repo := subj.Repository().OwnerName()
-	query := `query($owner:String!,$repo:String!,$number:Int!){ repository(owner:$owner,name:$repo){ pullRequest(number:$number){ reviewThreads(last:100){ nodes{ id isResolved comments(first:1){ nodes{ id author{ login __typename } body path line url } } } } } } rateLimit{ limit remaining resetAt } }`
+	query := `query($owner:String!,$repo:String!,$number:Int!){ repository(owner:$owner,name:$repo){ pullRequest(number:$number){ reviewThreads(last:100){ nodes{ id isResolved comments(first:100){ nodes{ id author{ login __typename } body path line url } } } } } } rateLimit{ limit remaining resetAt } }`
 	data, _, diag, err := p.client.DoGraphQL(ctx, query, map[string]any{"owner": owner, "repo": repo, "number": subj.PRNumber}, "github.review_threads")
 	diags := []domain.SCMDiagnostic{}
 	if diag.Operation != "" {
@@ -896,6 +970,11 @@ func (p *Provider) fetchTerminalPRFallback(ctx context.Context, subj domain.SCMS
 	if err != nil {
 		return domain.SCMSnapshot{}, false, resp.Diagnostic, err
 	}
+	snap, terminal, err := snapshotFromRESTPull(subj, resp.Body, now, "github.rest_pr_fallback")
+	return snap, terminal, resp.Diagnostic, err
+}
+
+func snapshotFromRESTPull(subj domain.SCMSubject, body []byte, now time.Time, operation string) (domain.SCMSnapshot, bool, error) {
 	var decoded struct {
 		Number    int    `json:"number"`
 		HTMLURL   string `json:"html_url"`
@@ -913,8 +992,8 @@ func (p *Provider) fetchTerminalPRFallback(ctx context.Context, subj domain.SCMS
 			Ref string `json:"ref"`
 		} `json:"base"`
 	}
-	if err := json.Unmarshal(resp.Body, &decoded); err != nil {
-		return domain.SCMSnapshot{}, false, resp.Diagnostic, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: "github.rest_pr_fallback", Message: err.Error(), Cause: err}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return domain.SCMSnapshot{}, false, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: operation, Message: err.Error(), Cause: err}
 	}
 	state := domain.PROpen
 	if decoded.Merged {
@@ -925,7 +1004,7 @@ func (p *Provider) fetchTerminalPRFallback(ctx context.Context, subj domain.SCMS
 		state = domain.PRDraft
 	}
 	if state != domain.PRMerged && state != domain.PRClosed {
-		return domain.SCMSnapshot{}, false, resp.Diagnostic, nil
+		return domain.SCMSnapshot{}, false, nil
 	}
 	number := decoded.Number
 	if number == 0 {
@@ -949,7 +1028,7 @@ func (p *Provider) fetchTerminalPRFallback(ctx context.Context, subj domain.SCMS
 	subj.PRNumber = number
 	subj.PRURL = url
 	subj.BaseBranch = firstNonEmpty(subj.BaseBranch, pull.TargetBranch)
-	return domain.SCMSnapshot{SessionID: subj.SessionID, Subject: subj, Freshness: domain.SCMFreshnessFresh, ObservedAt: now, PR: pull}, true, resp.Diagnostic, nil
+	return domain.SCMSnapshot{SessionID: subj.SessionID, Subject: subj, Freshness: domain.SCMFreshnessFresh, ObservedAt: now, PR: pull}, true, nil
 }
 
 func reviewCommentsEmpty(body []byte) bool {
@@ -988,23 +1067,49 @@ func summarizeChecks(checks []domain.SCMCheck) string {
 		return "none"
 	}
 	pending := false
+	passing := false
 	for _, c := range checks {
 		if failedCheck(c) {
 			return "failing"
 		}
-		if c.Conclusion == "" || strings.EqualFold(c.Status, "queued") || strings.EqualFold(c.Status, "in_progress") || strings.EqualFold(c.Status, "pending") {
+		if isPendingCheck(c) {
 			pending = true
+			continue
+		}
+		if isPassingCheck(c) {
+			passing = true
 		}
 	}
 	if pending {
 		return "pending"
 	}
-	return "passing"
+	if passing {
+		return "passing"
+	}
+	return "none"
 }
 
 func failedCheck(c domain.SCMCheck) bool {
-	s := strings.ToLower(firstNonEmpty(c.Conclusion, c.Status))
+	s := strings.ToLower(strings.TrimSpace(firstNonEmpty(c.Conclusion, c.Status)))
 	return s == "failure" || s == "failed" || s == "error" || s == "timed_out" || s == "cancelled" || s == "action_required"
+}
+
+func isPendingCheck(c domain.SCMCheck) bool {
+	status := strings.ToLower(strings.TrimSpace(c.Status))
+	conclusion := strings.ToLower(strings.TrimSpace(c.Conclusion))
+	if conclusion != "" {
+		return conclusion == "pending" || conclusion == "queued" || conclusion == "in_progress" || conclusion == "requested" || conclusion == "waiting" || conclusion == "expected"
+	}
+	return status == "queued" || status == "in_progress" || status == "pending" || status == "requested" || status == "waiting" || status == "expected"
+}
+
+func isPassingCheck(c domain.SCMCheck) bool {
+	status := strings.ToLower(strings.TrimSpace(c.Status))
+	conclusion := strings.ToLower(strings.TrimSpace(c.Conclusion))
+	if conclusion == "success" || conclusion == "successful" || conclusion == "passed" || conclusion == "passing" || conclusion == "pass" {
+		return true
+	}
+	return conclusion == "" && (status == "success" || status == "successful" || status == "passed" || status == "passing" || status == "pass")
 }
 
 func combinedFailureTail(checks []domain.SCMCheck) string {
@@ -1070,7 +1175,21 @@ func threadIsBot(comments []domain.SCMReviewComment) bool {
 func isBotAuthor(login, typ string) bool {
 	login = strings.ToLower(login)
 	typ = strings.ToLower(typ)
-	return typ == "bot" || strings.Contains(login, "[bot]") || strings.HasSuffix(login, "-bot") || strings.Contains(login, "bot")
+	if typ == "bot" || strings.Contains(login, "[bot]") || strings.HasSuffix(login, "-bot") {
+		return true
+	}
+	_, ok := knownBotLogins[login]
+	return ok
+}
+
+var knownBotLogins = map[string]struct{}{
+	"codecov":        {},
+	"cursor":         {},
+	"dependabot":     {},
+	"github-actions": {},
+	"renovate":       {},
+	"sonarcloud":     {},
+	"snyk":           {},
 }
 
 func nodes(v any) []map[string]any {
@@ -1211,6 +1330,8 @@ func githubCacheCap(namespace string) int {
 		return cacheCapBranchMap
 	case cacheCheckGuard:
 		return cacheCapCheckGuard
+	case cachePRState:
+		return cacheCapPRState
 	default:
 		return 0
 	}

--- a/backend/internal/adapters/scm/github/provider.go
+++ b/backend/internal/adapters/scm/github/provider.go
@@ -1,0 +1,671 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const (
+	cachePRList    = "pr-list"
+	cacheBranchMap = "branch-map"
+	cacheChecks    = "checks"
+	cacheReviews   = "reviews"
+)
+
+type Provider struct {
+	client *Client
+	host   string
+}
+
+type ProviderOptions struct {
+	Client     *Client
+	HTTPClient *http.Client
+	Token      TokenSource
+	RESTBase   string
+	GraphQLURL string
+	Host       string
+}
+
+func NewProvider(opts ProviderOptions) *Provider {
+	p := &Provider{client: opts.Client, host: opts.Host}
+	if p.client == nil {
+		p.client = NewClient(ClientOptions{HTTPClient: opts.HTTPClient, Token: opts.Token, RESTBase: opts.RESTBase, GraphQLURL: opts.GraphQLURL})
+	}
+	if p.host == "" {
+		p.host = defaultHost
+	}
+	return p
+}
+
+func (p *Provider) Provider() domain.SCMProvider { return domain.SCMProviderGitHub }
+
+func (p *Provider) ObserveSessions(ctx context.Context, req ports.SCMObserveRequest, cache ports.SCMProviderCache) (ports.SCMObserveResult, error) {
+	now := req.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	res := ports.SCMObserveResult{ProviderName: domain.SCMProviderGitHub}
+	groups := map[string][]domain.SCMSubject{}
+	for _, subj := range req.Subjects {
+		subj = p.normalizeSubject(ctx, subj)
+		groups[subj.Repository().Key()] = append(groups[subj.Repository().Key()], subj)
+	}
+	var firstErr error
+	for _, subjects := range groups {
+		updated, err := p.discover(ctx, subjects, cache, now)
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+		res.Subjects = append(res.Subjects, updated...)
+		snaps, diags, rl, err := p.observeKnownPRs(ctx, updated, cache, now)
+		res.Snapshots = append(res.Snapshots, snaps...)
+		res.Diagnostics = append(res.Diagnostics, diags...)
+		if rl != nil {
+			res.RateLimit = rl
+		}
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+		for _, subj := range updated {
+			key := domain.SCMPollStateKey{Provider: subj.Provider, Host: subj.Host, Repo: subj.Repo}
+			st := domain.SCMPollState{Key: key}
+			if err != nil {
+				st.ConsecutiveFail = 1
+				st.LastFailureAt = now
+				st.BackoffUntil = now.Add(30 * time.Second)
+				if se, ok := err.(*domain.SCMError); ok {
+					st.LastError = se
+					if se.Kind == domain.SCMErrorRateLimited && !se.RetryAfter.IsZero() {
+						st.RateLimitUntil = se.RetryAfter
+					}
+				}
+			} else {
+				st.LastSuccessAt = now
+			}
+			res.PollStates = append(res.PollStates, st)
+		}
+	}
+	return res, firstErr
+}
+
+func (p *Provider) normalizeSubject(ctx context.Context, subj domain.SCMSubject) domain.SCMSubject {
+	if subj.Provider == "" {
+		subj.Provider = domain.SCMProviderGitHub
+	}
+	if subj.Host == "" {
+		subj.Host = p.host
+	}
+	if subj.CredentialHash == "" {
+		subj.CredentialHash = p.client.CredentialHash(ctx)
+	}
+	return subj
+}
+
+func (p *Provider) discover(ctx context.Context, subjects []domain.SCMSubject, cache ports.SCMProviderCache, now time.Time) ([]domain.SCMSubject, error) {
+	if len(subjects) == 0 {
+		return nil, nil
+	}
+	out := append([]domain.SCMSubject(nil), subjects...)
+	need := false
+	for _, subj := range out {
+		if subj.PRNumber == 0 && subj.Branch != "" {
+			need = true
+			break
+		}
+	}
+	if !need {
+		return out, nil
+	}
+	scope := out[0].CacheScope()
+	for i := range out {
+		if out[i].PRNumber != 0 || out[i].Branch == "" {
+			continue
+		}
+		if mapped, ok, _ := getCachedBranch(ctx, cache, scope, out[i].Branch); ok {
+			out[i].PRNumber = mapped.Number
+			out[i].PRURL = mapped.URL
+			out[i].BaseBranch = firstNonEmpty(out[i].BaseBranch, mapped.BaseBranch)
+		}
+	}
+	stillNeed := false
+	for _, subj := range out {
+		if subj.PRNumber == 0 && subj.Branch != "" {
+			stillNeed = true
+			break
+		}
+	}
+	if !stillNeed {
+		return out, nil
+	}
+
+	cacheKey := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cachePRList, Key: "open"}
+	entry, hasEntry, _ := cache.GetProviderCache(ctx, cacheKey)
+	owner, repo := out[0].Repository().OwnerName()
+	q := url.Values{"state": []string{"open"}, "per_page": []string{"100"}}
+	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "pulls"), q, nil, entry.ETag, "github.pr_list")
+	if err != nil {
+		return out, err
+	}
+	var pulls []restPull
+	if resp.NotModified && hasEntry {
+		_ = json.Unmarshal(entry.Value, &pulls)
+	} else {
+		if err := json.Unmarshal(resp.Body, &pulls); err != nil {
+			return out, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: "github.pr_list", Message: err.Error(), Cause: err}
+		}
+		_ = cache.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: cacheKey, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
+	}
+	for _, pr := range pulls {
+		if pr.Number <= 0 || pr.Head.Ref == "" {
+			continue
+		}
+		m := branchMapping{Number: pr.Number, URL: pr.HTMLURL, Branch: pr.Head.Ref, BaseBranch: pr.Base.Ref}
+		putCachedBranch(ctx, cache, scope, pr.Head.Ref, m, now)
+	}
+	for i := range out {
+		if out[i].PRNumber != 0 || out[i].Branch == "" {
+			continue
+		}
+		if mapped, ok := findPullForBranch(pulls, out[i].Branch); ok {
+			out[i].PRNumber = mapped.Number
+			out[i].PRURL = mapped.URL
+			out[i].BaseBranch = firstNonEmpty(out[i].BaseBranch, mapped.BaseBranch)
+		}
+	}
+	return out, nil
+}
+
+func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSubject, cache ports.SCMProviderCache, now time.Time) ([]domain.SCMSnapshot, []domain.SCMDiagnostic, *domain.SCMRateLimit, error) {
+	known := make([]domain.SCMSubject, 0, len(subjects))
+	snaps := make([]domain.SCMSnapshot, 0, len(subjects))
+	for _, subj := range subjects {
+		if subj.PRNumber == 0 {
+			snaps = append(snaps, domain.SCMSnapshot{SessionID: subj.SessionID, Subject: subj, Freshness: domain.SCMFreshnessFresh, ObservedAt: now})
+			continue
+		}
+		known = append(known, subj)
+	}
+	if len(known) == 0 {
+		return snaps, nil, nil, nil
+	}
+	owner, repo := known[0].Repository().OwnerName()
+	data, rl, diag, err := p.fetchPRBatch(ctx, owner, repo, known)
+	diags := []domain.SCMDiagnostic{diag}
+	if err != nil {
+		for _, subj := range known {
+			snaps = append(snaps, unavailableSnapshot(subj, now, err))
+		}
+		return snaps, diags, rl, err
+	}
+	for _, subj := range known {
+		prData, _ := data[aliasFor(subj.PRNumber)].(map[string]any)
+		if prData == nil {
+			snaps = append(snaps, unavailableSnapshot(subj, now, &domain.SCMError{Kind: domain.SCMErrorNotFound, Operation: "github.graphql_pr", Message: "pull request not found"}))
+			continue
+		}
+		snap := snapshotFromGraphQL(subj, prData, now)
+		checks, checkDiag, err := p.fetchCheckRuns(ctx, cache, subj, snap, now)
+		if checkDiag.Operation != "" {
+			snap.Diagnostics = append(snap.Diagnostics, checkDiag)
+		}
+		if err == nil && len(checks) > 0 {
+			snap.CI.Checks = checks
+			snap.CI.Summary = summarizeChecks(checks)
+			snap.CI.FailureLogTail = combinedFailureTail(checks)
+		}
+		reviewThreads, reviewDiag, err := p.fetchReviewComments(ctx, cache, subj, now)
+		if reviewDiag.Operation != "" {
+			snap.Diagnostics = append(snap.Diagnostics, reviewDiag)
+		}
+		if err == nil && len(reviewThreads) > 0 && len(snap.Review.UnresolvedThreads) == 0 {
+			snap.Review.UnresolvedThreads = reviewThreads
+			classifyThreads(&snap.Review)
+		}
+		finalizeMergeability(&snap)
+		snaps = append(snaps, snap)
+	}
+	return snaps, diags, rl, nil
+}
+
+func (p *Provider) fetchPRBatch(ctx context.Context, owner, repo string, subjects []domain.SCMSubject) (map[string]any, *domain.SCMRateLimit, domain.SCMDiagnostic, error) {
+	var b strings.Builder
+	b.WriteString("query($owner:String!,$repo:String!){ repository(owner:$owner,name:$repo){")
+	seen := map[int]bool{}
+	for _, subj := range subjects {
+		if seen[subj.PRNumber] {
+			continue
+		}
+		seen[subj.PRNumber] = true
+		fmt.Fprintf(&b, `%s: pullRequest(number:%d){ number title url state isDraft merged closed headRefName baseRefName headRefOid additions deletions mergeable reviewDecision mergeStateStatus commits(last:1){ nodes{ commit{ statusCheckRollup{ state contexts(first:50){ nodes{ __typename ... on CheckRun { name status conclusion detailsUrl url } ... on StatusContext { context state targetUrl } } } } } } } reviewThreads(first:50){ nodes{ id isResolved path line comments(first:20){ nodes{ id body url author{ __typename login } } } } } }`, aliasFor(subj.PRNumber), subj.PRNumber)
+	}
+	b.WriteString("} rateLimit{ limit remaining resetAt } }")
+	data, rl, diag, err := p.client.DoGraphQL(ctx, b.String(), map[string]any{"owner": owner, "repo": repo}, "github.graphql_pr_batch")
+	if err != nil {
+		return nil, rl, diag, err
+	}
+	repoData, _ := data["repository"].(map[string]any)
+	return repoData, rl, diag, nil
+}
+
+func snapshotFromGraphQL(subj domain.SCMSubject, pr map[string]any, now time.Time) domain.SCMSnapshot {
+	number := int(num(pr["number"]))
+	if number == 0 {
+		number = subj.PRNumber
+	}
+	state := prStateFromGraphQL(str(pr["state"]), boolv(pr["isDraft"]), boolv(pr["merged"]), boolv(pr["closed"]))
+	url := firstNonEmpty(str(pr["url"]), subj.PRURL)
+	pull := &domain.SCMPullRequest{ID: domain.SCMChangeRequestID{Provider: subj.Provider, Host: subj.Host, Repo: subj.Repo, Number: number}, Number: number, URL: url, Title: str(pr["title"]), State: state, Draft: boolv(pr["isDraft"]), Merged: boolv(pr["merged"]), SourceBranch: str(pr["headRefName"]), TargetBranch: str(pr["baseRefName"]), HeadSHA: str(pr["headRefOid"]), Additions: int(num(pr["additions"])), Deletions: int(num(pr["deletions"]))}
+	if pull.SourceBranch == "" {
+		pull.SourceBranch = subj.Branch
+	}
+	if pull.TargetBranch == "" {
+		pull.TargetBranch = subj.BaseBranch
+	}
+	subj.PRNumber = number
+	subj.PRURL = url
+	subj.BaseBranch = firstNonEmpty(subj.BaseBranch, pull.TargetBranch)
+	ci := ciFromGraphQL(pr)
+	review := reviewFromGraphQL(pr)
+	merge := mergeabilityFromGraphQL(pr, ci, review)
+	return domain.SCMSnapshot{SessionID: subj.SessionID, Subject: subj, Freshness: domain.SCMFreshnessFresh, ObservedAt: now, PR: pull, CI: ci, Review: review, Mergeability: merge}
+}
+
+func ciFromGraphQL(pr map[string]any) domain.SCMCI {
+	roll := statusRollup(pr)
+	ci := domain.SCMCI{Summary: domain.NormalizeSCMCI(str(roll["state"]))}
+	contexts, _ := roll["contexts"].(map[string]any)
+	for _, n := range nodes(contexts["nodes"]) {
+		typ := str(n["__typename"])
+		check := domain.SCMCheck{}
+		switch typ {
+		case "CheckRun":
+			check.Name = str(n["name"])
+			check.Status = str(n["status"])
+			check.Conclusion = str(n["conclusion"])
+			check.URL = firstNonEmpty(str(n["detailsUrl"]), str(n["url"]))
+		case "StatusContext":
+			check.Name = str(n["context"])
+			check.Conclusion = str(n["state"])
+			check.URL = str(n["targetUrl"])
+		}
+		if check.Name != "" {
+			ci.Checks = append(ci.Checks, check)
+		}
+	}
+	if ci.Summary == "" {
+		ci.Summary = summarizeChecks(ci.Checks)
+	}
+	return ci
+}
+
+func statusRollup(pr map[string]any) map[string]any {
+	commits, _ := pr["commits"].(map[string]any)
+	for _, n := range nodes(commits["nodes"]) {
+		commit, _ := n["commit"].(map[string]any)
+		roll, _ := commit["statusCheckRollup"].(map[string]any)
+		if roll != nil {
+			return roll
+		}
+	}
+	return nil
+}
+
+func reviewFromGraphQL(pr map[string]any) domain.SCMReview {
+	review := domain.SCMReview{Decision: domain.NormalizeSCMReviewDecision(str(pr["reviewDecision"]))}
+	threads, _ := pr["reviewThreads"].(map[string]any)
+	for _, n := range nodes(threads["nodes"]) {
+		if boolv(n["isResolved"]) {
+			continue
+		}
+		th := domain.SCMReviewThread{ID: str(n["id"]), Path: str(n["path"]), Line: int(num(n["line"]))}
+		comments, _ := n["comments"].(map[string]any)
+		for _, cn := range nodes(comments["nodes"]) {
+			author, _ := cn["author"].(map[string]any)
+			login := str(author["login"])
+			isBot := isBotAuthor(login, str(author["__typename"]))
+			th.Comments = append(th.Comments, domain.SCMReviewComment{ID: str(cn["id"]), Author: login, Body: str(cn["body"]), URL: str(cn["url"]), IsBot: isBot, Path: th.Path, Line: th.Line, ThreadID: th.ID})
+			if th.URL == "" {
+				th.URL = str(cn["url"])
+			}
+		}
+		th.IsBot = threadIsBot(th.Comments)
+		review.UnresolvedThreads = append(review.UnresolvedThreads, th)
+	}
+	classifyThreads(&review)
+	return review
+}
+
+func mergeabilityFromGraphQL(pr map[string]any, ci domain.SCMCI, review domain.SCMReview) domain.SCMMergeability {
+	raw := strings.ToUpper(str(pr["mergeable"]))
+	mergeState := strings.ToUpper(str(pr["mergeStateStatus"]))
+	m := domain.SCMMergeability{RawState: raw, MergeState: mergeState}
+	m.CIPassing = ci.Summary == "passing" || ci.Summary == "none" || ci.Summary == ""
+	m.Approved = review.Decision == "approved" || review.Decision == "none" || review.Decision == ""
+	m.Conflict = raw == "CONFLICTING" || mergeState == "DIRTY"
+	m.NoConflicts = !m.Conflict
+	m.BehindBase = mergeState == "BEHIND"
+	if m.Conflict {
+		m.Blockers = append(m.Blockers, "merge conflicts")
+	}
+	if m.BehindBase {
+		m.Blockers = append(m.Blockers, "branch is behind base")
+	}
+	if ci.Summary == "failing" {
+		m.Blockers = append(m.Blockers, "CI failing")
+	}
+	if ci.Summary == "pending" {
+		m.Blockers = append(m.Blockers, "CI pending")
+	}
+	if review.Decision == "changes_requested" {
+		m.Blockers = append(m.Blockers, "changes requested")
+	}
+	if mergeState == "BLOCKED" {
+		m.Blockers = append(m.Blockers, "merge blocked")
+	}
+	m.Mergeable = raw == "MERGEABLE" && m.NoConflicts && !m.BehindBase && m.CIPassing && m.Approved && len(m.Blockers) == 0
+	return m
+}
+
+func finalizeMergeability(s *domain.SCMSnapshot) {
+	if s.PR == nil || s.PR.State == domain.PRMerged {
+		return
+	}
+	if s.Mergeability.CIPassing == false && (s.CI.Summary == "passing" || s.CI.Summary == "none" || s.CI.Summary == "") {
+		s.Mergeability.CIPassing = true
+	}
+	if s.Mergeability.Approved == false && (s.Review.Decision == "approved" || s.Review.Decision == "none" || s.Review.Decision == "") {
+		s.Mergeability.Approved = true
+	}
+	if s.Mergeability.RawState == "" && !s.Mergeability.Conflict {
+		s.Mergeability.NoConflicts = true
+	}
+	s.Mergeability.Mergeable = s.Mergeability.Mergeable || (s.Mergeability.NoConflicts && !s.Mergeability.BehindBase && s.Mergeability.CIPassing && s.Mergeability.Approved && len(s.Mergeability.Blockers) == 0)
+}
+
+func (p *Provider) fetchCheckRuns(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject, snap domain.SCMSnapshot, now time.Time) ([]domain.SCMCheck, domain.SCMDiagnostic, error) {
+	if snap.PR == nil || snap.PR.HeadSHA == "" {
+		return nil, domain.SCMDiagnostic{}, nil
+	}
+	scope := subj.CacheScope()
+	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cacheChecks, Key: snap.PR.HeadSHA}
+	entry, hasEntry, _ := cache.GetProviderCache(ctx, key)
+	owner, repo := subj.Repository().OwnerName()
+	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "commits", snap.PR.HeadSHA, "check-runs"), nil, nil, entry.ETag, "github.check_runs")
+	if err != nil {
+		return nil, resp.Diagnostic, err
+	}
+	body := resp.Body
+	if resp.NotModified && hasEntry {
+		body = entry.Value
+	} else {
+		_ = cache.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
+	}
+	var decoded struct {
+		CheckRuns []struct {
+			Name       string `json:"name"`
+			Status     string `json:"status"`
+			Conclusion string `json:"conclusion"`
+			HTMLURL    string `json:"html_url"`
+			DetailsURL string `json:"details_url"`
+			Output     struct {
+				Title   string `json:"title"`
+				Summary string `json:"summary"`
+				Text    string `json:"text"`
+			} `json:"output"`
+		} `json:"check_runs"`
+	}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return nil, resp.Diagnostic, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: "github.check_runs", Message: err.Error(), Cause: err}
+	}
+	checks := make([]domain.SCMCheck, 0, len(decoded.CheckRuns))
+	for _, r := range decoded.CheckRuns {
+		checks = append(checks, domain.SCMCheck{Name: r.Name, Status: r.Status, Conclusion: r.Conclusion, URL: firstNonEmpty(r.HTMLURL, r.DetailsURL), Details: firstNonEmpty(r.Output.Title, r.Output.Summary), LogTail: tailLines(firstNonEmpty(r.Output.Text, r.Output.Summary), 120)})
+	}
+	return checks, resp.Diagnostic, nil
+}
+
+func (p *Provider) fetchReviewComments(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject, now time.Time) ([]domain.SCMReviewThread, domain.SCMDiagnostic, error) {
+	if subj.PRNumber == 0 {
+		return nil, domain.SCMDiagnostic{}, nil
+	}
+	scope := subj.CacheScope()
+	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cacheReviews, Key: strconv.Itoa(subj.PRNumber)}
+	entry, hasEntry, _ := cache.GetProviderCache(ctx, key)
+	owner, repo := subj.Repository().OwnerName()
+	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "pulls", strconv.Itoa(subj.PRNumber), "comments"), nil, nil, entry.ETag, "github.review_comments")
+	if err != nil {
+		return nil, resp.Diagnostic, err
+	}
+	body := resp.Body
+	if resp.NotModified && hasEntry {
+		body = entry.Value
+	} else {
+		_ = cache.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
+	}
+	var comments []struct {
+		ID                  int64  `json:"id"`
+		Body                string `json:"body"`
+		HTMLURL             string `json:"html_url"`
+		Path                string `json:"path"`
+		Line                int    `json:"line"`
+		OriginalLine        int    `json:"original_line"`
+		PullRequestReviewID int64  `json:"pull_request_review_id"`
+		User                struct {
+			Login string `json:"login"`
+			Type  string `json:"type"`
+		} `json:"user"`
+	}
+	if err := json.Unmarshal(body, &comments); err != nil {
+		return nil, resp.Diagnostic, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: "github.review_comments", Message: err.Error(), Cause: err}
+	}
+	threads := make([]domain.SCMReviewThread, 0, len(comments))
+	for _, c := range comments {
+		line := c.Line
+		if line == 0 {
+			line = c.OriginalLine
+		}
+		threadID := fmt.Sprintf("review-%d-comment-%d", c.PullRequestReviewID, c.ID)
+		isBot := isBotAuthor(c.User.Login, c.User.Type)
+		comment := domain.SCMReviewComment{ID: strconv.FormatInt(c.ID, 10), Author: c.User.Login, Body: c.Body, URL: c.HTMLURL, IsBot: isBot, Path: c.Path, Line: line, ThreadID: threadID}
+		threads = append(threads, domain.SCMReviewThread{ID: threadID, Path: c.Path, Line: line, URL: c.HTMLURL, IsBot: isBot, Comments: []domain.SCMReviewComment{comment}})
+	}
+	return threads, resp.Diagnostic, nil
+}
+
+func repoPath(owner, repo string, elems ...string) string {
+	all := append([]string{"repos", owner, repo}, elems...)
+	for i := range all {
+		all[i] = url.PathEscape(all[i])
+	}
+	return "/" + path.Join(all...)
+}
+
+func aliasFor(number int) string { return fmt.Sprintf("pr%d", number) }
+
+func prStateFromGraphQL(state string, draft, merged, closed bool) domain.PRState {
+	if merged || strings.EqualFold(state, "MERGED") {
+		return domain.PRMerged
+	}
+	if closed || strings.EqualFold(state, "CLOSED") {
+		return domain.PRClosed
+	}
+	if draft {
+		return domain.PRDraft
+	}
+	return domain.PROpen
+}
+
+func summarizeChecks(checks []domain.SCMCheck) string {
+	if len(checks) == 0 {
+		return "none"
+	}
+	pending := false
+	for _, c := range checks {
+		if failedCheck(c) {
+			return "failing"
+		}
+		if c.Conclusion == "" || strings.EqualFold(c.Status, "queued") || strings.EqualFold(c.Status, "in_progress") || strings.EqualFold(c.Status, "pending") {
+			pending = true
+		}
+	}
+	if pending {
+		return "pending"
+	}
+	return "passing"
+}
+
+func failedCheck(c domain.SCMCheck) bool {
+	s := strings.ToLower(firstNonEmpty(c.Conclusion, c.Status))
+	return s == "failure" || s == "failed" || s == "error" || s == "timed_out" || s == "cancelled" || s == "action_required"
+}
+
+func combinedFailureTail(checks []domain.SCMCheck) string {
+	var parts []string
+	for _, c := range checks {
+		if failedCheck(c) && c.LogTail != "" {
+			parts = append(parts, c.Name+":\n"+c.LogTail)
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func tailLines(s string, n int) string {
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
+}
+
+func classifyThreads(review *domain.SCMReview) {
+	review.BotComments = nil
+	review.HumanComments = nil
+	for i := range review.UnresolvedThreads {
+		review.UnresolvedThreads[i].IsBot = threadIsBot(review.UnresolvedThreads[i].Comments)
+		if review.UnresolvedThreads[i].IsBot {
+			review.BotComments = append(review.BotComments, review.UnresolvedThreads[i])
+		} else {
+			review.HumanComments = append(review.HumanComments, review.UnresolvedThreads[i])
+		}
+	}
+	if len(review.HumanComments) > 0 && review.Decision == "none" {
+		review.Decision = "changes_requested"
+	}
+}
+
+func threadIsBot(comments []domain.SCMReviewComment) bool {
+	if len(comments) == 0 {
+		return false
+	}
+	for _, c := range comments {
+		if !c.IsBot {
+			return false
+		}
+	}
+	return true
+}
+
+func isBotAuthor(login, typ string) bool {
+	login = strings.ToLower(login)
+	typ = strings.ToLower(typ)
+	return typ == "bot" || strings.Contains(login, "[bot]") || strings.HasSuffix(login, "-bot") || strings.Contains(login, "bot")
+}
+
+func nodes(v any) []map[string]any {
+	a, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(a))
+	for _, item := range a {
+		if m, ok := item.(map[string]any); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func str(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+func boolv(v any) bool {
+	if b, ok := v.(bool); ok {
+		return b
+	}
+	return false
+}
+
+type restPull struct {
+	Number  int    `json:"number"`
+	HTMLURL string `json:"html_url"`
+	Head    struct {
+		Ref string `json:"ref"`
+	} `json:"head"`
+	Base struct {
+		Ref string `json:"ref"`
+	} `json:"base"`
+}
+
+type branchMapping struct {
+	Number     int    `json:"number"`
+	URL        string `json:"url"`
+	Branch     string `json:"branch"`
+	BaseBranch string `json:"baseBranch"`
+}
+
+func getCachedBranch(ctx context.Context, cache ports.SCMProviderCache, scope domain.SCMProviderCacheScope, branch string) (branchMapping, bool, error) {
+	entry, ok, err := cache.GetProviderCache(ctx, domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cacheBranchMap, Key: branch})
+	if err != nil || !ok {
+		return branchMapping{}, false, err
+	}
+	var mapped branchMapping
+	if err := json.Unmarshal(entry.Value, &mapped); err != nil {
+		return branchMapping{}, false, nil
+	}
+	return mapped, mapped.Number > 0, nil
+}
+
+func putCachedBranch(ctx context.Context, cache ports.SCMProviderCache, scope domain.SCMProviderCacheScope, branch string, mapped branchMapping, now time.Time) {
+	b, _ := json.Marshal(mapped)
+	_ = cache.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cacheBranchMap, Key: branch}, Value: b, UpdatedAt: now})
+}
+
+func findPullForBranch(pulls []restPull, branch string) (branchMapping, bool) {
+	for _, pr := range pulls {
+		if pr.Head.Ref == branch {
+			return branchMapping{Number: pr.Number, URL: pr.HTMLURL, Branch: pr.Head.Ref, BaseBranch: pr.Base.Ref}, true
+		}
+	}
+	return branchMapping{}, false
+}
+
+func unavailableSnapshot(subj domain.SCMSubject, now time.Time, err error) domain.SCMSnapshot {
+	d := domain.SCMDiagnostic{Operation: "github.observe", ErrorKind: domain.SCMErrorUnavailable, Message: fmt.Sprint(err)}
+	if se, ok := err.(*domain.SCMError); ok {
+		d.Operation = se.Operation
+		d.ErrorKind = se.Kind
+		d.StatusCode = se.StatusCode
+	}
+	return domain.SCMSnapshot{SessionID: subj.SessionID, Subject: subj, Freshness: domain.SCMFreshnessUnavailable, ObservedAt: now, Diagnostics: []domain.SCMDiagnostic{d}}
+}
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}

--- a/backend/internal/adapters/scm/github/provider.go
+++ b/backend/internal/adapters/scm/github/provider.go
@@ -1122,9 +1122,6 @@ func classifyThreads(review *domain.SCMReview) {
 			review.HumanComments = append(review.HumanComments, review.UnresolvedThreads[i])
 		}
 	}
-	if len(review.HumanComments) > 0 && review.Decision == "none" {
-		review.Decision = "changes_requested"
-	}
 }
 
 func cloneReviewThreads(in []domain.SCMReviewThread) []domain.SCMReviewThread {

--- a/backend/internal/adapters/scm/github/provider.go
+++ b/backend/internal/adapters/scm/github/provider.go
@@ -39,6 +39,8 @@ type Provider struct {
 	host   string
 }
 
+type restCacheCommit func() error
+
 type ProviderOptions struct {
 	Client     *Client
 	HTTPClient *http.Client
@@ -74,35 +76,51 @@ func (p *Provider) ObserveSessions(ctx context.Context, req ports.SCMObserveRequ
 	}
 	var firstErr error
 	for _, subjects := range groups {
-		updated, err := p.discover(ctx, subjects, cache, now)
-		if err != nil && firstErr == nil {
-			firstErr = err
+		updated, discoverErr := p.discover(ctx, subjects, cache, now)
+		groupErr := discoverErr
+		if discoverErr != nil && firstErr == nil {
+			firstErr = discoverErr
 		}
 		res.Subjects = append(res.Subjects, updated...)
-		snaps, diags, rl, err := p.observeKnownPRs(ctx, updated, cache, now)
+		snaps, diags, rl, observeErr := p.observeKnownPRs(ctx, updated, cache, now)
 		res.Snapshots = append(res.Snapshots, snaps...)
 		res.Diagnostics = append(res.Diagnostics, diags...)
 		if rl != nil {
 			res.RateLimit = rl
 		}
-		if err != nil && firstErr == nil {
-			firstErr = err
+		if observeErr != nil {
+			if groupErr == nil {
+				groupErr = observeErr
+			}
+			if firstErr == nil {
+				firstErr = observeErr
+			}
 		}
 		for _, subj := range updated {
 			key := domain.SCMPollStateKey{Provider: subj.Provider, Host: subj.Host, Repo: subj.Repo}
 			st := domain.SCMPollState{Key: key}
-			if err != nil {
-				st.ConsecutiveFail = 1
+			if reader, ok := cache.(pollStateReader); ok {
+				if prev, ok, readErr := reader.GetPollState(ctx, key); readErr == nil && ok {
+					st = prev
+				}
+			}
+			st.Key = key
+			if groupErr != nil {
+				st.ConsecutiveFail++
 				st.LastFailureAt = now
 				st.BackoffUntil = now.Add(30 * time.Second)
-				if se, ok := err.(*domain.SCMError); ok {
+				if se, ok := groupErr.(*domain.SCMError); ok {
 					st.LastError = se
 					if se.Kind == domain.SCMErrorRateLimited && !se.RetryAfter.IsZero() {
 						st.RateLimitUntil = se.RetryAfter
 					}
 				}
 			} else {
+				st.ConsecutiveFail = 0
 				st.LastSuccessAt = now
+				st.LastError = nil
+				st.BackoffUntil = time.Time{}
+				st.RateLimitUntil = time.Time{}
 			}
 			res.PollStates = append(res.PollStates, st)
 		}
@@ -194,16 +212,16 @@ func (p *Provider) discover(ctx context.Context, subjects []domain.SCMSubject, c
 	return out, nil
 }
 
-func (p *Provider) checkOpenPullListChanged(ctx context.Context, cache ports.SCMProviderCache, scope domain.SCMProviderCacheScope, owner, repo string, now time.Time) (bool, domain.SCMDiagnostic, error) {
+func (p *Provider) checkOpenPullListChanged(ctx context.Context, cache ports.SCMProviderCache, scope domain.SCMProviderCacheScope, owner, repo string, now time.Time) (bool, domain.SCMDiagnostic, restCacheCommit, error) {
 	cacheKey := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cachePRList, Key: "open-guard"}
 	entry, hasEntry, _ := cache.GetProviderCache(ctx, cacheKey)
 	q := url.Values{"state": []string{"open"}, "sort": []string{"updated"}, "direction": []string{"desc"}, "per_page": []string{"1"}}
 	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "pulls"), q, nil, entry.ETag, "github.pr_list_guard")
 	if err != nil {
-		return true, resp.Diagnostic, err
+		return true, resp.Diagnostic, nil, err
 	}
-	_ = updateRESTCache(ctx, cache, cacheKey, entry, hasEntry, resp, now)
-	return !resp.NotModified, resp.Diagnostic, nil
+	_, commit := prepareRESTCache(ctx, cache, cacheKey, entry, hasEntry, resp, now)
+	return !resp.NotModified, resp.Diagnostic, commit, nil
 }
 
 func (p *Provider) fetchOpenPullsForDiscovery(ctx context.Context, cache ports.SCMProviderCache, scope domain.SCMProviderCacheScope, owner, repo string, now time.Time) ([]restPull, bool, domain.SCMDiagnostic, error) {
@@ -215,11 +233,12 @@ func (p *Provider) fetchOpenPullsForDiscovery(ctx context.Context, cache ports.S
 		return nil, true, resp.Diagnostic, err
 	}
 	changed := !resp.NotModified
-	body := updateRESTCache(ctx, cache, cacheKey, entry, hasEntry, resp, now)
+	body, commit := prepareRESTCache(ctx, cache, cacheKey, entry, hasEntry, resp, now)
 	var pulls []restPull
 	if err := json.Unmarshal(body, &pulls); err != nil {
 		return nil, changed, resp.Diagnostic, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: "github.pr_list_discovery", Message: err.Error(), Cause: err}
 	}
+	commitRESTCache(commit)
 	return pulls, changed, resp.Diagnostic, nil
 }
 
@@ -255,9 +274,9 @@ func latestSnapshots(ctx context.Context, cache ports.SCMProviderCache, subjects
 	return out
 }
 
-func (p *Provider) checkRunsChanged(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject, headSHA string, now time.Time) (bool, domain.SCMDiagnostic, error) {
+func (p *Provider) checkRunsChanged(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject, headSHA string, now time.Time) (bool, domain.SCMDiagnostic, restCacheCommit, error) {
 	if headSHA == "" {
-		return true, domain.SCMDiagnostic{}, nil
+		return true, domain.SCMDiagnostic{}, nil, nil
 	}
 	scope := subj.CacheScope()
 	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cacheCheckGuard, Key: headSHA}
@@ -266,15 +285,15 @@ func (p *Provider) checkRunsChanged(ctx context.Context, cache ports.SCMProvider
 	q := url.Values{"per_page": []string{"1"}}
 	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "commits", headSHA, "check-runs"), q, nil, entry.ETag, "github.check_runs_guard")
 	if err != nil {
-		return true, resp.Diagnostic, err
+		return true, resp.Diagnostic, nil, err
 	}
-	_ = updateRESTCache(ctx, cache, key, entry, hasEntry, resp, now)
-	return !resp.NotModified, resp.Diagnostic, nil
+	_, commit := prepareRESTCache(ctx, cache, key, entry, hasEntry, resp, now)
+	return !resp.NotModified, resp.Diagnostic, commit, nil
 }
 
-func (p *Provider) reviewCommentsChanged(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject, now time.Time) (bool, domain.SCMDiagnostic, error) {
+func (p *Provider) reviewCommentsChanged(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject, now time.Time) (bool, domain.SCMDiagnostic, restCacheCommit, error) {
 	if subj.PRNumber == 0 {
-		return false, domain.SCMDiagnostic{}, nil
+		return false, domain.SCMDiagnostic{}, nil, nil
 	}
 	scope := subj.CacheScope()
 	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cacheReviews, Key: strconv.Itoa(subj.PRNumber)}
@@ -282,10 +301,10 @@ func (p *Provider) reviewCommentsChanged(ctx context.Context, cache ports.SCMPro
 	owner, repo := subj.Repository().OwnerName()
 	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "pulls", strconv.Itoa(subj.PRNumber), "comments"), nil, nil, entry.ETag, "github.review_comments_guard")
 	if err != nil {
-		return true, resp.Diagnostic, err
+		return true, resp.Diagnostic, nil, err
 	}
-	_ = updateRESTCache(ctx, cache, key, entry, hasEntry, resp, now)
-	return !resp.NotModified, resp.Diagnostic, nil
+	_, commit := prepareRESTCache(ctx, cache, key, entry, hasEntry, resp, now)
+	return !resp.NotModified, resp.Diagnostic, commit, nil
 }
 
 func chunkSubjects(subjects []domain.SCMSubject, size int) [][]domain.SCMSubject {
@@ -347,6 +366,10 @@ type snapshotReader interface {
 	GetLatestSnapshot(ctx context.Context, sessionID domain.SessionID) (domain.SCMSnapshot, bool, error)
 }
 
+type pollStateReader interface {
+	GetPollState(ctx context.Context, key domain.SCMPollStateKey) (domain.SCMPollState, bool, error)
+}
+
 func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSubject, cache ports.SCMProviderCache, now time.Time) ([]domain.SCMSnapshot, []domain.SCMDiagnostic, *domain.SCMRateLimit, error) {
 	known := make([]domain.SCMSubject, 0, len(subjects))
 	snaps := make([]domain.SCMSnapshot, 0, len(subjects))
@@ -364,11 +387,13 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 	owner, repo := known[0].Repository().OwnerName()
 	latest := latestSnapshots(ctx, cache, known)
 	prListChanged := true
+	var prListCommit restCacheCommit
 	diags := []domain.SCMDiagnostic{}
 	if len(latest) > 0 {
 		scope := known[0].CacheScope()
-		changed, prListDiag, err := p.checkOpenPullListChanged(ctx, cache, scope, owner, repo, now)
+		changed, prListDiag, commit, err := p.checkOpenPullListChanged(ctx, cache, scope, owner, repo, now)
 		prListChanged = changed
+		prListCommit = commit
 		if prListDiag.Operation != "" {
 			diags = append(diags, prListDiag)
 		}
@@ -381,6 +406,8 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 
 	toFetch := known
 	reviewChangedBySession := map[domain.SessionID]bool{}
+	checkGuardCommits := map[domain.SessionID]restCacheCommit{}
+	reviewGuardCommits := map[domain.SessionID]restCacheCommit{}
 	if !prListChanged && len(latest) > 0 {
 		toFetch = toFetch[:0]
 		for _, subj := range known {
@@ -389,21 +416,25 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 				toFetch = append(toFetch, subj)
 				continue
 			}
-			changed, diag, err := p.checkRunsChanged(ctx, cache, subj, prev.PR.HeadSHA, now)
+			changed, diag, commit, err := p.checkRunsChanged(ctx, cache, subj, prev.PR.HeadSHA, now)
 			if diag.Operation != "" {
 				diags = append(diags, diag)
 			}
 			if err != nil || changed {
+				if err == nil && changed {
+					checkGuardCommits[subj.SessionID] = commit
+				}
 				toFetch = append(toFetch, subj)
 				continue
 			}
-			reviewChanged, diag, err := p.reviewCommentsChanged(ctx, cache, subj, now)
+			reviewChanged, diag, commit, err := p.reviewCommentsChanged(ctx, cache, subj, now)
 			if diag.Operation != "" {
 				diags = append(diags, diag)
 			}
 			if err != nil || reviewChanged {
 				if err == nil && reviewChanged {
 					reviewChangedBySession[subj.SessionID] = true
+					reviewGuardCommits[subj.SessionID] = commit
 				}
 				toFetch = append(toFetch, subj)
 				continue
@@ -421,6 +452,7 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 
 	var firstErr error
 	var lastRL *domain.SCMRateLimit
+	mainFetchOK := true
 	for _, batch := range chunkSubjects(toFetch, maxGraphQLBatchSize) {
 		data, rl, diag, err := p.fetchPRBatch(ctx, owner, repo, batch)
 		if diag.Operation != "" {
@@ -430,6 +462,7 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 			lastRL = rl
 		}
 		if err != nil {
+			mainFetchOK = false
 			if firstErr == nil {
 				firstErr = err
 			}
@@ -448,6 +481,7 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 		for _, subj := range batch {
 			prData, _ := data[aliasFor(subj.PRNumber)].(map[string]any)
 			if prData == nil {
+				mainFetchOK = false
 				err := &domain.SCMError{Kind: domain.SCMErrorNotFound, Operation: "github.graphql_pr", Message: "pull request not found"}
 				if prev, ok := latest[subj.SessionID]; ok {
 					prev.ObservedAt = now
@@ -466,13 +500,16 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 				if checkDiag.Operation != "" {
 					snap.Diagnostics = append(snap.Diagnostics, checkDiag)
 				}
-				if err == nil && len(checks) > 0 {
+				if err == nil {
 					snap.CI.Checks = checks
 					snap.CI.Summary = summarizeChecks(checks)
+					commitRESTCache(checkGuardCommits[subj.SessionID])
 				} else if err != nil && havePrev && prev.PR != nil && prev.PR.HeadSHA == snap.PR.HeadSHA {
 					snap.CI = prev.CI
 					snap.Diagnostics = append(snap.Diagnostics, diagnosticFromError("github.check_runs", err))
 				}
+			} else {
+				commitRESTCache(checkGuardCommits[subj.SessionID])
 			}
 			if snap.CI.Summary == "failing" {
 				if diag, err := p.enrichFailedCheckLogs(ctx, subj, &snap); err != nil {
@@ -500,14 +537,20 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 			case err == nil:
 				snap.Review.UnresolvedThreads = reviewThreads
 				classifyThreads(&snap.Review)
+				commitRESTCache(reviewGuardCommits[subj.SessionID])
 			case err != nil && havePrev:
 				snap.Review.UnresolvedThreads = prev.Review.UnresolvedThreads
 				classifyThreads(&snap.Review)
+				snap.Diagnostics = append(snap.Diagnostics, diagnosticFromError("github.review_threads", err))
+			case err != nil:
 				snap.Diagnostics = append(snap.Diagnostics, diagnosticFromError("github.review_threads", err))
 			}
 			finalizeMergeability(&snap)
 			snaps = append(snaps, snap)
 		}
+	}
+	if mainFetchOK {
+		commitRESTCache(prListCommit)
 	}
 	return snaps, diags, lastRL, firstErr
 }
@@ -706,11 +749,12 @@ func (p *Provider) fetchCheckRuns(ctx context.Context, cache ports.SCMProviderCa
 	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cacheChecks, Key: snap.PR.HeadSHA}
 	entry, hasEntry, _ := cache.GetProviderCache(ctx, key)
 	owner, repo := subj.Repository().OwnerName()
-	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "commits", snap.PR.HeadSHA, "check-runs"), nil, nil, entry.ETag, "github.check_runs")
+	q := url.Values{"per_page": []string{"100"}}
+	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "commits", snap.PR.HeadSHA, "check-runs"), q, nil, entry.ETag, "github.check_runs")
 	if err != nil {
 		return nil, resp.Diagnostic, err
 	}
-	body := updateRESTCache(ctx, cache, key, entry, hasEntry, resp, now)
+	body, commit := prepareRESTCache(ctx, cache, key, entry, hasEntry, resp, now)
 	var decoded struct {
 		CheckRuns []struct {
 			Name       string `json:"name"`
@@ -728,6 +772,7 @@ func (p *Provider) fetchCheckRuns(ctx context.Context, cache ports.SCMProviderCa
 	if err := json.Unmarshal(body, &decoded); err != nil {
 		return nil, resp.Diagnostic, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: "github.check_runs", Message: err.Error(), Cause: err}
 	}
+	commitRESTCache(commit)
 	checks := make([]domain.SCMCheck, 0, len(decoded.CheckRuns))
 	for _, r := range decoded.CheckRuns {
 		checks = append(checks, domain.SCMCheck{Name: r.Name, Status: r.Status, Conclusion: r.Conclusion, URL: firstNonEmpty(r.HTMLURL, r.DetailsURL), Details: firstNonEmpty(r.Output.Title, r.Output.Summary), LogTail: tailLines(firstNonEmpty(r.Output.Text, r.Output.Summary), ciFailureLogTailLines)})
@@ -816,11 +861,12 @@ func (p *Provider) fetchReviewThreads(ctx context.Context, cache ports.SCMProvid
 	if err != nil {
 		return nil, diags, false, err
 	}
-	body := updateRESTCache(ctx, cache, key, entry, hasEntry, resp, now)
+	body, commit := prepareRESTCache(ctx, cache, key, entry, hasEntry, resp, now)
 	if resp.NotModified {
 		return nil, diags, false, nil
 	}
 	if reviewCommentsEmpty(body) {
+		commitRESTCache(commit)
 		return nil, diags, true, nil
 	}
 	threads, graphDiags, err := p.fetchReviewThreadsGraphQL(ctx, subj)
@@ -828,6 +874,7 @@ func (p *Provider) fetchReviewThreads(ctx context.Context, cache ports.SCMProvid
 	if err != nil {
 		return nil, diags, true, err
 	}
+	commitRESTCache(commit)
 	return threads, diags, true, nil
 }
 
@@ -1042,7 +1089,7 @@ func putCachedBranch(ctx context.Context, cache ports.SCMProviderCache, scope do
 	_ = putProviderCache(ctx, cache, domain.SCMProviderCacheEntry{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cacheBranchMap, Key: branch}, Value: b, UpdatedAt: now})
 }
 
-func updateRESTCache(ctx context.Context, cache ports.SCMProviderCache, key domain.SCMProviderCacheKey, entry domain.SCMProviderCacheEntry, hasEntry bool, resp RESTResponse, now time.Time) []byte {
+func prepareRESTCache(ctx context.Context, cache ports.SCMProviderCache, key domain.SCMProviderCacheKey, entry domain.SCMProviderCacheEntry, hasEntry bool, resp RESTResponse, now time.Time) ([]byte, restCacheCommit) {
 	if resp.NotModified {
 		if hasEntry {
 			if resp.ETag != "" && resp.ETag != entry.ETag {
@@ -1050,13 +1097,18 @@ func updateRESTCache(ctx context.Context, cache ports.SCMProviderCache, key doma
 				entry.UpdatedAt = now
 				_ = putProviderCache(ctx, cache, entry)
 			}
-			return entry.Value
+			return entry.Value, nil
 		}
-		return resp.Body
+		return resp.Body, nil
 	}
-	entry = domain.SCMProviderCacheEntry{Key: key, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now}
-	_ = putProviderCache(ctx, cache, entry)
-	return resp.Body
+	pending := domain.SCMProviderCacheEntry{Key: key, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now}
+	return resp.Body, func() error { return putProviderCache(ctx, cache, pending) }
+}
+
+func commitRESTCache(commit restCacheCommit) {
+	if commit != nil {
+		_ = commit()
+	}
 }
 
 func putProviderCache(ctx context.Context, cache ports.SCMProviderCache, entry domain.SCMProviderCacheEntry) error {

--- a/backend/internal/adapters/scm/github/provider.go
+++ b/backend/internal/adapters/scm/github/provider.go
@@ -30,6 +30,8 @@ const (
 	cacheCapReviews    = 500
 	cacheCapBranchMap  = 1000
 	cacheCapCheckGuard = 500
+
+	ciFailureLogTailLines = 20
 )
 
 type Provider struct {
@@ -159,7 +161,7 @@ func (p *Provider) discover(ctx context.Context, subjects []domain.SCMSubject, c
 	}
 
 	owner, repo := out[0].Repository().OwnerName()
-	pulls, _, _, err := p.fetchOpenPulls(ctx, cache, scope, owner, repo, now)
+	pulls, _, _, err := p.fetchOpenPullsForDiscovery(ctx, cache, scope, owner, repo, now)
 	if err != nil {
 		return out, err
 	}
@@ -178,32 +180,64 @@ func (p *Provider) discover(ctx context.Context, subjects []domain.SCMSubject, c
 			out[i].PRNumber = mapped.Number
 			out[i].PRURL = mapped.URL
 			out[i].BaseBranch = firstNonEmpty(out[i].BaseBranch, mapped.BaseBranch)
+			continue
+		}
+		if mapped, ok, err := p.fetchPullForBranch(ctx, owner, repo, out[i].Branch); err != nil {
+			return out, err
+		} else if ok {
+			putCachedBranch(ctx, cache, scope, out[i].Branch, mapped, now)
+			out[i].PRNumber = mapped.Number
+			out[i].PRURL = mapped.URL
+			out[i].BaseBranch = firstNonEmpty(out[i].BaseBranch, mapped.BaseBranch)
 		}
 	}
 	return out, nil
 }
 
-func (p *Provider) fetchOpenPulls(ctx context.Context, cache ports.SCMProviderCache, scope domain.SCMProviderCacheScope, owner, repo string, now time.Time) ([]restPull, bool, domain.SCMDiagnostic, error) {
-	cacheKey := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cachePRList, Key: "open"}
+func (p *Provider) checkOpenPullListChanged(ctx context.Context, cache ports.SCMProviderCache, scope domain.SCMProviderCacheScope, owner, repo string, now time.Time) (bool, domain.SCMDiagnostic, error) {
+	cacheKey := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cachePRList, Key: "open-guard"}
+	entry, hasEntry, _ := cache.GetProviderCache(ctx, cacheKey)
+	q := url.Values{"state": []string{"open"}, "sort": []string{"updated"}, "direction": []string{"desc"}, "per_page": []string{"1"}}
+	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "pulls"), q, nil, entry.ETag, "github.pr_list_guard")
+	if err != nil {
+		return true, resp.Diagnostic, err
+	}
+	_ = updateRESTCache(ctx, cache, cacheKey, entry, hasEntry, resp, now)
+	return !resp.NotModified, resp.Diagnostic, nil
+}
+
+func (p *Provider) fetchOpenPullsForDiscovery(ctx context.Context, cache ports.SCMProviderCache, scope domain.SCMProviderCacheScope, owner, repo string, now time.Time) ([]restPull, bool, domain.SCMDiagnostic, error) {
+	cacheKey := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cachePRList, Key: "open-discovery"}
 	entry, hasEntry, _ := cache.GetProviderCache(ctx, cacheKey)
 	q := url.Values{"state": []string{"open"}, "sort": []string{"updated"}, "direction": []string{"desc"}, "per_page": []string{"100"}}
-	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "pulls"), q, nil, entry.ETag, "github.pr_list")
+	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "pulls"), q, nil, entry.ETag, "github.pr_list_discovery")
 	if err != nil {
 		return nil, true, resp.Diagnostic, err
 	}
-	var body []byte
 	changed := !resp.NotModified
-	if resp.NotModified && hasEntry {
-		body = entry.Value
-	} else {
-		body = resp.Body
-		_ = putProviderCache(ctx, cache, domain.SCMProviderCacheEntry{Key: cacheKey, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
-	}
+	body := updateRESTCache(ctx, cache, cacheKey, entry, hasEntry, resp, now)
 	var pulls []restPull
 	if err := json.Unmarshal(body, &pulls); err != nil {
-		return nil, changed, resp.Diagnostic, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: "github.pr_list", Message: err.Error(), Cause: err}
+		return nil, changed, resp.Diagnostic, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: "github.pr_list_discovery", Message: err.Error(), Cause: err}
 	}
 	return pulls, changed, resp.Diagnostic, nil
+}
+
+func (p *Provider) fetchPullForBranch(ctx context.Context, owner, repo, branch string) (branchMapping, bool, error) {
+	q := url.Values{"state": []string{"open"}, "head": []string{owner + ":" + branch}, "per_page": []string{"1"}}
+	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "pulls"), q, nil, "", "github.pr_branch_exact")
+	if err != nil {
+		return branchMapping{}, false, err
+	}
+	var pulls []restPull
+	if err := json.Unmarshal(resp.Body, &pulls); err != nil {
+		return branchMapping{}, false, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: "github.pr_branch_exact", Message: err.Error(), Cause: err}
+	}
+	if len(pulls) == 0 || pulls[0].Number <= 0 {
+		return branchMapping{}, false, nil
+	}
+	pr := pulls[0]
+	return branchMapping{Number: pr.Number, URL: pr.HTMLURL, Branch: pr.Head.Ref, BaseBranch: pr.Base.Ref}, true, nil
 }
 
 func latestSnapshots(ctx context.Context, cache ports.SCMProviderCache, subjects []domain.SCMSubject) map[domain.SessionID]domain.SCMSnapshot {
@@ -227,16 +261,14 @@ func (p *Provider) checkRunsChanged(ctx context.Context, cache ports.SCMProvider
 	}
 	scope := subj.CacheScope()
 	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cacheCheckGuard, Key: headSHA}
-	entry, _, _ := cache.GetProviderCache(ctx, key)
+	entry, hasEntry, _ := cache.GetProviderCache(ctx, key)
 	owner, repo := subj.Repository().OwnerName()
 	q := url.Values{"per_page": []string{"1"}}
 	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "commits", headSHA, "check-runs"), q, nil, entry.ETag, "github.check_runs_guard")
 	if err != nil {
 		return true, resp.Diagnostic, err
 	}
-	if !resp.NotModified {
-		_ = putProviderCache(ctx, cache, domain.SCMProviderCacheEntry{Key: key, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
-	}
+	_ = updateRESTCache(ctx, cache, key, entry, hasEntry, resp, now)
 	return !resp.NotModified, resp.Diagnostic, nil
 }
 
@@ -246,15 +278,13 @@ func (p *Provider) reviewCommentsChanged(ctx context.Context, cache ports.SCMPro
 	}
 	scope := subj.CacheScope()
 	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cacheReviews, Key: strconv.Itoa(subj.PRNumber)}
-	entry, _, _ := cache.GetProviderCache(ctx, key)
+	entry, hasEntry, _ := cache.GetProviderCache(ctx, key)
 	owner, repo := subj.Repository().OwnerName()
 	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "pulls", strconv.Itoa(subj.PRNumber), "comments"), nil, nil, entry.ETag, "github.review_comments_guard")
 	if err != nil {
 		return true, resp.Diagnostic, err
 	}
-	if !resp.NotModified {
-		_ = putProviderCache(ctx, cache, domain.SCMProviderCacheEntry{Key: key, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
-	}
+	_ = updateRESTCache(ctx, cache, key, entry, hasEntry, resp, now)
 	return !resp.NotModified, resp.Diagnostic, nil
 }
 
@@ -287,14 +317,30 @@ func shouldFetchCheckRuns(snap domain.SCMSnapshot, prData map[string]any) bool {
 	if snap.PR == nil || snap.PR.HeadSHA == "" {
 		return false
 	}
-	return snap.CI.Summary == "failing" || checkContextsIncomplete(prData)
+	missing, incomplete := checkContextsMissingOrIncomplete(prData)
+	if missing || incomplete {
+		return true
+	}
+	return snap.CI.Summary == "failing" && !hasFailedCheck(snap.CI.Checks)
 }
 
-func checkContextsIncomplete(pr map[string]any) bool {
+func checkContextsMissingOrIncomplete(pr map[string]any) (bool, bool) {
 	roll := statusRollup(pr)
 	contexts, _ := roll["contexts"].(map[string]any)
+	if contexts == nil {
+		return true, false
+	}
 	pageInfo, _ := contexts["pageInfo"].(map[string]any)
-	return boolv(pageInfo["hasNextPage"])
+	return false, boolv(pageInfo["hasNextPage"])
+}
+
+func hasFailedCheck(checks []domain.SCMCheck) bool {
+	for _, check := range checks {
+		if failedCheck(check) {
+			return true
+		}
+	}
+	return false
 }
 
 type snapshotReader interface {
@@ -321,7 +367,7 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 	diags := []domain.SCMDiagnostic{}
 	if len(latest) > 0 {
 		scope := known[0].CacheScope()
-		_, changed, prListDiag, err := p.fetchOpenPulls(ctx, cache, scope, owner, repo, now)
+		changed, prListDiag, err := p.checkOpenPullListChanged(ctx, cache, scope, owner, repo, now)
 		prListChanged = changed
 		if prListDiag.Operation != "" {
 			diags = append(diags, prListDiag)
@@ -334,6 +380,7 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 	}
 
 	toFetch := known
+	reviewChangedBySession := map[domain.SessionID]bool{}
 	if !prListChanged && len(latest) > 0 {
 		toFetch = toFetch[:0]
 		for _, subj := range known {
@@ -355,6 +402,9 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 				diags = append(diags, diag)
 			}
 			if err != nil || reviewChanged {
+				if err == nil && reviewChanged {
+					reviewChangedBySession[subj.SessionID] = true
+				}
 				toFetch = append(toFetch, subj)
 				continue
 			}
@@ -419,27 +469,41 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 				if err == nil && len(checks) > 0 {
 					snap.CI.Checks = checks
 					snap.CI.Summary = summarizeChecks(checks)
-					snap.CI.FailureLogTail = combinedFailureTail(checks)
 				} else if err != nil && havePrev && prev.PR != nil && prev.PR.HeadSHA == snap.PR.HeadSHA {
 					snap.CI = prev.CI
 					snap.Diagnostics = append(snap.Diagnostics, diagnosticFromError("github.check_runs", err))
 				}
 			}
-			reviewThreads, reviewDiag, reviewChanged, err := p.fetchReviewComments(ctx, cache, subj, now)
-			if reviewDiag.Operation != "" {
-				snap.Diagnostics = append(snap.Diagnostics, reviewDiag)
+			if snap.CI.Summary == "failing" {
+				if diag, err := p.enrichFailedCheckLogs(ctx, subj, &snap); err != nil {
+					snap.Diagnostics = append(snap.Diagnostics, diagnosticFromError("github.actions_job_logs", err))
+				} else if diag.Operation != "" {
+					snap.Diagnostics = append(snap.Diagnostics, diag)
+				}
+				snap.CI.FailureLogTail = combinedFailureTail(snap.CI.Checks)
 			}
+			var reviewThreads []domain.SCMReviewThread
+			var reviewDiags []domain.SCMDiagnostic
+			var reviewChangedNow bool
+			var err error
+			if reviewChangedBySession[subj.SessionID] {
+				reviewThreads, reviewDiags, err = p.fetchReviewThreadsGraphQL(ctx, subj)
+				reviewChangedNow = true
+			} else {
+				reviewThreads, reviewDiags, reviewChangedNow, err = p.fetchReviewThreads(ctx, cache, subj, now)
+			}
+			snap.Diagnostics = append(snap.Diagnostics, reviewDiags...)
 			switch {
-			case err == nil && !reviewChanged && havePrev && len(prev.Review.UnresolvedThreads) > 0:
+			case err == nil && !reviewChangedNow && havePrev:
 				snap.Review.UnresolvedThreads = prev.Review.UnresolvedThreads
 				classifyThreads(&snap.Review)
-			case err == nil && len(reviewThreads) > 0:
+			case err == nil:
 				snap.Review.UnresolvedThreads = reviewThreads
 				classifyThreads(&snap.Review)
 			case err != nil && havePrev:
 				snap.Review.UnresolvedThreads = prev.Review.UnresolvedThreads
 				classifyThreads(&snap.Review)
-				snap.Diagnostics = append(snap.Diagnostics, diagnosticFromError("github.review_comments", err))
+				snap.Diagnostics = append(snap.Diagnostics, diagnosticFromError("github.review_threads", err))
 			}
 			finalizeMergeability(&snap)
 			snaps = append(snaps, snap)
@@ -538,12 +602,20 @@ func reviewFromGraphQL(pr map[string]any) domain.SCMReview {
 		if boolv(n["isResolved"]) {
 			continue
 		}
-		th := domain.SCMReviewThread{ID: str(n["id"]), Path: str(n["path"]), Line: int(num(n["line"]))}
+		th := domain.SCMReviewThread{ID: str(n["id"])}
 		comments, _ := n["comments"].(map[string]any)
 		for _, cn := range nodes(comments["nodes"]) {
 			author, _ := cn["author"].(map[string]any)
 			login := str(author["login"])
 			isBot := isBotAuthor(login, str(author["__typename"]))
+			path := str(cn["path"])
+			line := int(num(cn["line"]))
+			if th.Path == "" {
+				th.Path = path
+			}
+			if th.Line == 0 {
+				th.Line = line
+			}
 			th.Comments = append(th.Comments, domain.SCMReviewComment{ID: str(cn["id"]), Author: login, Body: str(cn["body"]), URL: str(cn["url"]), IsBot: isBot, Path: th.Path, Line: th.Line, ThreadID: th.ID})
 			if th.URL == "" {
 				th.URL = str(cn["url"])
@@ -563,8 +635,12 @@ func mergeabilityFromGraphQL(pr map[string]any, ci domain.SCMCI, review domain.S
 	m.CIPassing = ci.Summary == "passing" || ci.Summary == "none" || ci.Summary == ""
 	m.Approved = review.Decision == "approved" || review.Decision == "none" || review.Decision == ""
 	m.Conflict = raw == "CONFLICTING" || mergeState == "DIRTY"
-	m.NoConflicts = !m.Conflict
+	m.NoConflicts = raw == "MERGEABLE" && !m.Conflict
 	m.BehindBase = mergeState == "BEHIND"
+	draft := boolv(pr["isDraft"])
+	if raw == "" || raw == "UNKNOWN" {
+		m.Blockers = append(m.Blockers, "merge status unknown (GitHub is computing)")
+	}
 	if m.Conflict {
 		m.Blockers = append(m.Blockers, "merge conflicts")
 	}
@@ -580,10 +656,19 @@ func mergeabilityFromGraphQL(pr map[string]any, ci domain.SCMCI, review domain.S
 	if review.Decision == "changes_requested" {
 		m.Blockers = append(m.Blockers, "changes requested")
 	}
-	if mergeState == "BLOCKED" {
-		m.Blockers = append(m.Blockers, "merge blocked")
+	if review.Decision == "pending" {
+		m.Blockers = append(m.Blockers, "review required")
 	}
-	m.Mergeable = raw == "MERGEABLE" && m.NoConflicts && !m.BehindBase && m.CIPassing && m.Approved && len(m.Blockers) == 0
+	if mergeState == "BLOCKED" {
+		m.Blockers = append(m.Blockers, "merge blocked by branch protection")
+	}
+	if mergeState == "UNSTABLE" {
+		m.Blockers = append(m.Blockers, "required checks are failing")
+	}
+	if draft {
+		m.Blockers = append(m.Blockers, "PR is still a draft")
+	}
+	m.Mergeable = raw == "MERGEABLE" && !draft && m.NoConflicts && !m.BehindBase && m.CIPassing && m.Approved && len(m.Blockers) == 0
 	return m
 }
 
@@ -597,10 +682,20 @@ func finalizeMergeability(s *domain.SCMSnapshot) {
 	if s.Mergeability.Approved == false && (s.Review.Decision == "approved" || s.Review.Decision == "none" || s.Review.Decision == "") {
 		s.Mergeability.Approved = true
 	}
-	if s.Mergeability.RawState == "" && !s.Mergeability.Conflict {
-		s.Mergeability.NoConflicts = true
+	if s.PR.Draft {
+		s.Mergeability.Mergeable = false
+		if !containsString(s.Mergeability.Blockers, "PR is still a draft") {
+			s.Mergeability.Blockers = append(s.Mergeability.Blockers, "PR is still a draft")
+		}
+		return
 	}
-	s.Mergeability.Mergeable = s.Mergeability.Mergeable || (s.Mergeability.NoConflicts && !s.Mergeability.BehindBase && s.Mergeability.CIPassing && s.Mergeability.Approved && len(s.Mergeability.Blockers) == 0)
+	s.Mergeability.Mergeable = s.PR.State == domain.PROpen &&
+		s.Mergeability.RawState == "MERGEABLE" &&
+		s.Mergeability.NoConflicts &&
+		!s.Mergeability.BehindBase &&
+		s.Mergeability.CIPassing &&
+		s.Mergeability.Approved &&
+		len(s.Mergeability.Blockers) == 0
 }
 
 func (p *Provider) fetchCheckRuns(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject, snap domain.SCMSnapshot, now time.Time) ([]domain.SCMCheck, domain.SCMDiagnostic, error) {
@@ -615,12 +710,7 @@ func (p *Provider) fetchCheckRuns(ctx context.Context, cache ports.SCMProviderCa
 	if err != nil {
 		return nil, resp.Diagnostic, err
 	}
-	body := resp.Body
-	if resp.NotModified && hasEntry {
-		body = entry.Value
-	} else {
-		_ = putProviderCache(ctx, cache, domain.SCMProviderCacheEntry{Key: key, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
-	}
+	body := updateRESTCache(ctx, cache, key, entry, hasEntry, resp, now)
 	var decoded struct {
 		CheckRuns []struct {
 			Name       string `json:"name"`
@@ -640,57 +730,133 @@ func (p *Provider) fetchCheckRuns(ctx context.Context, cache ports.SCMProviderCa
 	}
 	checks := make([]domain.SCMCheck, 0, len(decoded.CheckRuns))
 	for _, r := range decoded.CheckRuns {
-		checks = append(checks, domain.SCMCheck{Name: r.Name, Status: r.Status, Conclusion: r.Conclusion, URL: firstNonEmpty(r.HTMLURL, r.DetailsURL), Details: firstNonEmpty(r.Output.Title, r.Output.Summary), LogTail: tailLines(firstNonEmpty(r.Output.Text, r.Output.Summary), 120)})
+		checks = append(checks, domain.SCMCheck{Name: r.Name, Status: r.Status, Conclusion: r.Conclusion, URL: firstNonEmpty(r.HTMLURL, r.DetailsURL), Details: firstNonEmpty(r.Output.Title, r.Output.Summary), LogTail: tailLines(firstNonEmpty(r.Output.Text, r.Output.Summary), ciFailureLogTailLines)})
 	}
 	return checks, resp.Diagnostic, nil
 }
 
-func (p *Provider) fetchReviewComments(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject, now time.Time) ([]domain.SCMReviewThread, domain.SCMDiagnostic, bool, error) {
+func (p *Provider) enrichFailedCheckLogs(ctx context.Context, subj domain.SCMSubject, snap *domain.SCMSnapshot) (domain.SCMDiagnostic, error) {
+	if snap == nil || snap.PR == nil || len(snap.CI.Checks) == 0 {
+		return domain.SCMDiagnostic{}, nil
+	}
+	owner, repo := subj.Repository().OwnerName()
+	seen := map[string]bool{}
+	var lastDiag domain.SCMDiagnostic
+	var firstErr error
+	for i := range snap.CI.Checks {
+		if !failedCheck(snap.CI.Checks[i]) {
+			continue
+		}
+		ref, ok := actionRunReferenceFromCheck(snap.CI.Checks[i])
+		if !ok || ref.jobID == "" {
+			continue
+		}
+		key := ref.runID + ":" + ref.jobID
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "actions", "jobs", ref.jobID, "logs"), nil, nil, "", "github.actions_job_logs")
+		if resp.Diagnostic.Operation != "" {
+			lastDiag = resp.Diagnostic
+		}
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if tail := tailLines(string(resp.Body), ciFailureLogTailLines); tail != "" {
+			snap.CI.Checks[i].LogTail = tail
+		}
+	}
+	return lastDiag, firstErr
+}
+
+type actionRunReference struct {
+	runID string
+	jobID string
+}
+
+func actionRunReferenceFromCheck(check domain.SCMCheck) (actionRunReference, bool) {
+	rawURL := firstNonEmpty(check.URL, "")
+	if rawURL == "" {
+		return actionRunReference{}, false
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return actionRunReference{}, false
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	var ref actionRunReference
+	for i := 0; i < len(parts); i++ {
+		if parts[i] == "runs" && i+1 < len(parts) && isDecimal(parts[i+1]) {
+			ref.runID = parts[i+1]
+		}
+		if parts[i] == "job" && i+1 < len(parts) && isDecimal(parts[i+1]) {
+			ref.jobID = parts[i+1]
+		}
+	}
+	return ref, ref.runID != "" && ref.jobID != ""
+}
+
+func (p *Provider) fetchReviewThreads(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject, now time.Time) ([]domain.SCMReviewThread, []domain.SCMDiagnostic, bool, error) {
 	if subj.PRNumber == 0 {
-		return nil, domain.SCMDiagnostic{}, false, nil
+		return nil, nil, false, nil
 	}
 	scope := subj.CacheScope()
 	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cacheReviews, Key: strconv.Itoa(subj.PRNumber)}
 	entry, hasEntry, _ := cache.GetProviderCache(ctx, key)
 	owner, repo := subj.Repository().OwnerName()
 	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "pulls", strconv.Itoa(subj.PRNumber), "comments"), nil, nil, entry.ETag, "github.review_comments")
+	diags := []domain.SCMDiagnostic{}
+	if resp.Diagnostic.Operation != "" {
+		diags = append(diags, resp.Diagnostic)
+	}
 	if err != nil {
-		return nil, resp.Diagnostic, false, err
+		return nil, diags, false, err
 	}
-	body := resp.Body
-	if resp.NotModified && hasEntry {
-		body = entry.Value
-	} else {
-		_ = putProviderCache(ctx, cache, domain.SCMProviderCacheEntry{Key: key, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
+	body := updateRESTCache(ctx, cache, key, entry, hasEntry, resp, now)
+	if resp.NotModified {
+		return nil, diags, false, nil
 	}
-	var comments []struct {
-		ID                  int64  `json:"id"`
-		Body                string `json:"body"`
-		HTMLURL             string `json:"html_url"`
-		Path                string `json:"path"`
-		Line                int    `json:"line"`
-		OriginalLine        int    `json:"original_line"`
-		PullRequestReviewID int64  `json:"pull_request_review_id"`
-		User                struct {
-			Login string `json:"login"`
-			Type  string `json:"type"`
-		} `json:"user"`
+	if reviewCommentsEmpty(body) {
+		return nil, diags, true, nil
 	}
+	threads, graphDiags, err := p.fetchReviewThreadsGraphQL(ctx, subj)
+	diags = append(diags, graphDiags...)
+	if err != nil {
+		return nil, diags, true, err
+	}
+	return threads, diags, true, nil
+}
+
+func (p *Provider) fetchReviewThreadsGraphQL(ctx context.Context, subj domain.SCMSubject) ([]domain.SCMReviewThread, []domain.SCMDiagnostic, error) {
+	if subj.PRNumber == 0 {
+		return nil, nil, nil
+	}
+	owner, repo := subj.Repository().OwnerName()
+	query := `query($owner:String!,$repo:String!,$number:Int!){ repository(owner:$owner,name:$repo){ pullRequest(number:$number){ reviewThreads(last:100){ nodes{ id isResolved comments(first:1){ nodes{ id author{ login __typename } body path line url } } } } } } rateLimit{ limit remaining resetAt } }`
+	data, _, diag, err := p.client.DoGraphQL(ctx, query, map[string]any{"owner": owner, "repo": repo, "number": subj.PRNumber}, "github.review_threads")
+	diags := []domain.SCMDiagnostic{}
+	if diag.Operation != "" {
+		diags = append(diags, diag)
+	}
+	if err != nil {
+		return nil, diags, err
+	}
+	repoData, _ := data["repository"].(map[string]any)
+	prData, _ := repoData["pullRequest"].(map[string]any)
+	review := reviewFromGraphQL(prData)
+	return review.UnresolvedThreads, diags, nil
+}
+
+func reviewCommentsEmpty(body []byte) bool {
+	var comments []json.RawMessage
 	if err := json.Unmarshal(body, &comments); err != nil {
-		return nil, resp.Diagnostic, false, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: "github.review_comments", Message: err.Error(), Cause: err}
+		return false
 	}
-	threads := make([]domain.SCMReviewThread, 0, len(comments))
-	for _, c := range comments {
-		line := c.Line
-		if line == 0 {
-			line = c.OriginalLine
-		}
-		threadID := fmt.Sprintf("review-%d-comment-%d", c.PullRequestReviewID, c.ID)
-		isBot := isBotAuthor(c.User.Login, c.User.Type)
-		comment := domain.SCMReviewComment{ID: strconv.FormatInt(c.ID, 10), Author: c.User.Login, Body: c.Body, URL: c.HTMLURL, IsBot: isBot, Path: c.Path, Line: line, ThreadID: threadID}
-		threads = append(threads, domain.SCMReviewThread{ID: threadID, Path: c.Path, Line: line, URL: c.HTMLURL, IsBot: isBot, Comments: []domain.SCMReviewComment{comment}})
-	}
-	return threads, resp.Diagnostic, !resp.NotModified, nil
+	return len(comments) == 0
 }
 
 func repoPath(owner, repo string, elems ...string) string {
@@ -751,7 +917,7 @@ func combinedFailureTail(checks []domain.SCMCheck) string {
 }
 
 func tailLines(s string, n int) string {
-	lines := strings.Split(strings.TrimSpace(s), "\n")
+	lines := strings.Split(strings.ReplaceAll(strings.TrimSpace(s), "\r\n", "\n"), "\n")
 	if len(lines) > n {
 		lines = lines[len(lines)-n:]
 	}
@@ -820,6 +986,27 @@ func boolv(v any) bool {
 	return false
 }
 
+func isDecimal(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
 type restPull struct {
 	Number  int    `json:"number"`
 	HTMLURL string `json:"html_url"`
@@ -853,6 +1040,23 @@ func getCachedBranch(ctx context.Context, cache ports.SCMProviderCache, scope do
 func putCachedBranch(ctx context.Context, cache ports.SCMProviderCache, scope domain.SCMProviderCacheScope, branch string, mapped branchMapping, now time.Time) {
 	b, _ := json.Marshal(mapped)
 	_ = putProviderCache(ctx, cache, domain.SCMProviderCacheEntry{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cacheBranchMap, Key: branch}, Value: b, UpdatedAt: now})
+}
+
+func updateRESTCache(ctx context.Context, cache ports.SCMProviderCache, key domain.SCMProviderCacheKey, entry domain.SCMProviderCacheEntry, hasEntry bool, resp RESTResponse, now time.Time) []byte {
+	if resp.NotModified {
+		if hasEntry {
+			if resp.ETag != "" && resp.ETag != entry.ETag {
+				entry.ETag = resp.ETag
+				entry.UpdatedAt = now
+				_ = putProviderCache(ctx, cache, entry)
+			}
+			return entry.Value
+		}
+		return resp.Body
+	}
+	entry = domain.SCMProviderCacheEntry{Key: key, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now}
+	_ = putProviderCache(ctx, cache, entry)
+	return resp.Body
 }
 
 func putProviderCache(ctx context.Context, cache ports.SCMProviderCache, entry domain.SCMProviderCacheEntry) error {

--- a/backend/internal/adapters/scm/github/provider.go
+++ b/backend/internal/adapters/scm/github/provider.go
@@ -24,6 +24,12 @@ const (
 
 	maxGraphQLBatchSize      = 25
 	graphQLCheckContextLimit = 20
+
+	cacheCapPRList     = 100
+	cacheCapChecks     = 500
+	cacheCapReviews    = 500
+	cacheCapBranchMap  = 1000
+	cacheCapCheckGuard = 500
 )
 
 type Provider struct {
@@ -191,7 +197,7 @@ func (p *Provider) fetchOpenPulls(ctx context.Context, cache ports.SCMProviderCa
 		body = entry.Value
 	} else {
 		body = resp.Body
-		_ = cache.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: cacheKey, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
+		_ = putProviderCache(ctx, cache, domain.SCMProviderCacheEntry{Key: cacheKey, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
 	}
 	var pulls []restPull
 	if err := json.Unmarshal(body, &pulls); err != nil {
@@ -229,7 +235,7 @@ func (p *Provider) checkRunsChanged(ctx context.Context, cache ports.SCMProvider
 		return true, resp.Diagnostic, err
 	}
 	if !resp.NotModified {
-		_ = cache.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
+		_ = putProviderCache(ctx, cache, domain.SCMProviderCacheEntry{Key: key, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
 	}
 	return !resp.NotModified, resp.Diagnostic, nil
 }
@@ -247,7 +253,7 @@ func (p *Provider) reviewCommentsChanged(ctx context.Context, cache ports.SCMPro
 		return true, resp.Diagnostic, err
 	}
 	if !resp.NotModified {
-		_ = cache.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
+		_ = putProviderCache(ctx, cache, domain.SCMProviderCacheEntry{Key: key, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
 	}
 	return !resp.NotModified, resp.Diagnostic, nil
 }
@@ -613,7 +619,7 @@ func (p *Provider) fetchCheckRuns(ctx context.Context, cache ports.SCMProviderCa
 	if resp.NotModified && hasEntry {
 		body = entry.Value
 	} else {
-		_ = cache.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
+		_ = putProviderCache(ctx, cache, domain.SCMProviderCacheEntry{Key: key, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
 	}
 	var decoded struct {
 		CheckRuns []struct {
@@ -655,7 +661,7 @@ func (p *Provider) fetchReviewComments(ctx context.Context, cache ports.SCMProvi
 	if resp.NotModified && hasEntry {
 		body = entry.Value
 	} else {
-		_ = cache.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
+		_ = putProviderCache(ctx, cache, domain.SCMProviderCacheEntry{Key: key, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
 	}
 	var comments []struct {
 		ID                  int64  `json:"id"`
@@ -846,7 +852,29 @@ func getCachedBranch(ctx context.Context, cache ports.SCMProviderCache, scope do
 
 func putCachedBranch(ctx context.Context, cache ports.SCMProviderCache, scope domain.SCMProviderCacheScope, branch string, mapped branchMapping, now time.Time) {
 	b, _ := json.Marshal(mapped)
-	_ = cache.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cacheBranchMap, Key: branch}, Value: b, UpdatedAt: now})
+	_ = putProviderCache(ctx, cache, domain.SCMProviderCacheEntry{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cacheBranchMap, Key: branch}, Value: b, UpdatedAt: now})
+}
+
+func putProviderCache(ctx context.Context, cache ports.SCMProviderCache, entry domain.SCMProviderCacheEntry) error {
+	entry.MaxEntries = githubCacheCap(entry.Key.Namespace)
+	return cache.PutProviderCache(ctx, entry)
+}
+
+func githubCacheCap(namespace string) int {
+	switch namespace {
+	case cachePRList:
+		return cacheCapPRList
+	case cacheChecks:
+		return cacheCapChecks
+	case cacheReviews:
+		return cacheCapReviews
+	case cacheBranchMap:
+		return cacheCapBranchMap
+	case cacheCheckGuard:
+		return cacheCapCheckGuard
+	default:
+		return 0
+	}
 }
 
 func findPullForBranch(pulls []restPull, branch string) (branchMapping, bool) {

--- a/backend/internal/adapters/scm/github/provider.go
+++ b/backend/internal/adapters/scm/github/provider.go
@@ -16,22 +16,25 @@ import (
 )
 
 const (
-	cachePRList     = "pr-list"
-	cacheBranchMap  = "branch-map"
-	cacheChecks     = "checks"
-	cacheReviews    = "reviews"
-	cacheCheckGuard = "checks-guard"
+	cachePRList        = "pr-list"
+	cacheBranchMap     = "branch-map"
+	cacheChecks        = "checks"
+	cacheReviews       = "reviews"
+	cacheReviewDetails = "review-details"
+	cacheCheckGuard    = "checks-guard"
 
 	maxGraphQLBatchSize      = 25
 	graphQLCheckContextLimit = 20
 
-	cacheCapPRList     = 100
-	cacheCapChecks     = 500
-	cacheCapReviews    = 500
-	cacheCapBranchMap  = 1000
-	cacheCapCheckGuard = 500
+	cacheCapPRList        = 100
+	cacheCapChecks        = 500
+	cacheCapReviews       = 500
+	cacheCapReviewDetails = 500
+	cacheCapBranchMap     = 1000
+	cacheCapCheckGuard    = 500
 
 	ciFailureLogTailLines = 20
+	reviewDetailThrottle  = 2 * time.Minute
 )
 
 type Provider struct {
@@ -179,7 +182,7 @@ func (p *Provider) discover(ctx context.Context, subjects []domain.SCMSubject, c
 	}
 
 	owner, repo := out[0].Repository().OwnerName()
-	pulls, _, _, err := p.fetchOpenPullsForDiscovery(ctx, cache, scope, owner, repo, now)
+	pulls, changed, _, err := p.fetchOpenPullsForDiscovery(ctx, cache, scope, owner, repo, now)
 	if err != nil {
 		return out, err
 	}
@@ -198,6 +201,9 @@ func (p *Provider) discover(ctx context.Context, subjects []domain.SCMSubject, c
 			out[i].PRNumber = mapped.Number
 			out[i].PRURL = mapped.URL
 			out[i].BaseBranch = firstNonEmpty(out[i].BaseBranch, mapped.BaseBranch)
+			continue
+		}
+		if !changed {
 			continue
 		}
 		if mapped, ok, err := p.fetchPullForBranch(ctx, owner, repo, out[i].Branch); err != nil {
@@ -405,9 +411,7 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 	}
 
 	toFetch := known
-	reviewChangedBySession := map[domain.SessionID]bool{}
 	checkGuardCommits := map[domain.SessionID]restCacheCommit{}
-	reviewGuardCommits := map[domain.SessionID]restCacheCommit{}
 	if !prListChanged && len(latest) > 0 {
 		toFetch = toFetch[:0]
 		for _, subj := range known {
@@ -427,22 +431,12 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 				toFetch = append(toFetch, subj)
 				continue
 			}
-			reviewChanged, diag, commit, err := p.reviewCommentsChanged(ctx, cache, subj, now)
-			if diag.Operation != "" {
-				diags = append(diags, diag)
-			}
-			if err != nil || reviewChanged {
-				if err == nil && reviewChanged {
-					reviewChangedBySession[subj.SessionID] = true
-					reviewGuardCommits[subj.SessionID] = commit
-				}
-				toFetch = append(toFetch, subj)
-				continue
-			}
 			reused := prev
 			reused.ObservedAt = now
 			reused.Freshness = domain.SCMFreshnessUnchanged
 			reused.Subject = subj
+			reviewDiags := p.refreshReviewDetails(ctx, cache, subj, &reused, prev, true, now)
+			diags = append(diags, reviewDiags...)
 			snaps = append(snaps, reused)
 		}
 	}
@@ -467,6 +461,17 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 				firstErr = err
 			}
 			for _, subj := range batch {
+				if terminal, ok, fallbackDiag, fallbackErr := p.fetchTerminalPRFallback(ctx, subj, now); ok {
+					if fallbackDiag.Operation != "" {
+						terminal.Diagnostics = append(terminal.Diagnostics, fallbackDiag)
+					}
+					snaps = append(snaps, terminal)
+					continue
+				} else if fallbackDiag.Operation != "" {
+					diags = append(diags, fallbackDiag)
+				} else if fallbackErr != nil {
+					diags = append(diags, diagnosticFromError("github.rest_pr_fallback", fallbackErr))
+				}
 				if prev, ok := latest[subj.SessionID]; ok {
 					prev.ObservedAt = now
 					prev.Freshness = domain.SCMFreshnessUnavailable
@@ -519,32 +524,8 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 				}
 				snap.CI.FailureLogTail = combinedFailureTail(snap.CI.Checks)
 			}
-			var reviewThreads []domain.SCMReviewThread
-			var reviewDiags []domain.SCMDiagnostic
-			var reviewChangedNow bool
-			var err error
-			if reviewChangedBySession[subj.SessionID] {
-				reviewThreads, reviewDiags, err = p.fetchReviewThreadsGraphQL(ctx, subj)
-				reviewChangedNow = true
-			} else {
-				reviewThreads, reviewDiags, reviewChangedNow, err = p.fetchReviewThreads(ctx, cache, subj, now)
-			}
+			reviewDiags := p.refreshReviewDetails(ctx, cache, subj, &snap, prev, havePrev, now)
 			snap.Diagnostics = append(snap.Diagnostics, reviewDiags...)
-			switch {
-			case err == nil && !reviewChangedNow && havePrev:
-				snap.Review.UnresolvedThreads = prev.Review.UnresolvedThreads
-				classifyThreads(&snap.Review)
-			case err == nil:
-				snap.Review.UnresolvedThreads = reviewThreads
-				classifyThreads(&snap.Review)
-				commitRESTCache(reviewGuardCommits[subj.SessionID])
-			case err != nil && havePrev:
-				snap.Review.UnresolvedThreads = prev.Review.UnresolvedThreads
-				classifyThreads(&snap.Review)
-				snap.Diagnostics = append(snap.Diagnostics, diagnosticFromError("github.review_threads", err))
-			case err != nil:
-				snap.Diagnostics = append(snap.Diagnostics, diagnosticFromError("github.review_threads", err))
-			}
 			finalizeMergeability(&snap)
 			snaps = append(snaps, snap)
 		}
@@ -780,6 +761,84 @@ func (p *Provider) fetchCheckRuns(ctx context.Context, cache ports.SCMProviderCa
 	return checks, resp.Diagnostic, nil
 }
 
+type reviewDetailsCache struct {
+	Decision string                   `json:"decision,omitempty"`
+	Threads  []domain.SCMReviewThread `json:"threads,omitempty"`
+}
+
+func (p *Provider) refreshReviewDetails(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject, snap *domain.SCMSnapshot, prev domain.SCMSnapshot, havePrev bool, now time.Time) []domain.SCMDiagnostic {
+	if snap == nil || subj.PRNumber == 0 {
+		return nil
+	}
+	cached, entry, hasCache := getCachedReviewDetails(ctx, cache, subj)
+	prevDecision := ""
+	if havePrev {
+		prevDecision = prev.Review.Decision
+	}
+	decisionChanged := havePrev && prevDecision != snap.Review.Decision
+	forceGraphQL := decisionChanged && (snap.Review.Decision == "changes_requested" || prevDecision == "changes_requested" || len(prev.Review.UnresolvedThreads) > 0)
+
+	attach := func(threads []domain.SCMReviewThread) {
+		snap.Review.UnresolvedThreads = cloneReviewThreads(threads)
+		classifyThreads(&snap.Review)
+	}
+	attachFallback := func() {
+		switch {
+		case hasCache:
+			attach(cached.Threads)
+		case havePrev:
+			attach(prev.Review.UnresolvedThreads)
+		default:
+			classifyThreads(&snap.Review)
+		}
+	}
+
+	if !forceGraphQL && hasCache && now.Sub(entry.UpdatedAt) < reviewDetailThrottle {
+		attach(cached.Threads)
+		return nil
+	}
+	if !forceGraphQL && !hasCache && havePrev && len(prev.Review.UnresolvedThreads) > 0 {
+		attach(prev.Review.UnresolvedThreads)
+		putCachedReviewDetails(ctx, cache, subj, snap.Review.Decision, prev.Review.UnresolvedThreads, now)
+		return nil
+	}
+
+	if forceGraphQL {
+		threads, diags, err := p.fetchReviewThreadsGraphQL(ctx, subj)
+		if err != nil {
+			attachFallback()
+			return append(diags, diagnosticFromError("github.review_threads", err))
+		}
+		attach(threads)
+		putCachedReviewDetails(ctx, cache, subj, snap.Review.Decision, threads, now)
+		return diags
+	}
+
+	threads, diags, changed, err := p.fetchReviewThreads(ctx, cache, subj, now)
+	if err != nil {
+		attachFallback()
+		return append(diags, diagnosticFromError("github.review_threads", err))
+	}
+	if changed {
+		attach(threads)
+		putCachedReviewDetails(ctx, cache, subj, snap.Review.Decision, threads, now)
+		return diags
+	}
+	if hasCache {
+		attach(cached.Threads)
+		touchCachedReviewDetails(ctx, cache, entry, now)
+		return diags
+	}
+	if havePrev {
+		attach(prev.Review.UnresolvedThreads)
+		putCachedReviewDetails(ctx, cache, subj, snap.Review.Decision, prev.Review.UnresolvedThreads, now)
+		return diags
+	}
+	attach(nil)
+	putCachedReviewDetails(ctx, cache, subj, snap.Review.Decision, nil, now)
+	return diags
+}
+
 func (p *Provider) enrichFailedCheckLogs(ctx context.Context, subj domain.SCMSubject, snap *domain.SCMSnapshot) (domain.SCMDiagnostic, error) {
 	if snap == nil || snap.PR == nil || len(snap.CI.Checks) == 0 {
 		return domain.SCMDiagnostic{}, nil
@@ -898,6 +957,71 @@ func (p *Provider) fetchReviewThreadsGraphQL(ctx context.Context, subj domain.SC
 	return review.UnresolvedThreads, diags, nil
 }
 
+func (p *Provider) fetchTerminalPRFallback(ctx context.Context, subj domain.SCMSubject, now time.Time) (domain.SCMSnapshot, bool, domain.SCMDiagnostic, error) {
+	if subj.PRNumber == 0 {
+		return domain.SCMSnapshot{}, false, domain.SCMDiagnostic{}, nil
+	}
+	owner, repo := subj.Repository().OwnerName()
+	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "pulls", strconv.Itoa(subj.PRNumber)), nil, nil, "", "github.rest_pr_fallback")
+	if err != nil {
+		return domain.SCMSnapshot{}, false, resp.Diagnostic, err
+	}
+	var decoded struct {
+		Number    int    `json:"number"`
+		HTMLURL   string `json:"html_url"`
+		Title     string `json:"title"`
+		State     string `json:"state"`
+		Draft     bool   `json:"draft"`
+		Merged    bool   `json:"merged"`
+		Additions int    `json:"additions"`
+		Deletions int    `json:"deletions"`
+		Head      struct {
+			Ref string `json:"ref"`
+			SHA string `json:"sha"`
+		} `json:"head"`
+		Base struct {
+			Ref string `json:"ref"`
+		} `json:"base"`
+	}
+	if err := json.Unmarshal(resp.Body, &decoded); err != nil {
+		return domain.SCMSnapshot{}, false, resp.Diagnostic, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: "github.rest_pr_fallback", Message: err.Error(), Cause: err}
+	}
+	state := domain.PROpen
+	if decoded.Merged {
+		state = domain.PRMerged
+	} else if strings.EqualFold(decoded.State, "closed") {
+		state = domain.PRClosed
+	} else if decoded.Draft {
+		state = domain.PRDraft
+	}
+	if state != domain.PRMerged && state != domain.PRClosed {
+		return domain.SCMSnapshot{}, false, resp.Diagnostic, nil
+	}
+	number := decoded.Number
+	if number == 0 {
+		number = subj.PRNumber
+	}
+	url := firstNonEmpty(decoded.HTMLURL, subj.PRURL)
+	pull := &domain.SCMPullRequest{
+		ID:           domain.SCMChangeRequestID{Provider: subj.Provider, Host: subj.Host, Repo: subj.Repo, Number: number},
+		Number:       number,
+		URL:          url,
+		Title:        decoded.Title,
+		State:        state,
+		Draft:        decoded.Draft,
+		Merged:       decoded.Merged || state == domain.PRMerged,
+		SourceBranch: firstNonEmpty(decoded.Head.Ref, subj.Branch),
+		TargetBranch: firstNonEmpty(decoded.Base.Ref, subj.BaseBranch),
+		HeadSHA:      decoded.Head.SHA,
+		Additions:    decoded.Additions,
+		Deletions:    decoded.Deletions,
+	}
+	subj.PRNumber = number
+	subj.PRURL = url
+	subj.BaseBranch = firstNonEmpty(subj.BaseBranch, pull.TargetBranch)
+	return domain.SCMSnapshot{SessionID: subj.SessionID, Subject: subj, Freshness: domain.SCMFreshnessFresh, ObservedAt: now, PR: pull}, true, resp.Diagnostic, nil
+}
+
 func reviewCommentsEmpty(body []byte) bool {
 	var comments []json.RawMessage
 	if err := json.Unmarshal(body, &comments); err != nil {
@@ -985,6 +1109,20 @@ func classifyThreads(review *domain.SCMReview) {
 	if len(review.HumanComments) > 0 && review.Decision == "none" {
 		review.Decision = "changes_requested"
 	}
+}
+
+func cloneReviewThreads(in []domain.SCMReviewThread) []domain.SCMReviewThread {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]domain.SCMReviewThread, len(in))
+	for i := range in {
+		out[i] = in[i]
+		if len(in[i].Comments) > 0 {
+			out[i].Comments = append([]domain.SCMReviewComment(nil), in[i].Comments...)
+		}
+	}
+	return out
 }
 
 func threadIsBot(comments []domain.SCMReviewComment) bool {
@@ -1089,6 +1227,31 @@ func putCachedBranch(ctx context.Context, cache ports.SCMProviderCache, scope do
 	_ = putProviderCache(ctx, cache, domain.SCMProviderCacheEntry{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cacheBranchMap, Key: branch}, Value: b, UpdatedAt: now})
 }
 
+func getCachedReviewDetails(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject) (reviewDetailsCache, domain.SCMProviderCacheEntry, bool) {
+	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheReviewDetails, Key: strconv.Itoa(subj.PRNumber)}
+	entry, ok, err := cache.GetProviderCache(ctx, key)
+	if err != nil || !ok {
+		return reviewDetailsCache{}, domain.SCMProviderCacheEntry{}, false
+	}
+	var cached reviewDetailsCache
+	if len(entry.Value) > 0 {
+		if err := json.Unmarshal(entry.Value, &cached); err != nil {
+			return reviewDetailsCache{}, domain.SCMProviderCacheEntry{}, false
+		}
+	}
+	return cached, entry, true
+}
+
+func putCachedReviewDetails(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject, decision string, threads []domain.SCMReviewThread, now time.Time) {
+	b, _ := json.Marshal(reviewDetailsCache{Decision: decision, Threads: cloneReviewThreads(threads)})
+	_ = putProviderCache(ctx, cache, domain.SCMProviderCacheEntry{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheReviewDetails, Key: strconv.Itoa(subj.PRNumber)}, Value: b, UpdatedAt: now})
+}
+
+func touchCachedReviewDetails(ctx context.Context, cache ports.SCMProviderCache, entry domain.SCMProviderCacheEntry, now time.Time) {
+	entry.UpdatedAt = now
+	_ = putProviderCache(ctx, cache, entry)
+}
+
 func prepareRESTCache(ctx context.Context, cache ports.SCMProviderCache, key domain.SCMProviderCacheKey, entry domain.SCMProviderCacheEntry, hasEntry bool, resp RESTResponse, now time.Time) ([]byte, restCacheCommit) {
 	if resp.NotModified {
 		if hasEntry {
@@ -1124,6 +1287,8 @@ func githubCacheCap(namespace string) int {
 		return cacheCapChecks
 	case cacheReviews:
 		return cacheCapReviews
+	case cacheReviewDetails:
+		return cacheCapReviewDetails
 	case cacheBranchMap:
 		return cacheCapBranchMap
 	case cacheCheckGuard:

--- a/backend/internal/adapters/scm/github/provider.go
+++ b/backend/internal/adapters/scm/github/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	scmlog "github.com/aoagents/agent-orchestrator/backend/internal/scm/logging"
 )
 
 const (
@@ -52,12 +54,13 @@ type ProviderOptions struct {
 	RESTBase   string
 	GraphQLURL string
 	Host       string
+	Logger     *slog.Logger
 }
 
 func NewProvider(opts ProviderOptions) *Provider {
 	p := &Provider{client: opts.Client, host: opts.Host}
 	if p.client == nil {
-		p.client = NewClient(ClientOptions{HTTPClient: opts.HTTPClient, Token: opts.Token, RESTBase: opts.RESTBase, GraphQLURL: opts.GraphQLURL})
+		p.client = NewClient(ClientOptions{HTTPClient: opts.HTTPClient, Token: opts.Token, RESTBase: opts.RESTBase, GraphQLURL: opts.GraphQLURL, Logger: opts.Logger})
 	}
 	if p.host == "" {
 		p.host = defaultHost
@@ -68,6 +71,7 @@ func NewProvider(opts ProviderOptions) *Provider {
 func (p *Provider) Provider() domain.SCMProvider { return domain.SCMProviderGitHub }
 
 func (p *Provider) ObserveSessions(ctx context.Context, req ports.SCMObserveRequest, cache ports.SCMProviderCache) (ports.SCMObserveResult, error) {
+	ctx, _ = scmlog.EnsureCorrelationID(ctx)
 	now := req.Now
 	if now.IsZero() {
 		now = time.Now()
@@ -113,7 +117,7 @@ func (p *Provider) ObserveSessions(ctx context.Context, req ports.SCMObserveRequ
 				st.ConsecutiveFail++
 				st.LastFailureAt = now
 				st.BackoffUntil = now.Add(30 * time.Second)
-				if se, ok := groupErr.(*domain.SCMError); ok {
+				if se, ok := scmlog.SCMError(groupErr); ok {
 					st.LastError = se
 					if se.Kind == domain.SCMErrorRateLimited && !se.RetryAfter.IsZero() {
 						st.RateLimitUntil = se.RetryAfter
@@ -358,13 +362,18 @@ func chunkSubjects(subjects []domain.SCMSubject, size int) [][]domain.SCMSubject
 }
 
 func diagnosticFromError(operation string, err error) domain.SCMDiagnostic {
-	d := domain.SCMDiagnostic{Operation: operation, ErrorKind: domain.SCMErrorUnavailable, Message: fmt.Sprint(err)}
-	if se, ok := err.(*domain.SCMError); ok {
-		d.Operation = firstNonEmpty(se.Operation, operation)
-		d.ErrorKind = se.Kind
-		d.StatusCode = se.StatusCode
+	return scmlog.DiagnosticFromError(operation, err)
+}
+
+func appendDiagnostic(diags []domain.SCMDiagnostic, diag domain.SCMDiagnostic) []domain.SCMDiagnostic {
+	if durableDiagnostic(diag) {
+		return append(diags, diag)
 	}
-	return d
+	return diags
+}
+
+func durableDiagnostic(diag domain.SCMDiagnostic) bool {
+	return diag.Operation != "" && (diag.ErrorKind != "" || diag.Message != "" || diag.StatusCode >= 400)
 }
 
 func shouldFetchCheckRuns(snap domain.SCMSnapshot, prData map[string]any) bool {
@@ -429,9 +438,7 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 		changed, prListDiag, commit, err := p.checkOpenPullListChanged(ctx, cache, scope, owner, repo, now)
 		prListChanged = changed
 		prListCommit = commit
-		if prListDiag.Operation != "" {
-			diags = append(diags, prListDiag)
-		}
+		diags = appendDiagnostic(diags, prListDiag)
 		if err != nil {
 			// PR-list guard failures should not be terminal truth. Fall through to
 			// GraphQL so one failed optimization guard does not hide real PR changes.
@@ -466,9 +473,7 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 				continue
 			}
 			changed, diag, commit, err := p.checkRunsChanged(ctx, cache, subj, prev.PR.HeadSHA, now)
-			if diag.Operation != "" {
-				diags = append(diags, diag)
-			}
+			diags = appendDiagnostic(diags, diag)
 			if err != nil || changed {
 				if err == nil && changed {
 					checkGuardCommits[subj.SessionID] = commit
@@ -494,9 +499,7 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 	mainFetchOK := true
 	for _, batch := range chunkSubjects(toFetch, maxGraphQLBatchSize) {
 		data, rl, diag, err := p.fetchPRBatch(ctx, owner, repo, batch)
-		if diag.Operation != "" {
-			diags = append(diags, diag)
-		}
+		diags = appendDiagnostic(diags, diag)
 		if rl != nil {
 			lastRL = rl
 		}
@@ -507,12 +510,12 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 			}
 			for _, subj := range batch {
 				if terminal, ok, fallbackDiag, fallbackErr := p.fetchTerminalPRFallback(ctx, subj, now); ok {
-					if fallbackDiag.Operation != "" {
+					if durableDiagnostic(fallbackDiag) {
 						terminal.Diagnostics = append(terminal.Diagnostics, fallbackDiag)
 					}
 					snaps = append(snaps, terminal)
 					continue
-				} else if fallbackDiag.Operation != "" {
+				} else if durableDiagnostic(fallbackDiag) {
 					diags = append(diags, fallbackDiag)
 				} else if fallbackErr != nil {
 					diags = append(diags, diagnosticFromError("github.rest_pr_fallback", fallbackErr))
@@ -547,9 +550,7 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 			prev, havePrev := latest[subj.SessionID]
 			if shouldFetchCheckRuns(snap, prData) {
 				checks, checkDiag, err := p.fetchCheckRuns(ctx, cache, subj, snap, now)
-				if checkDiag.Operation != "" {
-					snap.Diagnostics = append(snap.Diagnostics, checkDiag)
-				}
+				snap.Diagnostics = appendDiagnostic(snap.Diagnostics, checkDiag)
 				if err == nil {
 					snap.CI.Checks = checks
 					snap.CI.Summary = summarizeChecks(checks)
@@ -918,9 +919,7 @@ func (p *Provider) fetchReviewThreads(ctx context.Context, cache ports.SCMProvid
 	owner, repo := subj.Repository().OwnerName()
 	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "pulls", strconv.Itoa(subj.PRNumber), "comments"), nil, nil, entry.ETag, "github.review_comments")
 	diags := []domain.SCMDiagnostic{}
-	if resp.Diagnostic.Operation != "" {
-		diags = append(diags, resp.Diagnostic)
-	}
+	diags = appendDiagnostic(diags, resp.Diagnostic)
 	if err != nil {
 		return nil, diags, false, err
 	}
@@ -949,9 +948,7 @@ func (p *Provider) fetchReviewThreadsGraphQL(ctx context.Context, subj domain.SC
 	query := `query($owner:String!,$repo:String!,$number:Int!){ repository(owner:$owner,name:$repo){ pullRequest(number:$number){ reviewThreads(last:100){ nodes{ id isResolved comments(first:100){ nodes{ id author{ login __typename } body path line url } } } } } } rateLimit{ limit remaining resetAt } }`
 	data, _, diag, err := p.client.DoGraphQL(ctx, query, map[string]any{"owner": owner, "repo": repo, "number": subj.PRNumber}, "github.review_threads")
 	diags := []domain.SCMDiagnostic{}
-	if diag.Operation != "" {
-		diags = append(diags, diag)
-	}
+	diags = appendDiagnostic(diags, diag)
 	if err != nil {
 		return nil, diags, err
 	}
@@ -1347,12 +1344,7 @@ func findPullForBranch(pulls []restPull, branch string) (branchMapping, bool) {
 }
 
 func unavailableSnapshot(subj domain.SCMSubject, now time.Time, err error) domain.SCMSnapshot {
-	d := domain.SCMDiagnostic{Operation: "github.observe", ErrorKind: domain.SCMErrorUnavailable, Message: fmt.Sprint(err)}
-	if se, ok := err.(*domain.SCMError); ok {
-		d.Operation = se.Operation
-		d.ErrorKind = se.Kind
-		d.StatusCode = se.StatusCode
-	}
+	d := scmlog.DiagnosticFromError("github.observe", err)
 	return domain.SCMSnapshot{SessionID: subj.SessionID, Subject: subj, Freshness: domain.SCMFreshnessUnavailable, ObservedAt: now, Diagnostics: []domain.SCMDiagnostic{d}}
 }
 

--- a/backend/internal/adapters/scm/github/provider.go
+++ b/backend/internal/adapters/scm/github/provider.go
@@ -302,22 +302,6 @@ func (p *Provider) checkRunsChanged(ctx context.Context, cache ports.SCMProvider
 	return !resp.NotModified, resp.Diagnostic, commit, nil
 }
 
-func (p *Provider) reviewCommentsChanged(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject, now time.Time) (bool, domain.SCMDiagnostic, restCacheCommit, error) {
-	if subj.PRNumber == 0 {
-		return false, domain.SCMDiagnostic{}, nil, nil
-	}
-	scope := subj.CacheScope()
-	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cacheReviews, Key: strconv.Itoa(subj.PRNumber)}
-	entry, hasEntry, _ := cache.GetProviderCache(ctx, key)
-	owner, repo := subj.Repository().OwnerName()
-	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "pulls", strconv.Itoa(subj.PRNumber), "comments"), nil, nil, entry.ETag, "github.review_comments_guard")
-	if err != nil {
-		return true, resp.Diagnostic, nil, err
-	}
-	_, commit := prepareRESTCache(ctx, cache, key, entry, hasEntry, resp, now)
-	return !resp.NotModified, resp.Diagnostic, commit, nil
-}
-
 func (p *Provider) checkBoundPullState(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject, now time.Time) (changed bool, terminal *domain.SCMSnapshot, diag domain.SCMDiagnostic, commit restCacheCommit, err error) {
 	if subj.PRNumber == 0 {
 		return false, nil, domain.SCMDiagnostic{}, nil, nil

--- a/backend/internal/adapters/scm/github/provider.go
+++ b/backend/internal/adapters/scm/github/provider.go
@@ -16,10 +16,14 @@ import (
 )
 
 const (
-	cachePRList    = "pr-list"
-	cacheBranchMap = "branch-map"
-	cacheChecks    = "checks"
-	cacheReviews   = "reviews"
+	cachePRList     = "pr-list"
+	cacheBranchMap  = "branch-map"
+	cacheChecks     = "checks"
+	cacheReviews    = "reviews"
+	cacheCheckGuard = "checks-guard"
+
+	maxGraphQLBatchSize      = 25
+	graphQLCheckContextLimit = 20
 )
 
 type Provider struct {
@@ -148,22 +152,10 @@ func (p *Provider) discover(ctx context.Context, subjects []domain.SCMSubject, c
 		return out, nil
 	}
 
-	cacheKey := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cachePRList, Key: "open"}
-	entry, hasEntry, _ := cache.GetProviderCache(ctx, cacheKey)
 	owner, repo := out[0].Repository().OwnerName()
-	q := url.Values{"state": []string{"open"}, "per_page": []string{"100"}}
-	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "pulls"), q, nil, entry.ETag, "github.pr_list")
+	pulls, _, _, err := p.fetchOpenPulls(ctx, cache, scope, owner, repo, now)
 	if err != nil {
 		return out, err
-	}
-	var pulls []restPull
-	if resp.NotModified && hasEntry {
-		_ = json.Unmarshal(entry.Value, &pulls)
-	} else {
-		if err := json.Unmarshal(resp.Body, &pulls); err != nil {
-			return out, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: "github.pr_list", Message: err.Error(), Cause: err}
-		}
-		_ = cache.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: cacheKey, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
 	}
 	for _, pr := range pulls {
 		if pr.Number <= 0 || pr.Head.Ref == "" {
@@ -185,6 +177,124 @@ func (p *Provider) discover(ctx context.Context, subjects []domain.SCMSubject, c
 	return out, nil
 }
 
+func (p *Provider) fetchOpenPulls(ctx context.Context, cache ports.SCMProviderCache, scope domain.SCMProviderCacheScope, owner, repo string, now time.Time) ([]restPull, bool, domain.SCMDiagnostic, error) {
+	cacheKey := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cachePRList, Key: "open"}
+	entry, hasEntry, _ := cache.GetProviderCache(ctx, cacheKey)
+	q := url.Values{"state": []string{"open"}, "sort": []string{"updated"}, "direction": []string{"desc"}, "per_page": []string{"100"}}
+	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "pulls"), q, nil, entry.ETag, "github.pr_list")
+	if err != nil {
+		return nil, true, resp.Diagnostic, err
+	}
+	var body []byte
+	changed := !resp.NotModified
+	if resp.NotModified && hasEntry {
+		body = entry.Value
+	} else {
+		body = resp.Body
+		_ = cache.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: cacheKey, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
+	}
+	var pulls []restPull
+	if err := json.Unmarshal(body, &pulls); err != nil {
+		return nil, changed, resp.Diagnostic, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: "github.pr_list", Message: err.Error(), Cause: err}
+	}
+	return pulls, changed, resp.Diagnostic, nil
+}
+
+func latestSnapshots(ctx context.Context, cache ports.SCMProviderCache, subjects []domain.SCMSubject) map[domain.SessionID]domain.SCMSnapshot {
+	reader, ok := cache.(snapshotReader)
+	if !ok {
+		return nil
+	}
+	out := map[domain.SessionID]domain.SCMSnapshot{}
+	for _, subj := range subjects {
+		snap, ok, err := reader.GetLatestSnapshot(ctx, subj.SessionID)
+		if err == nil && ok {
+			out[subj.SessionID] = snap
+		}
+	}
+	return out
+}
+
+func (p *Provider) checkRunsChanged(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject, headSHA string, now time.Time) (bool, domain.SCMDiagnostic, error) {
+	if headSHA == "" {
+		return true, domain.SCMDiagnostic{}, nil
+	}
+	scope := subj.CacheScope()
+	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cacheCheckGuard, Key: headSHA}
+	entry, _, _ := cache.GetProviderCache(ctx, key)
+	owner, repo := subj.Repository().OwnerName()
+	q := url.Values{"per_page": []string{"1"}}
+	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "commits", headSHA, "check-runs"), q, nil, entry.ETag, "github.check_runs_guard")
+	if err != nil {
+		return true, resp.Diagnostic, err
+	}
+	if !resp.NotModified {
+		_ = cache.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
+	}
+	return !resp.NotModified, resp.Diagnostic, nil
+}
+
+func (p *Provider) reviewCommentsChanged(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject, now time.Time) (bool, domain.SCMDiagnostic, error) {
+	if subj.PRNumber == 0 {
+		return false, domain.SCMDiagnostic{}, nil
+	}
+	scope := subj.CacheScope()
+	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cacheReviews, Key: strconv.Itoa(subj.PRNumber)}
+	entry, _, _ := cache.GetProviderCache(ctx, key)
+	owner, repo := subj.Repository().OwnerName()
+	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "pulls", strconv.Itoa(subj.PRNumber), "comments"), nil, nil, entry.ETag, "github.review_comments_guard")
+	if err != nil {
+		return true, resp.Diagnostic, err
+	}
+	if !resp.NotModified {
+		_ = cache.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: resp.ETag, Value: append([]byte(nil), resp.Body...), UpdatedAt: now})
+	}
+	return !resp.NotModified, resp.Diagnostic, nil
+}
+
+func chunkSubjects(subjects []domain.SCMSubject, size int) [][]domain.SCMSubject {
+	if size <= 0 || len(subjects) <= size {
+		return [][]domain.SCMSubject{subjects}
+	}
+	out := make([][]domain.SCMSubject, 0, (len(subjects)+size-1)/size)
+	for start := 0; start < len(subjects); start += size {
+		end := start + size
+		if end > len(subjects) {
+			end = len(subjects)
+		}
+		out = append(out, subjects[start:end])
+	}
+	return out
+}
+
+func diagnosticFromError(operation string, err error) domain.SCMDiagnostic {
+	d := domain.SCMDiagnostic{Operation: operation, ErrorKind: domain.SCMErrorUnavailable, Message: fmt.Sprint(err)}
+	if se, ok := err.(*domain.SCMError); ok {
+		d.Operation = firstNonEmpty(se.Operation, operation)
+		d.ErrorKind = se.Kind
+		d.StatusCode = se.StatusCode
+	}
+	return d
+}
+
+func shouldFetchCheckRuns(snap domain.SCMSnapshot, prData map[string]any) bool {
+	if snap.PR == nil || snap.PR.HeadSHA == "" {
+		return false
+	}
+	return snap.CI.Summary == "failing" || checkContextsIncomplete(prData)
+}
+
+func checkContextsIncomplete(pr map[string]any) bool {
+	roll := statusRollup(pr)
+	contexts, _ := roll["contexts"].(map[string]any)
+	pageInfo, _ := contexts["pageInfo"].(map[string]any)
+	return boolv(pageInfo["hasNextPage"])
+}
+
+type snapshotReader interface {
+	GetLatestSnapshot(ctx context.Context, sessionID domain.SessionID) (domain.SCMSnapshot, bool, error)
+}
+
 func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSubject, cache ports.SCMProviderCache, now time.Time) ([]domain.SCMSnapshot, []domain.SCMDiagnostic, *domain.SCMRateLimit, error) {
 	known := make([]domain.SCMSubject, 0, len(subjects))
 	snaps := make([]domain.SCMSnapshot, 0, len(subjects))
@@ -198,43 +308,138 @@ func (p *Provider) observeKnownPRs(ctx context.Context, subjects []domain.SCMSub
 	if len(known) == 0 {
 		return snaps, nil, nil, nil
 	}
+
 	owner, repo := known[0].Repository().OwnerName()
-	data, rl, diag, err := p.fetchPRBatch(ctx, owner, repo, known)
-	diags := []domain.SCMDiagnostic{diag}
-	if err != nil {
-		for _, subj := range known {
-			snaps = append(snaps, unavailableSnapshot(subj, now, err))
+	latest := latestSnapshots(ctx, cache, known)
+	prListChanged := true
+	diags := []domain.SCMDiagnostic{}
+	if len(latest) > 0 {
+		scope := known[0].CacheScope()
+		_, changed, prListDiag, err := p.fetchOpenPulls(ctx, cache, scope, owner, repo, now)
+		prListChanged = changed
+		if prListDiag.Operation != "" {
+			diags = append(diags, prListDiag)
 		}
-		return snaps, diags, rl, err
+		if err != nil {
+			// PR-list guard failures should not be terminal truth. Fall through to
+			// GraphQL so one failed optimization guard does not hide real PR changes.
+			prListChanged = true
+		}
 	}
-	for _, subj := range known {
-		prData, _ := data[aliasFor(subj.PRNumber)].(map[string]any)
-		if prData == nil {
-			snaps = append(snaps, unavailableSnapshot(subj, now, &domain.SCMError{Kind: domain.SCMErrorNotFound, Operation: "github.graphql_pr", Message: "pull request not found"}))
+
+	toFetch := known
+	if !prListChanged && len(latest) > 0 {
+		toFetch = toFetch[:0]
+		for _, subj := range known {
+			prev, ok := latest[subj.SessionID]
+			if !ok || prev.PR == nil || prev.PR.HeadSHA == "" {
+				toFetch = append(toFetch, subj)
+				continue
+			}
+			changed, diag, err := p.checkRunsChanged(ctx, cache, subj, prev.PR.HeadSHA, now)
+			if diag.Operation != "" {
+				diags = append(diags, diag)
+			}
+			if err != nil || changed {
+				toFetch = append(toFetch, subj)
+				continue
+			}
+			reviewChanged, diag, err := p.reviewCommentsChanged(ctx, cache, subj, now)
+			if diag.Operation != "" {
+				diags = append(diags, diag)
+			}
+			if err != nil || reviewChanged {
+				toFetch = append(toFetch, subj)
+				continue
+			}
+			reused := prev
+			reused.ObservedAt = now
+			reused.Freshness = domain.SCMFreshnessUnchanged
+			reused.Subject = subj
+			snaps = append(snaps, reused)
+		}
+	}
+	if len(toFetch) == 0 {
+		return snaps, diags, nil, nil
+	}
+
+	var firstErr error
+	var lastRL *domain.SCMRateLimit
+	for _, batch := range chunkSubjects(toFetch, maxGraphQLBatchSize) {
+		data, rl, diag, err := p.fetchPRBatch(ctx, owner, repo, batch)
+		if diag.Operation != "" {
+			diags = append(diags, diag)
+		}
+		if rl != nil {
+			lastRL = rl
+		}
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			for _, subj := range batch {
+				if prev, ok := latest[subj.SessionID]; ok {
+					prev.ObservedAt = now
+					prev.Freshness = domain.SCMFreshnessUnavailable
+					prev.Diagnostics = append(prev.Diagnostics, diagnosticFromError("github.graphql_pr_batch", err))
+					snaps = append(snaps, prev)
+				} else {
+					snaps = append(snaps, unavailableSnapshot(subj, now, err))
+				}
+			}
 			continue
 		}
-		snap := snapshotFromGraphQL(subj, prData, now)
-		checks, checkDiag, err := p.fetchCheckRuns(ctx, cache, subj, snap, now)
-		if checkDiag.Operation != "" {
-			snap.Diagnostics = append(snap.Diagnostics, checkDiag)
+		for _, subj := range batch {
+			prData, _ := data[aliasFor(subj.PRNumber)].(map[string]any)
+			if prData == nil {
+				err := &domain.SCMError{Kind: domain.SCMErrorNotFound, Operation: "github.graphql_pr", Message: "pull request not found"}
+				if prev, ok := latest[subj.SessionID]; ok {
+					prev.ObservedAt = now
+					prev.Freshness = domain.SCMFreshnessUnavailable
+					prev.Diagnostics = append(prev.Diagnostics, diagnosticFromError("github.graphql_pr", err))
+					snaps = append(snaps, prev)
+				} else {
+					snaps = append(snaps, unavailableSnapshot(subj, now, err))
+				}
+				continue
+			}
+			snap := snapshotFromGraphQL(subj, prData, now)
+			prev, havePrev := latest[subj.SessionID]
+			if shouldFetchCheckRuns(snap, prData) {
+				checks, checkDiag, err := p.fetchCheckRuns(ctx, cache, subj, snap, now)
+				if checkDiag.Operation != "" {
+					snap.Diagnostics = append(snap.Diagnostics, checkDiag)
+				}
+				if err == nil && len(checks) > 0 {
+					snap.CI.Checks = checks
+					snap.CI.Summary = summarizeChecks(checks)
+					snap.CI.FailureLogTail = combinedFailureTail(checks)
+				} else if err != nil && havePrev && prev.PR != nil && prev.PR.HeadSHA == snap.PR.HeadSHA {
+					snap.CI = prev.CI
+					snap.Diagnostics = append(snap.Diagnostics, diagnosticFromError("github.check_runs", err))
+				}
+			}
+			reviewThreads, reviewDiag, reviewChanged, err := p.fetchReviewComments(ctx, cache, subj, now)
+			if reviewDiag.Operation != "" {
+				snap.Diagnostics = append(snap.Diagnostics, reviewDiag)
+			}
+			switch {
+			case err == nil && !reviewChanged && havePrev && len(prev.Review.UnresolvedThreads) > 0:
+				snap.Review.UnresolvedThreads = prev.Review.UnresolvedThreads
+				classifyThreads(&snap.Review)
+			case err == nil && len(reviewThreads) > 0:
+				snap.Review.UnresolvedThreads = reviewThreads
+				classifyThreads(&snap.Review)
+			case err != nil && havePrev:
+				snap.Review.UnresolvedThreads = prev.Review.UnresolvedThreads
+				classifyThreads(&snap.Review)
+				snap.Diagnostics = append(snap.Diagnostics, diagnosticFromError("github.review_comments", err))
+			}
+			finalizeMergeability(&snap)
+			snaps = append(snaps, snap)
 		}
-		if err == nil && len(checks) > 0 {
-			snap.CI.Checks = checks
-			snap.CI.Summary = summarizeChecks(checks)
-			snap.CI.FailureLogTail = combinedFailureTail(checks)
-		}
-		reviewThreads, reviewDiag, err := p.fetchReviewComments(ctx, cache, subj, now)
-		if reviewDiag.Operation != "" {
-			snap.Diagnostics = append(snap.Diagnostics, reviewDiag)
-		}
-		if err == nil && len(reviewThreads) > 0 && len(snap.Review.UnresolvedThreads) == 0 {
-			snap.Review.UnresolvedThreads = reviewThreads
-			classifyThreads(&snap.Review)
-		}
-		finalizeMergeability(&snap)
-		snaps = append(snaps, snap)
 	}
-	return snaps, diags, rl, nil
+	return snaps, diags, lastRL, firstErr
 }
 
 func (p *Provider) fetchPRBatch(ctx context.Context, owner, repo string, subjects []domain.SCMSubject) (map[string]any, *domain.SCMRateLimit, domain.SCMDiagnostic, error) {
@@ -246,7 +451,7 @@ func (p *Provider) fetchPRBatch(ctx context.Context, owner, repo string, subject
 			continue
 		}
 		seen[subj.PRNumber] = true
-		fmt.Fprintf(&b, `%s: pullRequest(number:%d){ number title url state isDraft merged closed headRefName baseRefName headRefOid additions deletions mergeable reviewDecision mergeStateStatus commits(last:1){ nodes{ commit{ statusCheckRollup{ state contexts(first:50){ nodes{ __typename ... on CheckRun { name status conclusion detailsUrl url } ... on StatusContext { context state targetUrl } } } } } } } reviewThreads(first:50){ nodes{ id isResolved path line comments(first:20){ nodes{ id body url author{ __typename login } } } } } }`, aliasFor(subj.PRNumber), subj.PRNumber)
+		fmt.Fprintf(&b, `%s: pullRequest(number:%d){ number title url state isDraft merged closed headRefName baseRefName headRefOid additions deletions mergeable reviewDecision mergeStateStatus commits(last:1){ nodes{ commit{ statusCheckRollup{ state contexts(first:%d){ nodes{ __typename ... on CheckRun { name status conclusion detailsUrl url } ... on StatusContext { context state targetUrl } } pageInfo{ hasNextPage } } } } } } } }`, aliasFor(subj.PRNumber), subj.PRNumber, graphQLCheckContextLimit)
 	}
 	b.WriteString("} rateLimit{ limit remaining resetAt } }")
 	data, rl, diag, err := p.client.DoGraphQL(ctx, b.String(), map[string]any{"owner": owner, "repo": repo}, "github.graphql_pr_batch")
@@ -434,9 +639,9 @@ func (p *Provider) fetchCheckRuns(ctx context.Context, cache ports.SCMProviderCa
 	return checks, resp.Diagnostic, nil
 }
 
-func (p *Provider) fetchReviewComments(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject, now time.Time) ([]domain.SCMReviewThread, domain.SCMDiagnostic, error) {
+func (p *Provider) fetchReviewComments(ctx context.Context, cache ports.SCMProviderCache, subj domain.SCMSubject, now time.Time) ([]domain.SCMReviewThread, domain.SCMDiagnostic, bool, error) {
 	if subj.PRNumber == 0 {
-		return nil, domain.SCMDiagnostic{}, nil
+		return nil, domain.SCMDiagnostic{}, false, nil
 	}
 	scope := subj.CacheScope()
 	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cacheReviews, Key: strconv.Itoa(subj.PRNumber)}
@@ -444,7 +649,7 @@ func (p *Provider) fetchReviewComments(ctx context.Context, cache ports.SCMProvi
 	owner, repo := subj.Repository().OwnerName()
 	resp, err := p.client.DoREST(ctx, http.MethodGet, repoPath(owner, repo, "pulls", strconv.Itoa(subj.PRNumber), "comments"), nil, nil, entry.ETag, "github.review_comments")
 	if err != nil {
-		return nil, resp.Diagnostic, err
+		return nil, resp.Diagnostic, false, err
 	}
 	body := resp.Body
 	if resp.NotModified && hasEntry {
@@ -466,7 +671,7 @@ func (p *Provider) fetchReviewComments(ctx context.Context, cache ports.SCMProvi
 		} `json:"user"`
 	}
 	if err := json.Unmarshal(body, &comments); err != nil {
-		return nil, resp.Diagnostic, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: "github.review_comments", Message: err.Error(), Cause: err}
+		return nil, resp.Diagnostic, false, &domain.SCMError{Kind: domain.SCMErrorParse, Operation: "github.review_comments", Message: err.Error(), Cause: err}
 	}
 	threads := make([]domain.SCMReviewThread, 0, len(comments))
 	for _, c := range comments {
@@ -479,7 +684,7 @@ func (p *Provider) fetchReviewComments(ctx context.Context, cache ports.SCMProvi
 		comment := domain.SCMReviewComment{ID: strconv.FormatInt(c.ID, 10), Author: c.User.Login, Body: c.Body, URL: c.HTMLURL, IsBot: isBot, Path: c.Path, Line: line, ThreadID: threadID}
 		threads = append(threads, domain.SCMReviewThread{ID: threadID, Path: c.Path, Line: line, URL: c.HTMLURL, IsBot: isBot, Comments: []domain.SCMReviewComment{comment}})
 	}
-	return threads, resp.Diagnostic, nil
+	return threads, resp.Diagnostic, !resp.NotModified, nil
 }
 
 func repoPath(owner, repo string, elems ...string) string {

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -1,0 +1,144 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/aoagents/agent-orchestrator/backend/internal/scm/store"
+)
+
+func TestRESTETag200And304(t *testing.T) {
+	var calls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer token" {
+			t.Fatalf("auth header %q", got)
+		}
+		w.Header().Set("ETag", `"v1"`)
+		if calls.Add(1) == 2 {
+			if got := r.Header.Get("If-None-Match"); got != `"v1"` {
+				t.Fatalf("If-None-Match %q", got)
+			}
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+	c := NewClient(ClientOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	ctx := context.Background()
+	resp, err := c.DoREST(ctx, http.MethodGet, "/x", nil, nil, "", "test")
+	if err != nil || resp.NotModified || resp.ETag != `"v1"` {
+		t.Fatalf("first resp=%+v err=%v", resp, err)
+	}
+	resp, err = c.DoREST(ctx, http.MethodGet, "/x", nil, nil, resp.ETag, "test")
+	if err != nil || !resp.NotModified {
+		t.Fatalf("second resp=%+v err=%v", resp, err)
+	}
+}
+
+func TestBranchDiscoveryCachesPositiveMapping(t *testing.T) {
+	var pullListCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls":
+			pullListCalls.Add(1)
+			w.Header().Set("ETag", `"pulls"`)
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"number": 3, "html_url": "https://github.com/o/r/pull/3", "head": map[string]any{"ref": "feat/27"}, "base": map[string]any{"ref": "main"}}})
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			writeGraphQLPR(t, w, 3, "feat/27", "SUCCESS", "APPROVED", nil)
+		case strings.Contains(r.URL.Path, "/check-runs"):
+			_, _ = w.Write([]byte(`{"check_runs":[]}`))
+		case strings.Contains(r.URL.Path, "/comments"):
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	st := store.NewMemoryStore()
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27"}
+	res, err := p.ObserveSessions(context.Background(), observeReq(subj), st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Subjects) != 1 || res.Subjects[0].PRNumber != 3 {
+		t.Fatalf("discovered subjects=%+v", res.Subjects)
+	}
+	res, err = p.ObserveSessions(context.Background(), observeReq(subj), st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pullListCalls.Load() != 1 {
+		t.Fatalf("positive branch mapping did not avoid rediscovery; calls=%d", pullListCalls.Load())
+	}
+}
+
+func TestGraphQLBatchNormalizationReviewAndMergeability(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			threads := []map[string]any{
+				{"id": "human-thread", "isResolved": false, "path": "main.go", "line": 12, "comments": map[string]any{"nodes": []map[string]any{{"id": "c1", "body": "please change", "url": "https://example/comment", "author": map[string]any{"__typename": "User", "login": "alice"}}}}},
+				{"id": "bot-thread", "isResolved": false, "path": "lint.go", "line": 1, "comments": map[string]any{"nodes": []map[string]any{{"id": "c2", "body": "lint", "url": "https://example/bot", "author": map[string]any{"__typename": "Bot", "login": "review-bot"}}}}},
+			}
+			writeGraphQLPR(t, w, 5, "feat/27", "SUCCESS", "APPROVED", threads)
+		case strings.Contains(r.URL.Path, "/check-runs"):
+			_, _ = w.Write([]byte(`{"check_runs":[{"name":"test","status":"completed","conclusion":"success","html_url":"https://checks"}]}`))
+		case strings.Contains(r.URL.Path, "/comments"):
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 5}
+	res, err := p.ObserveSessions(context.Background(), observeReq(subj), store.NewMemoryStore())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Snapshots) != 1 {
+		t.Fatalf("snapshots=%d", len(res.Snapshots))
+	}
+	s := res.Snapshots[0]
+	if s.PR == nil || s.PR.State != domain.PROpen || s.CI.Summary != "passing" {
+		t.Fatalf("bad pr/ci snapshot=%+v", s)
+	}
+	if len(s.Review.HumanComments) != 1 || len(s.Review.BotComments) != 1 {
+		t.Fatalf("review split human=%d bot=%d", len(s.Review.HumanComments), len(s.Review.BotComments))
+	}
+	if !s.Mergeability.Mergeable {
+		t.Fatalf("expected mergeable: %+v", s.Mergeability)
+	}
+}
+
+func observeReq(subj domain.SCMSubject) ports.SCMObserveRequest {
+	return ports.SCMObserveRequest{Subjects: []domain.SCMSubject{subj}, Now: time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)}
+}
+
+func writeGraphQLPR(t *testing.T, w http.ResponseWriter, number int, branch, ciState, reviewDecision string, threads []map[string]any) {
+	t.Helper()
+	if threads == nil {
+		threads = []map[string]any{}
+	}
+	alias := "pr" + strconv.Itoa(number)
+	resp := map[string]any{"data": map[string]any{"repository": map[string]any{alias: map[string]any{
+		"number": number, "title": "PR", "url": "https://github.com/o/r/pull/" + strconv.Itoa(number), "state": "OPEN", "isDraft": false, "merged": false, "closed": false,
+		"headRefName": branch, "baseRefName": "main", "headRefOid": "sha", "additions": 1, "deletions": 2, "mergeable": "MERGEABLE", "reviewDecision": reviewDecision, "mergeStateStatus": "CLEAN",
+		"commits":       map[string]any{"nodes": []map[string]any{{"commit": map[string]any{"statusCheckRollup": map[string]any{"state": ciState, "contexts": map[string]any{"nodes": []map[string]any{{"__typename": "CheckRun", "name": "test", "status": "COMPLETED", "conclusion": "SUCCESS", "detailsUrl": "https://checks"}}}}}}}},
+		"reviewThreads": map[string]any{"nodes": threads},
+	}}, "rateLimit": map[string]any{"limit": 5000, "remaining": 4999, "resetAt": "2026-05-28T13:00:00Z"}}}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -302,7 +302,7 @@ func TestGraphQLBatchNormalizationReviewAndMergeability(t *testing.T) {
 	}
 }
 
-func TestCompleteGraphQLCIContextsAvoidFullCheckRunsAndFetchJobLogs(t *testing.T) {
+func TestCompleteGraphQLCIContextsAvoidFullCheckRunsAndJobLogs(t *testing.T) {
 	var checkRunsCalls atomic.Int32
 	var logCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -316,7 +316,7 @@ func TestCompleteGraphQLCIContextsAvoidFullCheckRunsAndFetchJobLogs(t *testing.T
 			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"repository": map[string]any{"pr5": payload}}})
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/actions/jobs/20/logs":
 			logCalls.Add(1)
-			_, _ = w.Write([]byte(numberedLines(25)))
+			t.Fatalf("job logs should not be fetched from the SCM polling hot path")
 		case strings.Contains(r.URL.Path, "/check-runs"):
 			checkRunsCalls.Add(1)
 			t.Fatalf("full check-runs should not be fetched when GraphQL contexts are complete")
@@ -333,12 +333,11 @@ func TestCompleteGraphQLCIContextsAvoidFullCheckRunsAndFetchJobLogs(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	if checkRunsCalls.Load() != 0 || logCalls.Load() != 1 {
+	if checkRunsCalls.Load() != 0 || logCalls.Load() != 0 {
 		t.Fatalf("checkRuns=%d logs=%d", checkRunsCalls.Load(), logCalls.Load())
 	}
-	tail := res.Snapshots[0].CI.Checks[0].LogTail
-	if strings.Contains(tail, "line-05") || !strings.Contains(tail, "line-06") || !strings.Contains(tail, "line-25") {
-		t.Fatalf("unexpected 20-line tail:\n%s", tail)
+	if got := res.Snapshots[0].CI.FailureLogTail; got != "" {
+		t.Fatalf("failure log tail should stay empty when only GraphQL check contexts were needed: %q", got)
 	}
 }
 

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -427,11 +427,23 @@ func TestETagGuardsReuseLatestSnapshotAndSkipGraphQL(t *testing.T) {
 			}
 			w.Header().Set("ETag", `"pulls"`)
 			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls/5":
+			if got := r.Header.Get("If-None-Match"); got != `"pr"` {
+				t.Fatalf("pr-state If-None-Match = %q", got)
+			}
+			w.Header().Set("ETag", `"pr"`)
+			w.WriteHeader(http.StatusNotModified)
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/check-runs"):
 			if got := r.Header.Get("If-None-Match"); got != `"checks"` {
 				t.Fatalf("check guard If-None-Match = %q", got)
 			}
 			w.Header().Set("ETag", `"checks"`)
+			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/comments"):
+			if got := r.Header.Get("If-None-Match"); got != `"reviews"` {
+				t.Fatalf("review If-None-Match = %q", got)
+			}
+			w.Header().Set("ETag", `"reviews"`)
 			w.WriteHeader(http.StatusNotModified)
 		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
 			graphQLCalls.Add(1)
@@ -456,6 +468,12 @@ func TestETagGuardsReuseLatestSnapshotAndSkipGraphQL(t *testing.T) {
 	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheCheckGuard, Key: "sha"}, ETag: `"checks"`, UpdatedAt: time.Now()}); err != nil {
 		t.Fatal(err)
 	}
+	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRState, Key: "5"}, ETag: `"pr"`}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheReviews, Key: "5"}, ETag: `"reviews"`, Value: []byte(`[{"id":1}]`)}); err != nil {
+		t.Fatal(err)
+	}
 	putCachedReviewDetails(ctx, st, subj, "none", snap.Review.UnresolvedThreads, time.Date(2026, 5, 28, 11, 59, 0, 0, time.UTC))
 
 	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
@@ -474,18 +492,75 @@ func TestETagGuardsReuseLatestSnapshotAndSkipGraphQL(t *testing.T) {
 	}
 }
 
-func TestReviewDetailsThrottleUsesCacheWithinTwoMinutes(t *testing.T) {
+func TestBoundPRStateGuardDetectsTerminalPRWhenOpenListUnchanged(t *testing.T) {
 	var graphQLCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls":
 			w.Header().Set("ETag", `"pulls"`)
 			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls/5":
+			w.Header().Set("ETag", `"pr-closed"`)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"number":   5,
+				"state":    "closed",
+				"merged":   true,
+				"html_url": "https://github.com/o/r/pull/5",
+				"head":     map[string]any{"ref": "feat/27", "sha": "sha"},
+				"base":     map[string]any{"ref": "main"},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			graphQLCalls.Add(1)
+			t.Fatalf("terminal PR state should be detected before GraphQL reuse/fetch")
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 5, CredentialHash: "cred"}
+	snap := domain.SCMSnapshot{SessionID: "s1", Subject: subj, Freshness: domain.SCMFreshnessFresh, PR: &domain.SCMPullRequest{Number: 5, URL: "https://github.com/o/r/pull/5", State: domain.PROpen, HeadSHA: "sha"}, CI: domain.SCMCI{Summary: "passing"}}
+	if _, _, err := st.SaveSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRList, Key: "open-guard"}, ETag: `"pulls"`, Value: []byte(`[{"number":5}]`)}); err != nil {
+		t.Fatal(err)
+	}
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	res, err := p.ObserveSessions(ctx, observeReq(subj), st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if graphQLCalls.Load() != 0 {
+		t.Fatalf("GraphQL calls=%d", graphQLCalls.Load())
+	}
+	if len(res.Snapshots) != 1 || res.Snapshots[0].PR == nil || res.Snapshots[0].PR.State != domain.PRMerged {
+		t.Fatalf("expected merged terminal snapshot, got %+v", res.Snapshots)
+	}
+}
+
+func TestReviewDetailsChecksETagEveryPollAndReusesCacheOn304(t *testing.T) {
+	var graphQLCalls atomic.Int32
+	var commentCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls":
+			w.Header().Set("ETag", `"pulls"`)
+			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls/5":
+			w.Header().Set("ETag", `"pr"`)
+			w.WriteHeader(http.StatusNotModified)
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/check-runs"):
 			w.Header().Set("ETag", `"checks"`)
 			w.WriteHeader(http.StatusNotModified)
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/comments"):
-			t.Fatalf("review comments should be throttled")
+			commentCalls.Add(1)
+			if got := r.Header.Get("If-None-Match"); got != `"reviews"` {
+				t.Fatalf("review If-None-Match=%q", got)
+			}
+			w.Header().Set("ETag", `"reviews"`)
+			w.WriteHeader(http.StatusNotModified)
 		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
 			graphQLCalls.Add(1)
 			t.Fatalf("GraphQL should be skipped")
@@ -505,7 +580,9 @@ func TestReviewDetailsThrottleUsesCacheWithinTwoMinutes(t *testing.T) {
 	}
 	for _, entry := range []domain.SCMProviderCacheEntry{
 		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRList, Key: "open-guard"}, ETag: `"pulls"`, Value: []byte(`[{"number":5}]`)},
+		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRState, Key: "5"}, ETag: `"pr"`},
 		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheCheckGuard, Key: "sha"}, ETag: `"checks"`},
+		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheReviews, Key: "5"}, ETag: `"reviews"`, Value: []byte(`[{"id":1}]`)},
 	} {
 		if err := st.PutProviderCache(ctx, entry); err != nil {
 			t.Fatal(err)
@@ -517,17 +594,20 @@ func TestReviewDetailsThrottleUsesCacheWithinTwoMinutes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if graphQLCalls.Load() != 0 || len(res.Snapshots) != 1 || len(res.Snapshots[0].Review.UnresolvedThreads) != 1 {
-		t.Fatalf("calls=%d snapshots=%+v", graphQLCalls.Load(), res.Snapshots)
+	if graphQLCalls.Load() != 0 || commentCalls.Load() != 1 || len(res.Snapshots) != 1 || len(res.Snapshots[0].Review.UnresolvedThreads) != 1 {
+		t.Fatalf("graphQLCalls=%d commentCalls=%d snapshots=%+v", graphQLCalls.Load(), commentCalls.Load(), res.Snapshots)
 	}
 }
 
-func TestReviewDetailsChecksETagAfterThrottleAndReusesOn304(t *testing.T) {
+func TestReviewDetailsChecksETagAndReusesOn304(t *testing.T) {
 	var commentCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls":
 			w.Header().Set("ETag", `"pulls"`)
+			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls/5":
+			w.Header().Set("ETag", `"pr"`)
 			w.WriteHeader(http.StatusNotModified)
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/check-runs"):
 			w.Header().Set("ETag", `"checks"`)
@@ -557,6 +637,7 @@ func TestReviewDetailsChecksETagAfterThrottleAndReusesOn304(t *testing.T) {
 	}
 	for _, entry := range []domain.SCMProviderCacheEntry{
 		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRList, Key: "open-guard"}, ETag: `"pulls"`, Value: []byte(`[{"number":5}]`)},
+		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRState, Key: "5"}, ETag: `"pr"`},
 		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheCheckGuard, Key: "sha"}, ETag: `"checks"`},
 		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheReviews, Key: "5"}, ETag: `"reviews"`, Value: []byte(`[{"id":1}]`)},
 	} {
@@ -576,6 +657,61 @@ func TestReviewDetailsChecksETagAfterThrottleAndReusesOn304(t *testing.T) {
 	_, entry, ok := getCachedReviewDetails(ctx, st, subj)
 	if !ok || !entry.UpdatedAt.Equal(now) {
 		t.Fatalf("review details cache not touched: ok=%v entry=%+v", ok, entry)
+	}
+}
+
+func TestReviewCommentsChangeClearsCachedThreadsImmediately(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls":
+			w.Header().Set("ETag", `"pulls"`)
+			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls/5":
+			w.Header().Set("ETag", `"pr"`)
+			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/check-runs"):
+			w.Header().Set("ETag", `"checks"`)
+			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/comments"):
+			if got := r.Header.Get("If-None-Match"); got != `"reviews-old"` {
+				t.Fatalf("review If-None-Match=%q", got)
+			}
+			w.Header().Set("ETag", `"reviews-empty"`)
+			_, _ = w.Write([]byte(`[]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			t.Fatalf("GraphQL should not be needed when review comments become empty")
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 5, CredentialHash: "cred"}
+	threads := []domain.SCMReviewThread{{ID: "thread-old", Comments: []domain.SCMReviewComment{{ID: "c1", Author: "alice"}}}}
+	snap := domain.SCMSnapshot{SessionID: "s1", Subject: subj, Freshness: domain.SCMFreshnessFresh, PR: &domain.SCMPullRequest{Number: 5, State: domain.PROpen, HeadSHA: "sha"}, CI: domain.SCMCI{Summary: "passing"}, Review: domain.SCMReview{UnresolvedThreads: threads}}
+	if _, _, err := st.SaveSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range []domain.SCMProviderCacheEntry{
+		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRList, Key: "open-guard"}, ETag: `"pulls"`, Value: []byte(`[{"number":5}]`)},
+		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRState, Key: "5"}, ETag: `"pr"`},
+		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheCheckGuard, Key: "sha"}, ETag: `"checks"`},
+		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheReviews, Key: "5"}, ETag: `"reviews-old"`, Value: []byte(`[{"id":1}]`)},
+	} {
+		if err := st.PutProviderCache(ctx, entry); err != nil {
+			t.Fatal(err)
+		}
+	}
+	putCachedReviewDetails(ctx, st, subj, "none", threads, now.Add(-time.Minute))
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	res, err := p.ObserveSessions(ctx, ports.SCMObserveRequest{Subjects: []domain.SCMSubject{subj}, Now: now}, st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(res.Snapshots[0].Review.UnresolvedThreads); got != 0 {
+		t.Fatalf("review threads should have cleared immediately, got %d", got)
 	}
 }
 
@@ -627,6 +763,56 @@ func TestReviewDecisionChangeBypassesReviewThrottle(t *testing.T) {
 	}
 	if reviewGraphQLCalls.Load() != 1 || len(res.Snapshots[0].Review.HumanComments) != 1 {
 		t.Fatalf("reviewGraphQLCalls=%d snapshot=%+v", reviewGraphQLCalls.Load(), res.Snapshots[0].Review)
+	}
+}
+
+func TestReviewThreadsFetchAllCommentsForClassification(t *testing.T) {
+	var reviewGraphQLCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			var req struct {
+				Query string `json:"query"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(req.Query, "reviewThreads") {
+				reviewGraphQLCalls.Add(1)
+				if !strings.Contains(req.Query, "comments(first:100)") {
+					t.Fatalf("review thread query should fetch all bounded comments: %s", req.Query)
+				}
+				threads := []map[string]any{{
+					"id":         "thread-mixed",
+					"isResolved": false,
+					"comments": map[string]any{"nodes": []map[string]any{
+						{"id": "bot-c", "body": "automated hint", "url": "https://example/bot", "path": "main.go", "line": 7, "author": map[string]any{"login": "lint-bot", "__typename": "Bot"}},
+						{"id": "human-c", "body": "please fix this too", "url": "https://example/human", "path": "main.go", "line": 8, "author": map[string]any{"login": "alice", "__typename": "User"}},
+					}},
+				}}
+				_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"repository": map[string]any{"pullRequest": map[string]any{"reviewThreads": map[string]any{"nodes": threads}}}}})
+				return
+			}
+			writeGraphQLPR(t, w, 5, "feat/27", "SUCCESS", "CHANGES_REQUESTED", nil)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/comments"):
+			_, _ = w.Write([]byte(`[{"id":1}]`))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 5}
+	res, err := p.ObserveSessions(context.Background(), observeReq(subj), store.NewMemoryStore())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reviewGraphQLCalls.Load() != 1 {
+		t.Fatalf("review GraphQL calls=%d", reviewGraphQLCalls.Load())
+	}
+	review := res.Snapshots[0].Review
+	if len(review.HumanComments) != 1 || len(review.BotComments) != 0 || len(review.UnresolvedThreads[0].Comments) != 2 {
+		t.Fatalf("mixed thread should be human with both comments preserved: %+v", review)
 	}
 }
 
@@ -710,6 +896,9 @@ func TestReviewGuardETagIsNotAdvancedWhenReviewThreadsFail(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls":
 			w.Header().Set("ETag", `"pulls"`)
 			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls/5":
+			w.Header().Set("ETag", `"pr"`)
+			w.WriteHeader(http.StatusNotModified)
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/check-runs"):
 			w.Header().Set("ETag", `"checks"`)
 			w.WriteHeader(http.StatusNotModified)
@@ -743,6 +932,7 @@ func TestReviewGuardETagIsNotAdvancedWhenReviewThreadsFail(t *testing.T) {
 	}
 	for _, entry := range []domain.SCMProviderCacheEntry{
 		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRList, Key: "open-guard"}, ETag: `"pulls"`, Value: []byte(`[{"number":5}]`)},
+		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRState, Key: "5"}, ETag: `"pr"`},
 		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheCheckGuard, Key: "sha"}, ETag: `"checks"`},
 		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheReviews, Key: "5"}, ETag: `"reviews-old"`, Value: []byte(`[{"id":0}]`)},
 		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheReviewDetails, Key: "5"}, Value: []byte(`{"threads":[{"id":"old"}]}`), UpdatedAt: time.Date(2026, 5, 28, 11, 0, 0, 0, time.UTC)},
@@ -903,7 +1093,7 @@ func TestCommandCacheInvalidationsAreGitHubSpecific(t *testing.T) {
 			t.Fatalf("bad prefix scope: %+v", prefix)
 		}
 	}
-	for _, namespace := range []string{cachePRList, cacheBranchMap, cacheChecks, cacheCheckGuard, cacheReviews, cacheReviewDetails} {
+	for _, namespace := range []string{cachePRList, cacheBranchMap, cachePRState, cacheChecks, cacheCheckGuard, cacheReviews, cacheReviewDetails} {
 		if !got[namespace] {
 			t.Fatalf("missing invalidation namespace %q in %+v", namespace, prefixes)
 		}
@@ -945,6 +1135,56 @@ func TestMergeabilityIsConservativeForGitHubBlockers(t *testing.T) {
 	got := mergeabilityFromGraphQL(map[string]any{"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"}, domain.SCMCI{Summary: "passing"}, domain.SCMReview{Decision: "approved"})
 	if !got.Mergeable || len(got.Blockers) != 0 {
 		t.Fatalf("expected clean mergeable: %+v", got)
+	}
+}
+
+func TestFinalizeMergeabilityRebuildsBlockersAfterRESTCheckRuns(t *testing.T) {
+	snap := domain.SCMSnapshot{
+		PR:           &domain.SCMPullRequest{Number: 5, State: domain.PROpen},
+		CI:           domain.SCMCI{Summary: "failing", Checks: []domain.SCMCheck{{Name: "test", Status: "completed", Conclusion: "failure"}}},
+		Review:       domain.SCMReview{Decision: "approved"},
+		Mergeability: domain.SCMMergeability{RawState: "MERGEABLE", MergeState: "CLEAN", NoConflicts: true, CIPassing: true, Approved: true, Mergeable: true},
+	}
+	finalizeMergeability(&snap)
+	if snap.Mergeability.Mergeable || snap.Mergeability.CIPassing || !containsString(snap.Mergeability.Blockers, "CI failing") {
+		t.Fatalf("mergeability was not rebuilt from final CI state: %+v", snap.Mergeability)
+	}
+}
+
+func TestSkippedNeutralAndStaleChecksAreExplicitlyNonFailing(t *testing.T) {
+	for _, summary := range []string{"skipped", "neutral", "stale"} {
+		if got := domain.NormalizeSCMCI(summary); got != "none" {
+			t.Fatalf("NormalizeSCMCI(%q)=%q, want none", summary, got)
+		}
+	}
+	checks := []domain.SCMCheck{
+		{Name: "skipped", Status: "completed", Conclusion: "skipped"},
+		{Name: "neutral", Status: "completed", Conclusion: "neutral"},
+		{Name: "stale", Status: "completed", Conclusion: "stale"},
+	}
+	if got := summarizeChecks(checks); got != "none" {
+		t.Fatalf("summarizeChecks=%q, want none", got)
+	}
+	for _, check := range checks {
+		if failedCheck(check) {
+			t.Fatalf("check should not fail: %+v", check)
+		}
+	}
+}
+
+func TestBotAuthorDetectionDoesNotUseLooseSubstring(t *testing.T) {
+	for _, login := range []string{"robothon", "bigbob", "lambot123"} {
+		if isBotAuthor(login, "User") {
+			t.Fatalf("%q should not be classified as a bot", login)
+		}
+	}
+	for _, login := range []string{"dependabot[bot]", "review-bot", "github-actions"} {
+		if !isBotAuthor(login, "User") {
+			t.Fatalf("%q should be classified as a bot", login)
+		}
+	}
+	if !isBotAuthor("anything", "Bot") {
+		t.Fatal("GitHub Bot typename should classify as bot")
 	}
 }
 

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -984,6 +984,25 @@ func TestReviewThreadsFetchAllCommentsForClassification(t *testing.T) {
 	}
 }
 
+func TestClassifyThreadsDoesNotPromoteCommentThreadsToChangesRequested(t *testing.T) {
+	review := domain.SCMReview{
+		Decision: "none",
+		UnresolvedThreads: []domain.SCMReviewThread{{
+			ID: "thread-human",
+			Comments: []domain.SCMReviewComment{{
+				ID: "comment-review", Author: "alice", Body: "non-blocking comment", IsBot: false,
+			}},
+		}},
+	}
+	classifyThreads(&review)
+	if review.Decision != "none" {
+		t.Fatalf("comment-only human thread should not override formal review decision: %+v", review)
+	}
+	if len(review.HumanComments) != 1 || len(review.BotComments) != 0 {
+		t.Fatalf("thread classification changed unexpectedly: %+v", review)
+	}
+}
+
 func TestGraphQLFailureFallsBackToTerminalPRState(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -46,6 +47,66 @@ func TestRESTETag200And304(t *testing.T) {
 	}
 }
 
+func TestGHTokenSourceMemoizesAndIgnoresGithubTokenEnv(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "env-token")
+	var calls atomic.Int32
+	src := &GHTokenSource{Command: func(context.Context) ([]byte, error) {
+		calls.Add(1)
+		return []byte("gh-token\n"), nil
+	}}
+	tok, err := src.Token(context.Background())
+	if err != nil || tok != "gh-token" {
+		t.Fatalf("token=%q err=%v", tok, err)
+	}
+	tok, err = src.Token(context.Background())
+	if err != nil || tok != "gh-token" {
+		t.Fatalf("second token=%q err=%v", tok, err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("gh auth token calls=%d, want 1", calls.Load())
+	}
+}
+
+func TestAuthFailureIsNormalized(t *testing.T) {
+	src := &GHTokenSource{Command: func(context.Context) ([]byte, error) { return nil, ErrNoToken }}
+	c := NewClient(ClientOptions{Token: src, RESTBase: "http://127.0.0.1:1"})
+	_, err := c.DoREST(context.Background(), http.MethodGet, "/x", nil, nil, "", "test")
+	var scmErr *domain.SCMError
+	if !errors.As(err, &scmErr) || scmErr.Kind != domain.SCMErrorAuthFailed {
+		t.Fatalf("err=%T %[1]v", err)
+	}
+}
+
+func TestRotatedETagOn304UpdatesCacheOnly(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("If-None-Match"); got != `"old"` {
+			t.Fatalf("If-None-Match=%q", got)
+		}
+		w.Header().Set("ETag", `"new"`)
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer ts.Close()
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	scope := domain.SCMProviderCacheScope{Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", CredentialHash: "cred"}
+	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cachePRList, Key: "open-guard"}
+	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: `"old"`, Value: []byte(`[{"number":1}]`)}); err != nil {
+		t.Fatal(err)
+	}
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	changed, _, err := p.checkOpenPullListChanged(ctx, st, scope, "o", "r", time.Now())
+	if err != nil || changed {
+		t.Fatalf("changed=%v err=%v", changed, err)
+	}
+	got, ok, err := st.GetProviderCache(ctx, key)
+	if err != nil || !ok {
+		t.Fatalf("cache ok=%v err=%v", ok, err)
+	}
+	if got.ETag != `"new"` || string(got.Value) != `[{"number":1}]` {
+		t.Fatalf("cache=%+v body=%s", got, string(got.Value))
+	}
+}
+
 func TestBranchDiscoveryCachesPositiveMapping(t *testing.T) {
 	var pullListCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -84,6 +145,71 @@ func TestBranchDiscoveryCachesPositiveMapping(t *testing.T) {
 	}
 }
 
+func TestBranchDiscoveryExactFallbackAndNoNegativeCache(t *testing.T) {
+	var exactCalls atomic.Int32
+	var discoveryCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls" && r.URL.Query().Get("head") == "":
+			discoveryCalls.Add(1)
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls" && r.URL.Query().Get("head") == "o:feat/old":
+			exactCalls.Add(1)
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"number": 9, "html_url": "https://github.com/o/r/pull/9", "head": map[string]any{"ref": "feat/old"}, "base": map[string]any{"ref": "main"}}})
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			writeGraphQLPR(t, w, 9, "feat/old", "SUCCESS", "APPROVED", nil)
+		case strings.Contains(r.URL.Path, "/comments"):
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Fatalf("unexpected %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+		}
+	}))
+	defer ts.Close()
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/old"}
+	res, err := p.ObserveSessions(context.Background(), observeReq(subj), store.NewMemoryStore())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Subjects) != 1 || res.Subjects[0].PRNumber != 9 {
+		t.Fatalf("subjects=%+v", res.Subjects)
+	}
+	if exactCalls.Load() != 1 || discoveryCalls.Load() != 1 {
+		t.Fatalf("discovery=%d exact=%d", discoveryCalls.Load(), exactCalls.Load())
+	}
+}
+
+func TestBranchDiscoveryDoesNotCacheMisses(t *testing.T) {
+	var exactCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls" && r.URL.Query().Get("head") == "":
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls" && r.URL.Query().Get("head") == "o:feat/missing":
+			exactCalls.Add(1)
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		default:
+			t.Fatalf("unexpected %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+		}
+	}))
+	defer ts.Close()
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	st := store.NewMemoryStore()
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/missing"}
+	for i := 0; i < 2; i++ {
+		res, err := p.ObserveSessions(context.Background(), observeReq(subj), st)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(res.Subjects) != 1 || res.Subjects[0].PRNumber != 0 {
+			t.Fatalf("subjects=%+v", res.Subjects)
+		}
+	}
+	if exactCalls.Load() != 2 {
+		t.Fatalf("exact fallback calls=%d, want 2", exactCalls.Load())
+	}
+}
+
 func TestGraphQLBatchNormalizationReviewAndMergeability(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -93,6 +219,18 @@ func TestGraphQLBatchNormalizationReviewAndMergeability(t *testing.T) {
 			}
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 				t.Fatal(err)
+			}
+			if strings.Contains(req.Query, "reviewThreads") {
+				threads := []map[string]any{
+					{"id": "thread-human", "isResolved": false, "comments": map[string]any{"nodes": []map[string]any{{"id": "c1", "body": "please change", "url": "https://example/comment", "path": "main.go", "line": 12, "author": map[string]any{"login": "alice", "__typename": "User"}}}}},
+					{"id": "thread-bot", "isResolved": false, "comments": map[string]any{"nodes": []map[string]any{{"id": "c2", "body": "lint", "url": "https://example/bot", "path": "lint.go", "line": 1, "author": map[string]any{"login": "review-bot", "__typename": "Bot"}}}}},
+					{"id": "thread-resolved", "isResolved": true, "comments": map[string]any{"nodes": []map[string]any{{"id": "c3", "body": "done", "url": "https://example/done", "path": "done.go", "line": 1, "author": map[string]any{"login": "alice", "__typename": "User"}}}}},
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{
+					"repository": map[string]any{"pullRequest": map[string]any{"reviewThreads": map[string]any{"nodes": threads}}},
+					"rateLimit":  map[string]any{"limit": 5000, "remaining": 4999, "resetAt": "2026-05-28T13:00:00Z"},
+				}})
+				return
 			}
 			if strings.Contains(req.Query, "reviewThreads") || strings.Contains(req.Query, "comments(first") {
 				t.Fatalf("main batch query should not fetch review threads/comments: %s", req.Query)
@@ -131,11 +269,121 @@ func TestGraphQLBatchNormalizationReviewAndMergeability(t *testing.T) {
 	}
 }
 
+func TestCompleteGraphQLCIContextsAvoidFullCheckRunsAndFetchJobLogs(t *testing.T) {
+	var checkRunsCalls atomic.Int32
+	var logCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			payload := graphQLPRPayload(5, "feat/27", "FAILURE", "APPROVED", nil)
+			withCheckContexts(payload, "FAILURE", map[string]any{
+				"nodes":    []map[string]any{{"__typename": "CheckRun", "name": "lint", "status": "COMPLETED", "conclusion": "FAILURE", "detailsUrl": "https://github.com/o/r/actions/runs/10/job/20"}},
+				"pageInfo": map[string]any{"hasNextPage": false},
+			})
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"repository": map[string]any{"pr5": payload}}})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/actions/jobs/20/logs":
+			logCalls.Add(1)
+			_, _ = w.Write([]byte(numberedLines(25)))
+		case strings.Contains(r.URL.Path, "/check-runs"):
+			checkRunsCalls.Add(1)
+			t.Fatalf("full check-runs should not be fetched when GraphQL contexts are complete")
+		case strings.Contains(r.URL.Path, "/comments"):
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 5}
+	res, err := p.ObserveSessions(context.Background(), observeReq(subj), store.NewMemoryStore())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checkRunsCalls.Load() != 0 || logCalls.Load() != 1 {
+		t.Fatalf("checkRuns=%d logs=%d", checkRunsCalls.Load(), logCalls.Load())
+	}
+	tail := res.Snapshots[0].CI.Checks[0].LogTail
+	if strings.Contains(tail, "line-05") || !strings.Contains(tail, "line-06") || !strings.Contains(tail, "line-25") {
+		t.Fatalf("unexpected 20-line tail:\n%s", tail)
+	}
+}
+
+func TestTruncatedGraphQLCIContextsFetchFullCheckRuns(t *testing.T) {
+	var checkRunsCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			payload := graphQLPRPayload(5, "feat/27", "FAILURE", "APPROVED", nil)
+			withCheckContexts(payload, "FAILURE", map[string]any{
+				"nodes":    []map[string]any{{"__typename": "CheckRun", "name": "first", "status": "COMPLETED", "conclusion": "SUCCESS", "detailsUrl": "https://checks/first"}},
+				"pageInfo": map[string]any{"hasNextPage": true},
+			})
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"repository": map[string]any{"pr5": payload}}})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/check-runs"):
+			checkRunsCalls.Add(1)
+			_, _ = w.Write([]byte(`{"check_runs":[{"name":"late-failure","status":"completed","conclusion":"failure","html_url":"https://checks/late"}]}`))
+		case strings.Contains(r.URL.Path, "/comments"):
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 5}
+	res, err := p.ObserveSessions(context.Background(), observeReq(subj), store.NewMemoryStore())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checkRunsCalls.Load() != 1 {
+		t.Fatalf("check-runs calls=%d", checkRunsCalls.Load())
+	}
+	if got := res.Snapshots[0].CI.Checks[0].Name; got != "late-failure" {
+		t.Fatalf("check name=%q", got)
+	}
+}
+
+func TestFailingCIWithoutFailedContextFetchesFullCheckRuns(t *testing.T) {
+	var checkRunsCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			payload := graphQLPRPayload(5, "feat/27", "FAILURE", "APPROVED", nil)
+			withCheckContexts(payload, "FAILURE", map[string]any{
+				"nodes":    []map[string]any{{"__typename": "CheckRun", "name": "green", "status": "COMPLETED", "conclusion": "SUCCESS", "detailsUrl": "https://checks/green"}},
+				"pageInfo": map[string]any{"hasNextPage": false},
+			})
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"repository": map[string]any{"pr5": payload}}})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/check-runs"):
+			checkRunsCalls.Add(1)
+			_, _ = w.Write([]byte(`{"check_runs":[{"name":"hidden-failure","status":"completed","conclusion":"failure","html_url":"https://checks/hidden"}]}`))
+		case strings.Contains(r.URL.Path, "/comments"):
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 5}
+	res, err := p.ObserveSessions(context.Background(), observeReq(subj), store.NewMemoryStore())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if checkRunsCalls.Load() != 1 || res.Snapshots[0].CI.Checks[0].Name != "hidden-failure" {
+		t.Fatalf("checkRuns=%d checks=%+v", checkRunsCalls.Load(), res.Snapshots[0].CI.Checks)
+	}
+}
+
 func TestETagGuardsReuseLatestSnapshotAndSkipGraphQL(t *testing.T) {
 	var graphQLCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls":
+			if got := r.URL.Query().Get("per_page"); got != "1" {
+				t.Fatalf("pr-list guard per_page=%q", got)
+			}
 			if got := r.Header.Get("If-None-Match"); got != `"pulls"` {
 				t.Fatalf("pr-list If-None-Match = %q", got)
 			}
@@ -165,12 +413,12 @@ func TestETagGuardsReuseLatestSnapshotAndSkipGraphQL(t *testing.T) {
 	ctx := context.Background()
 	st := store.NewMemoryStore()
 	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 5, CredentialHash: "cred"}
-	snap := domain.SCMSnapshot{SessionID: "s1", Subject: subj, Freshness: domain.SCMFreshnessFresh, ObservedAt: time.Date(2026, 5, 28, 11, 0, 0, 0, time.UTC), PR: &domain.SCMPullRequest{Number: 5, URL: "https://github.com/o/r/pull/5", State: domain.PROpen, HeadSHA: "sha"}, CI: domain.SCMCI{Summary: "passing"}}
+	snap := domain.SCMSnapshot{SessionID: "s1", Subject: subj, Freshness: domain.SCMFreshnessFresh, ObservedAt: time.Date(2026, 5, 28, 11, 0, 0, 0, time.UTC), PR: &domain.SCMPullRequest{Number: 5, URL: "https://github.com/o/r/pull/5", State: domain.PROpen, HeadSHA: "sha"}, CI: domain.SCMCI{Summary: "passing"}, Review: domain.SCMReview{UnresolvedThreads: []domain.SCMReviewThread{{ID: "thread-1", Comments: []domain.SCMReviewComment{{ID: "c1", Author: "alice"}}}}}}
 	if _, _, err := st.SaveSnapshot(ctx, snap); err != nil {
 		t.Fatal(err)
 	}
 	pullsBody := []byte(`[{"number":5,"html_url":"https://github.com/o/r/pull/5","head":{"ref":"feat/27"},"base":{"ref":"main"}}]`)
-	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRList, Key: "open"}, ETag: `"pulls"`, Value: pullsBody, UpdatedAt: time.Now()}); err != nil {
+	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRList, Key: "open-guard"}, ETag: `"pulls"`, Value: pullsBody, UpdatedAt: time.Now()}); err != nil {
 		t.Fatal(err)
 	}
 	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheCheckGuard, Key: "sha"}, ETag: `"checks"`, UpdatedAt: time.Now()}); err != nil {
@@ -190,6 +438,9 @@ func TestETagGuardsReuseLatestSnapshotAndSkipGraphQL(t *testing.T) {
 	}
 	if len(res.Snapshots) != 1 || res.Snapshots[0].Freshness != domain.SCMFreshnessUnchanged {
 		t.Fatalf("expected reused unchanged snapshot, got %+v", res.Snapshots)
+	}
+	if got := len(res.Snapshots[0].Review.UnresolvedThreads); got != 1 {
+		t.Fatalf("reused review threads=%d", got)
 	}
 }
 
@@ -262,6 +513,40 @@ func TestCommandCacheInvalidationsAreGitHubSpecific(t *testing.T) {
 	}
 }
 
+func TestMergeabilityIsConservativeForGitHubBlockers(t *testing.T) {
+	cases := []struct {
+		name       string
+		raw        string
+		mergeState string
+		draft      bool
+		blocker    string
+	}{
+		{name: "unknown", raw: "UNKNOWN", mergeState: "UNKNOWN", blocker: "merge status unknown (GitHub is computing)"},
+		{name: "empty", raw: "", mergeState: "", blocker: "merge status unknown (GitHub is computing)"},
+		{name: "blocked", raw: "MERGEABLE", mergeState: "BLOCKED", blocker: "merge blocked by branch protection"},
+		{name: "unstable", raw: "MERGEABLE", mergeState: "UNSTABLE", blocker: "required checks are failing"},
+		{name: "behind", raw: "MERGEABLE", mergeState: "BEHIND", blocker: "branch is behind base"},
+		{name: "conflict", raw: "CONFLICTING", mergeState: "DIRTY", blocker: "merge conflicts"},
+		{name: "draft", raw: "MERGEABLE", mergeState: "CLEAN", draft: true, blocker: "PR is still a draft"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := map[string]any{"mergeable": tc.raw, "mergeStateStatus": tc.mergeState, "isDraft": tc.draft}
+			got := mergeabilityFromGraphQL(pr, domain.SCMCI{Summary: "passing"}, domain.SCMReview{Decision: "approved"})
+			if got.Mergeable {
+				t.Fatalf("expected not mergeable: %+v", got)
+			}
+			if !containsString(got.Blockers, tc.blocker) {
+				t.Fatalf("missing blocker %q in %+v", tc.blocker, got.Blockers)
+			}
+		})
+	}
+	got := mergeabilityFromGraphQL(map[string]any{"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"}, domain.SCMCI{Summary: "passing"}, domain.SCMReview{Decision: "approved"})
+	if !got.Mergeable || len(got.Blockers) != 0 {
+		t.Fatalf("expected clean mergeable: %+v", got)
+	}
+}
+
 func observeReq(subj domain.SCMSubject) ports.SCMObserveRequest {
 	return ports.SCMObserveRequest{Subjects: []domain.SCMSubject{subj}, Now: time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)}
 }
@@ -304,4 +589,16 @@ func graphQLPRPayload(number int, branch, ciState, reviewDecision string, thread
 		"commits":          map[string]any{"nodes": []map[string]any{{"commit": commit}}},
 		"reviewThreads":    map[string]any{"nodes": threads},
 	}
+}
+
+func withCheckContexts(payload map[string]any, state string, contexts map[string]any) {
+	payload["commits"] = map[string]any{"nodes": []map[string]any{{"commit": map[string]any{"statusCheckRollup": map[string]any{"state": state, "contexts": contexts}}}}}
+}
+
+func numberedLines(n int) string {
+	var b strings.Builder
+	for i := 1; i <= n; i++ {
+		fmt.Fprintf(&b, "line-%02d\n", i)
+	}
+	return b.String()
 }

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -240,6 +240,28 @@ func TestGraphQLBatchIsCappedAtTwentyFivePRs(t *testing.T) {
 	}
 }
 
+func TestCommandCacheInvalidationsAreGitHubSpecific(t *testing.T) {
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 7}
+	prefixes := NewProvider(ProviderOptions{Token: StaticTokenSource("token")}).
+		CacheInvalidationPrefixes(subj, ports.SCMCommandMerge)
+	got := map[string]bool{}
+	for _, prefix := range prefixes {
+		got[prefix.Namespace] = true
+		if prefix.Provider != domain.SCMProviderGitHub || prefix.Repo != "o/r" {
+			t.Fatalf("bad prefix scope: %+v", prefix)
+		}
+	}
+	for _, namespace := range []string{cachePRList, cacheBranchMap, cacheChecks, cacheCheckGuard, cacheReviews} {
+		if !got[namespace] {
+			t.Fatalf("missing invalidation namespace %q in %+v", namespace, prefixes)
+		}
+	}
+	if got := NewProvider(ProviderOptions{Token: StaticTokenSource("token")}).
+		CacheInvalidationPrefixes(subj, ports.SCMCommandCheckout); got != nil {
+		t.Fatalf("checkout should not invalidate github caches: %+v", got)
+	}
+}
+
 func observeReq(subj domain.SCMSubject) ports.SCMObserveRequest {
 	return ports.SCMObserveRequest{Subjects: []domain.SCMSubject{subj}, Now: time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)}
 }

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -154,20 +154,81 @@ func TestTransportRateLimitLogsNormalizedKindAndHidesResponseBody(t *testing.T) 
 func TestGHTokenSourceMemoizesAndIgnoresGithubTokenEnv(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "env-token")
 	var calls atomic.Int32
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
 	src := &GHTokenSource{Command: func(context.Context) ([]byte, error) {
 		calls.Add(1)
 		return []byte("gh-token\n"), nil
-	}}
+	}, Clock: func() time.Time { return now }}
 	tok, err := src.Token(context.Background())
 	if err != nil || tok != "gh-token" {
 		t.Fatalf("token=%q err=%v", tok, err)
 	}
+	now = now.Add(defaultGHTokenCacheTTL - time.Second)
 	tok, err = src.Token(context.Background())
 	if err != nil || tok != "gh-token" {
 		t.Fatalf("second token=%q err=%v", tok, err)
 	}
 	if calls.Load() != 1 {
 		t.Fatalf("gh auth token calls=%d, want 1", calls.Load())
+	}
+}
+
+func TestGHTokenSourceRefreshesAfterTTL(t *testing.T) {
+	var calls atomic.Int32
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	src := &GHTokenSource{
+		TokenTTL: time.Minute,
+		Clock:    func() time.Time { return now },
+		Command: func(context.Context) ([]byte, error) {
+			return []byte(fmt.Sprintf("gh-token-%d\n", calls.Add(1))), nil
+		},
+	}
+	tok, err := src.Token(context.Background())
+	if err != nil || tok != "gh-token-1" {
+		t.Fatalf("token=%q err=%v", tok, err)
+	}
+	tok, err = src.Token(context.Background())
+	if err != nil || tok != "gh-token-1" {
+		t.Fatalf("cached token=%q err=%v", tok, err)
+	}
+	now = now.Add(time.Minute + time.Nanosecond)
+	tok, err = src.Token(context.Background())
+	if err != nil || tok != "gh-token-2" {
+		t.Fatalf("refreshed token=%q err=%v", tok, err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("gh auth token calls=%d, want 2", calls.Load())
+	}
+}
+
+func TestAuthFailureInvalidatesCachedGHToken(t *testing.T) {
+	var calls atomic.Int32
+	src := &GHTokenSource{Command: func(context.Context) ([]byte, error) {
+		return []byte(fmt.Sprintf("gh-token-%d\n", calls.Add(1))), nil
+	}}
+	var seen []string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Header.Get("Authorization"))
+		if len(seen) == 1 {
+			http.Error(w, `{"message":"Bad credentials"}`, http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+	c := NewClient(ClientOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: src})
+	if _, err := c.DoREST(context.Background(), http.MethodGet, "/x", nil, nil, "", "test.auth_failure"); err == nil {
+		t.Fatal("expected first request to fail auth")
+	}
+	if _, err := c.DoREST(context.Background(), http.MethodGet, "/x", nil, nil, "", "test.after_auth_failure"); err != nil {
+		t.Fatalf("second request should refetch token after auth failure: %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("gh auth token calls=%d, want 2", calls.Load())
+	}
+	if strings.Join(seen, ",") != "Bearer gh-token-1,Bearer gh-token-2" {
+		t.Fatalf("auth headers=%v", seen)
 	}
 }
 

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -94,7 +94,7 @@ func TestRotatedETagOn304UpdatesCacheOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
-	changed, _, err := p.checkOpenPullListChanged(ctx, st, scope, "o", "r", time.Now())
+	changed, _, _, err := p.checkOpenPullListChanged(ctx, st, scope, "o", "r", time.Now())
 	if err != nil || changed {
 		t.Fatalf("changed=%v err=%v", changed, err)
 	}
@@ -321,6 +321,9 @@ func TestTruncatedGraphQLCIContextsFetchFullCheckRuns(t *testing.T) {
 			})
 			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"repository": map[string]any{"pr5": payload}}})
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/check-runs"):
+			if got := r.URL.Query().Get("per_page"); got != "100" {
+				t.Fatalf("check-runs per_page=%q", got)
+			}
 			checkRunsCalls.Add(1)
 			_, _ = w.Write([]byte(`{"check_runs":[{"name":"late-failure","status":"completed","conclusion":"failure","html_url":"https://checks/late"}]}`))
 		case strings.Contains(r.URL.Path, "/comments"):
@@ -356,6 +359,9 @@ func TestFailingCIWithoutFailedContextFetchesFullCheckRuns(t *testing.T) {
 			})
 			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"repository": map[string]any{"pr5": payload}}})
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/check-runs"):
+			if got := r.URL.Query().Get("per_page"); got != "100" {
+				t.Fatalf("check-runs per_page=%q", got)
+			}
 			checkRunsCalls.Add(1)
 			_, _ = w.Write([]byte(`{"check_runs":[{"name":"hidden-failure","status":"completed","conclusion":"failure","html_url":"https://checks/hidden"}]}`))
 		case strings.Contains(r.URL.Path, "/comments"):
@@ -441,6 +447,185 @@ func TestETagGuardsReuseLatestSnapshotAndSkipGraphQL(t *testing.T) {
 	}
 	if got := len(res.Snapshots[0].Review.UnresolvedThreads); got != 1 {
 		t.Fatalf("reused review threads=%d", got)
+	}
+}
+
+func TestPRListGuardETagIsNotAdvancedWhenGraphQLFails(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls":
+			if got := r.Header.Get("If-None-Match"); got != `"old"` {
+				t.Fatalf("If-None-Match=%q", got)
+			}
+			w.Header().Set("ETag", `"new"`)
+			_, _ = w.Write([]byte(`[{"number":5}]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"boom"}`))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 5, CredentialHash: "cred"}
+	snap := domain.SCMSnapshot{SessionID: "s1", Subject: subj, Freshness: domain.SCMFreshnessFresh, PR: &domain.SCMPullRequest{Number: 5, State: domain.PROpen, HeadSHA: "sha"}, CI: domain.SCMCI{Summary: "passing"}}
+	if _, _, err := st.SaveSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRList, Key: "open-guard"}
+	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: `"old"`, Value: []byte(`[{"number":5}]`)}); err != nil {
+		t.Fatal(err)
+	}
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	if _, err := p.ObserveSessions(ctx, observeReq(subj), st); err == nil {
+		t.Fatal("expected GraphQL error")
+	}
+	got, ok, err := st.GetProviderCache(ctx, key)
+	if err != nil || !ok {
+		t.Fatalf("cache ok=%v err=%v", ok, err)
+	}
+	if got.ETag != `"old"` {
+		t.Fatalf("etag advanced on failed GraphQL: %q", got.ETag)
+	}
+}
+
+func TestReviewGuardETagIsNotAdvancedWhenReviewThreadsFail(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls":
+			w.Header().Set("ETag", `"pulls"`)
+			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/check-runs"):
+			w.Header().Set("ETag", `"checks"`)
+			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/comments"):
+			w.Header().Set("ETag", `"reviews-new"`)
+			_, _ = w.Write([]byte(`[{"id":1}]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			var req struct {
+				Query string `json:"query"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(req.Query, "reviewThreads") {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"message":"review down"}`))
+				return
+			}
+			writeGraphQLPR(t, w, 5, "feat/27", "SUCCESS", "APPROVED", nil)
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 5, CredentialHash: "cred"}
+	snap := domain.SCMSnapshot{SessionID: "s1", Subject: subj, Freshness: domain.SCMFreshnessFresh, PR: &domain.SCMPullRequest{Number: 5, State: domain.PROpen, HeadSHA: "sha"}, CI: domain.SCMCI{Summary: "passing"}, Review: domain.SCMReview{UnresolvedThreads: []domain.SCMReviewThread{{ID: "old"}}}}
+	if _, _, err := st.SaveSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range []domain.SCMProviderCacheEntry{
+		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRList, Key: "open-guard"}, ETag: `"pulls"`, Value: []byte(`[{"number":5}]`)},
+		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheCheckGuard, Key: "sha"}, ETag: `"checks"`},
+		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheReviews, Key: "5"}, ETag: `"reviews-old"`, Value: []byte(`[{"id":0}]`)},
+	} {
+		if err := st.PutProviderCache(ctx, entry); err != nil {
+			t.Fatal(err)
+		}
+	}
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	res, err := p.ObserveSessions(ctx, observeReq(subj), st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Snapshots) != 1 || len(res.Snapshots[0].Review.UnresolvedThreads) != 1 || res.Snapshots[0].Review.UnresolvedThreads[0].ID != "old" {
+		t.Fatalf("expected previous review threads, got %+v", res.Snapshots)
+	}
+	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheReviews, Key: "5"}
+	got, ok, err := st.GetProviderCache(ctx, key)
+	if err != nil || !ok {
+		t.Fatalf("cache ok=%v err=%v", ok, err)
+	}
+	if got.ETag != `"reviews-old"` {
+		t.Fatalf("review etag advanced on failed reviewThreads: %q", got.ETag)
+	}
+}
+
+func TestDiscoveryParseFailureDoesNotAdvanceCache(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/repos/o/r/pulls" {
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("ETag", `"new"`)
+		_, _ = w.Write([]byte(`not-json`))
+	}))
+	defer ts.Close()
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	scope := domain.SCMProviderCacheScope{Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", CredentialHash: "cred"}
+	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: cachePRList, Key: "open-discovery"}
+	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: `"old"`, Value: []byte(`[]`)}); err != nil {
+		t.Fatal(err)
+	}
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", CredentialHash: "cred"}
+	if _, err := p.ObserveSessions(ctx, observeReq(subj), st); err == nil {
+		t.Fatal("expected parse error")
+	}
+	got, ok, err := st.GetProviderCache(ctx, key)
+	if err != nil || !ok {
+		t.Fatalf("cache ok=%v err=%v", ok, err)
+	}
+	if got.ETag != `"old"` {
+		t.Fatalf("etag advanced on parse failure: %q", got.ETag)
+	}
+}
+
+func TestPollStateConsecutiveFailuresIncrementAndReset(t *testing.T) {
+	var fail atomic.Bool
+	fail.Store(true)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql" && fail.Load():
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"down"}`))
+			return
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			writeGraphQLPR(t, w, 5, "feat/27", "SUCCESS", "APPROVED", nil)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/comments"):
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 5}
+	for want := 1; want <= 2; want++ {
+		res, err := p.ObserveSessions(ctx, observeReq(subj), st)
+		if err == nil {
+			t.Fatal("expected failure")
+		}
+		if got := res.PollStates[0].ConsecutiveFail; got != want {
+			t.Fatalf("failure count=%d want=%d", got, want)
+		}
+		if err := st.PutPollState(ctx, res.PollStates[0]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fail.Store(false)
+	res, err := p.ObserveSessions(ctx, observeReq(subj), st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := res.PollStates[0].ConsecutiveFail; got != 0 {
+		t.Fatalf("failure count after success=%d", got)
 	}
 }
 

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -210,6 +210,39 @@ func TestBranchDiscoveryDoesNotCacheMisses(t *testing.T) {
 	}
 }
 
+func TestBranchDiscoverySkipsExactFallbackWhenPRListUnchanged(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls" && r.URL.Query().Get("head") == "":
+			if got := r.Header.Get("If-None-Match"); got != `"pulls"` {
+				t.Fatalf("If-None-Match=%q", got)
+			}
+			w.Header().Set("ETag", `"pulls"`)
+			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls" && r.URL.Query().Get("head") != "":
+			t.Fatalf("exact fallback should be skipped on unchanged PR list")
+		default:
+			t.Fatalf("unexpected %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+		}
+	}))
+	defer ts.Close()
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/missing", CredentialHash: "cred"}
+	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRList, Key: "open-discovery"}
+	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: `"pulls"`, Value: []byte(`[]`)}); err != nil {
+		t.Fatal(err)
+	}
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	res, err := p.ObserveSessions(ctx, observeReq(subj), st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Subjects) != 1 || res.Subjects[0].PRNumber != 0 {
+		t.Fatalf("subjects=%+v", res.Subjects)
+	}
+}
+
 func TestGraphQLBatchNormalizationReviewAndMergeability(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -401,12 +434,6 @@ func TestETagGuardsReuseLatestSnapshotAndSkipGraphQL(t *testing.T) {
 			}
 			w.Header().Set("ETag", `"checks"`)
 			w.WriteHeader(http.StatusNotModified)
-		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/comments"):
-			if got := r.Header.Get("If-None-Match"); got != `"reviews"` {
-				t.Fatalf("review guard If-None-Match = %q", got)
-			}
-			w.Header().Set("ETag", `"reviews"`)
-			w.WriteHeader(http.StatusNotModified)
 		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
 			graphQLCalls.Add(1)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -430,9 +457,7 @@ func TestETagGuardsReuseLatestSnapshotAndSkipGraphQL(t *testing.T) {
 	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheCheckGuard, Key: "sha"}, ETag: `"checks"`, UpdatedAt: time.Now()}); err != nil {
 		t.Fatal(err)
 	}
-	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheReviews, Key: "5"}, ETag: `"reviews"`, Value: []byte(`[]`), UpdatedAt: time.Now()}); err != nil {
-		t.Fatal(err)
-	}
+	putCachedReviewDetails(ctx, st, subj, "none", snap.Review.UnresolvedThreads, time.Date(2026, 5, 28, 11, 59, 0, 0, time.UTC))
 
 	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
 	res, err := p.ObserveSessions(ctx, observeReq(subj), st)
@@ -450,6 +475,193 @@ func TestETagGuardsReuseLatestSnapshotAndSkipGraphQL(t *testing.T) {
 	}
 }
 
+func TestReviewDetailsThrottleUsesCacheWithinTwoMinutes(t *testing.T) {
+	var graphQLCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls":
+			w.Header().Set("ETag", `"pulls"`)
+			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/check-runs"):
+			w.Header().Set("ETag", `"checks"`)
+			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/comments"):
+			t.Fatalf("review comments should be throttled")
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			graphQLCalls.Add(1)
+			t.Fatalf("GraphQL should be skipped")
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 5, CredentialHash: "cred"}
+	threads := []domain.SCMReviewThread{{ID: "thread-1", Comments: []domain.SCMReviewComment{{ID: "c1", Author: "alice"}}}}
+	snap := domain.SCMSnapshot{SessionID: "s1", Subject: subj, Freshness: domain.SCMFreshnessFresh, ObservedAt: now.Add(-time.Minute), PR: &domain.SCMPullRequest{Number: 5, State: domain.PROpen, HeadSHA: "sha"}, CI: domain.SCMCI{Summary: "passing"}, Review: domain.SCMReview{UnresolvedThreads: threads}}
+	if _, _, err := st.SaveSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range []domain.SCMProviderCacheEntry{
+		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRList, Key: "open-guard"}, ETag: `"pulls"`, Value: []byte(`[{"number":5}]`)},
+		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheCheckGuard, Key: "sha"}, ETag: `"checks"`},
+	} {
+		if err := st.PutProviderCache(ctx, entry); err != nil {
+			t.Fatal(err)
+		}
+	}
+	putCachedReviewDetails(ctx, st, subj, "none", threads, now.Add(-time.Minute))
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	res, err := p.ObserveSessions(ctx, ports.SCMObserveRequest{Subjects: []domain.SCMSubject{subj}, Now: now}, st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if graphQLCalls.Load() != 0 || len(res.Snapshots) != 1 || len(res.Snapshots[0].Review.UnresolvedThreads) != 1 {
+		t.Fatalf("calls=%d snapshots=%+v", graphQLCalls.Load(), res.Snapshots)
+	}
+}
+
+func TestReviewDetailsChecksETagAfterThrottleAndReusesOn304(t *testing.T) {
+	var commentCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls":
+			w.Header().Set("ETag", `"pulls"`)
+			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/check-runs"):
+			w.Header().Set("ETag", `"checks"`)
+			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/comments"):
+			commentCalls.Add(1)
+			if got := r.Header.Get("If-None-Match"); got != `"reviews"` {
+				t.Fatalf("review If-None-Match=%q", got)
+			}
+			w.Header().Set("ETag", `"reviews"`)
+			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			t.Fatalf("reviewThreads GraphQL should be skipped on 304")
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 5, CredentialHash: "cred"}
+	threads := []domain.SCMReviewThread{{ID: "thread-1", Comments: []domain.SCMReviewComment{{ID: "c1", Author: "alice"}}}}
+	snap := domain.SCMSnapshot{SessionID: "s1", Subject: subj, Freshness: domain.SCMFreshnessFresh, PR: &domain.SCMPullRequest{Number: 5, State: domain.PROpen, HeadSHA: "sha"}, CI: domain.SCMCI{Summary: "passing"}, Review: domain.SCMReview{UnresolvedThreads: threads}}
+	if _, _, err := st.SaveSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range []domain.SCMProviderCacheEntry{
+		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRList, Key: "open-guard"}, ETag: `"pulls"`, Value: []byte(`[{"number":5}]`)},
+		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheCheckGuard, Key: "sha"}, ETag: `"checks"`},
+		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheReviews, Key: "5"}, ETag: `"reviews"`, Value: []byte(`[{"id":1}]`)},
+	} {
+		if err := st.PutProviderCache(ctx, entry); err != nil {
+			t.Fatal(err)
+		}
+	}
+	putCachedReviewDetails(ctx, st, subj, "none", threads, now.Add(-3*time.Minute))
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	res, err := p.ObserveSessions(ctx, ports.SCMObserveRequest{Subjects: []domain.SCMSubject{subj}, Now: now}, st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if commentCalls.Load() != 1 || len(res.Snapshots[0].Review.UnresolvedThreads) != 1 {
+		t.Fatalf("commentCalls=%d snapshots=%+v", commentCalls.Load(), res.Snapshots)
+	}
+	_, entry, ok := getCachedReviewDetails(ctx, st, subj)
+	if !ok || !entry.UpdatedAt.Equal(now) {
+		t.Fatalf("review details cache not touched: ok=%v entry=%+v", ok, entry)
+	}
+}
+
+func TestReviewDecisionChangeBypassesReviewThrottle(t *testing.T) {
+	var reviewGraphQLCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls":
+			w.Header().Set("ETag", `"new-pulls"`)
+			_, _ = w.Write([]byte(`[{"number":5}]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			var req struct {
+				Query string `json:"query"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(req.Query, "reviewThreads") {
+				reviewGraphQLCalls.Add(1)
+				threads := []map[string]any{{"id": "thread-human", "isResolved": false, "comments": map[string]any{"nodes": []map[string]any{{"id": "c1", "body": "fix", "url": "https://example/comment", "path": "main.go", "line": 7, "author": map[string]any{"login": "alice", "__typename": "User"}}}}}}
+				_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"repository": map[string]any{"pullRequest": map[string]any{"reviewThreads": map[string]any{"nodes": threads}}}}})
+				return
+			}
+			writeGraphQLPR(t, w, 5, "feat/27", "SUCCESS", "CHANGES_REQUESTED", nil)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/comments"):
+			t.Fatalf("review decision change should force GraphQL directly")
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 5, CredentialHash: "cred"}
+	prev := domain.SCMSnapshot{SessionID: "s1", Subject: subj, Freshness: domain.SCMFreshnessFresh, PR: &domain.SCMPullRequest{Number: 5, State: domain.PROpen, HeadSHA: "sha"}, CI: domain.SCMCI{Summary: "passing"}, Review: domain.SCMReview{Decision: "none"}}
+	if _, _, err := st.SaveSnapshot(ctx, prev); err != nil {
+		t.Fatal(err)
+	}
+	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRList, Key: "open-guard"}
+	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: `"old"`, Value: []byte(`[{"number":5}]`)}); err != nil {
+		t.Fatal(err)
+	}
+	putCachedReviewDetails(ctx, st, subj, "none", nil, now.Add(-time.Minute))
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	res, err := p.ObserveSessions(ctx, ports.SCMObserveRequest{Subjects: []domain.SCMSubject{subj}, Now: now}, st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reviewGraphQLCalls.Load() != 1 || len(res.Snapshots[0].Review.HumanComments) != 1 {
+		t.Fatalf("reviewGraphQLCalls=%d snapshot=%+v", reviewGraphQLCalls.Load(), res.Snapshots[0].Review)
+	}
+}
+
+func TestGraphQLFailureFallsBackToTerminalPRState(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"down"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls/5":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"number":   5,
+				"state":    "closed",
+				"merged":   true,
+				"html_url": "https://github.com/o/r/pull/5",
+				"head":     map[string]any{"ref": "feat/27", "sha": "sha"},
+				"base":     map[string]any{"ref": "main"},
+			})
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 5}
+	res, err := p.ObserveSessions(context.Background(), observeReq(subj), store.NewMemoryStore())
+	if err == nil {
+		t.Fatal("expected GraphQL error to be reported")
+	}
+	if len(res.Snapshots) != 1 || res.Snapshots[0].PR == nil || res.Snapshots[0].PR.State != domain.PRMerged {
+		t.Fatalf("expected merged fallback snapshot, got %+v", res.Snapshots)
+	}
+}
+
 func TestPRListGuardETagIsNotAdvancedWhenGraphQLFails(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -462,6 +674,8 @@ func TestPRListGuardETagIsNotAdvancedWhenGraphQLFails(t *testing.T) {
 		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
 			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = w.Write([]byte(`{"message":"boom"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls/5":
+			_ = json.NewEncoder(w).Encode(map[string]any{"number": 5, "state": "open", "html_url": "https://github.com/o/r/pull/5", "head": map[string]any{"ref": "feat/27", "sha": "sha"}, "base": map[string]any{"ref": "main"}})
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
@@ -532,6 +746,7 @@ func TestReviewGuardETagIsNotAdvancedWhenReviewThreadsFail(t *testing.T) {
 		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRList, Key: "open-guard"}, ETag: `"pulls"`, Value: []byte(`[{"number":5}]`)},
 		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheCheckGuard, Key: "sha"}, ETag: `"checks"`},
 		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheReviews, Key: "5"}, ETag: `"reviews-old"`, Value: []byte(`[{"id":0}]`)},
+		{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheReviewDetails, Key: "5"}, Value: []byte(`{"threads":[{"id":"old"}]}`), UpdatedAt: time.Date(2026, 5, 28, 11, 0, 0, 0, time.UTC)},
 	} {
 		if err := st.PutProviderCache(ctx, entry); err != nil {
 			t.Fatal(err)
@@ -594,6 +809,8 @@ func TestPollStateConsecutiveFailuresIncrementAndReset(t *testing.T) {
 			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = w.Write([]byte(`{"message":"down"}`))
 			return
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls/5" && fail.Load():
+			_ = json.NewEncoder(w).Encode(map[string]any{"number": 5, "state": "open", "html_url": "https://github.com/o/r/pull/5", "head": map[string]any{"ref": "feat/27", "sha": "sha"}, "base": map[string]any{"ref": "main"}})
 		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
 			writeGraphQLPR(t, w, 5, "feat/27", "SUCCESS", "APPROVED", nil)
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/comments"):
@@ -687,7 +904,7 @@ func TestCommandCacheInvalidationsAreGitHubSpecific(t *testing.T) {
 			t.Fatalf("bad prefix scope: %+v", prefix)
 		}
 	}
-	for _, namespace := range []string{cachePRList, cacheBranchMap, cacheChecks, cacheCheckGuard, cacheReviews} {
+	for _, namespace := range []string{cachePRList, cacheBranchMap, cacheChecks, cacheCheckGuard, cacheReviews, cacheReviewDetails} {
 		if !got[namespace] {
 			t.Fatalf("missing invalidation namespace %q in %+v", namespace, prefixes)
 		}

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -1,10 +1,12 @@
 package github
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -15,6 +17,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	scmlog "github.com/aoagents/agent-orchestrator/backend/internal/scm/logging"
 	"github.com/aoagents/agent-orchestrator/backend/internal/scm/store"
 )
 
@@ -45,6 +48,107 @@ func TestRESTETag200And304(t *testing.T) {
 	if err != nil || !resp.NotModified {
 		t.Fatalf("second resp=%+v err=%v", resp, err)
 	}
+}
+
+func TestRESTTransportLogsUseNeutralFieldsAndDoNotLeakPayloads(t *testing.T) {
+	var logs bytes.Buffer
+	secretToken := "secret-token"
+	secretBody := "SECRET_COMMENT_BODY"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+secretToken {
+			t.Fatalf("auth header %q", got)
+		}
+		w.Header().Set("ETag", `"comment"`)
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Remaining", "4999")
+		w.Header().Set("X-RateLimit-Reset", "1780000000")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer ts.Close()
+	c := NewClient(ClientOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource(secretToken), Logger: githubJSONLogger(&logs)})
+	ctx := scmlog.WithCorrelationID(context.Background(), "corr-rest")
+	resp, err := c.DoREST(ctx, http.MethodPost, "/repos/o/r/issues/45/comments", nil, map[string]any{"body": secretBody}, "", "github.command.comment")
+	if err != nil || resp.StatusCode != http.StatusCreated {
+		t.Fatalf("resp=%+v err=%v", resp, err)
+	}
+	rawLogs := logs.String()
+	for _, secret := range []string{secretToken, "Authorization", secretBody} {
+		if strings.Contains(rawLogs, secret) {
+			t.Fatalf("transport logs leaked %q: %s", secret, rawLogs)
+		}
+	}
+	records := decodeGithubLogRecords(t, rawLogs)
+	request := findGithubLogRecord(t, records, scmlog.EventTransportRequest)
+	assertGithubLogField(t, request, scmlog.FieldCorrelationID, "corr-rest")
+	assertGithubLogField(t, request, scmlog.FieldProvider, "github")
+	assertGithubLogField(t, request, scmlog.FieldOperation, "github.command.comment")
+	assertGithubLogField(t, request, scmlog.FieldMethod, http.MethodPost)
+	assertGithubLogField(t, request, scmlog.FieldEndpointTemplate, "/repos/{owner}/{repo}/issues/{number}/comments")
+	response := findGithubLogRecord(t, records, scmlog.EventTransportResponse)
+	assertGithubLogNumber(t, response, scmlog.FieldStatusCode, http.StatusCreated)
+	assertGithubLogNumber(t, response, scmlog.FieldRateLimitRemaining, 4999)
+	assertGithubLogBool(t, response, scmlog.FieldETagPresent, true)
+	if _, ok := response["url"]; ok {
+		t.Fatalf("transport log should not include full url: %+v", response)
+	}
+}
+
+func TestGraphQLTransportLogsDoNotLeakQuery(t *testing.T) {
+	var logs bytes.Buffer
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/graphql" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"viewer": map[string]any{"login": "bot"}}})
+	}))
+	defer ts.Close()
+	c := NewClient(ClientOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token"), Logger: githubJSONLogger(&logs)})
+	secretQueryName := "SecretGraphQLQueryName"
+	if _, _, _, err := c.DoGraphQL(scmlog.WithCorrelationID(context.Background(), "corr-graphql"), "query "+secretQueryName+" { viewer { login } }", nil, "github.graphql_test"); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(logs.String(), secretQueryName) {
+		t.Fatalf("GraphQL query leaked into transport logs: %s", logs.String())
+	}
+	response := findGithubLogRecord(t, decodeGithubLogRecords(t, logs.String()), scmlog.EventTransportResponse)
+	assertGithubLogField(t, response, scmlog.FieldEndpointTemplate, "/graphql")
+	assertGithubLogField(t, response, scmlog.FieldMethod, http.MethodPost)
+	assertGithubLogField(t, response, scmlog.FieldCorrelationID, "corr-graphql")
+}
+
+func TestTransportRateLimitLogsNormalizedKindAndHidesResponseBody(t *testing.T) {
+	var logs bytes.Buffer
+	secretTail := "CI_LOG_TAIL_SECRET"
+	reset := time.Date(2026, 5, 28, 13, 0, 0, 0, time.UTC).Unix()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(reset, 10))
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(secretTail + "\nline 1\nline 2"))
+	}))
+	defer ts.Close()
+	c := NewClient(ClientOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token"), Logger: githubJSONLogger(&logs)})
+	resp, err := c.DoREST(scmlog.WithCorrelationID(context.Background(), "corr-rate"), http.MethodGet, "/repos/o/r/pulls/45", nil, nil, "", "github.pr_get")
+	if err == nil {
+		t.Fatal("expected rate limit error")
+	}
+	var scmErr *domain.SCMError
+	if !errors.As(err, &scmErr) || scmErr.Kind != domain.SCMErrorRateLimited || scmErr.Message != http.StatusText(http.StatusForbidden) {
+		t.Fatalf("err=%T %[1]v", err)
+	}
+	if strings.Contains(resp.Diagnostic.Message, secretTail) {
+		t.Fatalf("transport diagnostic leaked response body: %+v", resp.Diagnostic)
+	}
+	if strings.Contains(logs.String(), secretTail) {
+		t.Fatalf("response body leaked into transport logs: %s", logs.String())
+	}
+	rateLimited := findGithubLogRecord(t, decodeGithubLogRecords(t, logs.String()), scmlog.EventTransportRateLimited)
+	assertGithubLogField(t, rateLimited, scmlog.FieldCorrelationID, "corr-rate")
+	assertGithubLogField(t, rateLimited, scmlog.FieldErrorKind, string(domain.SCMErrorRateLimited))
+	assertGithubLogNumber(t, rateLimited, scmlog.FieldStatusCode, http.StatusForbidden)
+	assertGithubLogNumber(t, rateLimited, scmlog.FieldRateLimitRemaining, 0)
 }
 
 func TestGHTokenSourceMemoizesAndIgnoresGithubTokenEnv(t *testing.T) {
@@ -299,6 +403,9 @@ func TestGraphQLBatchNormalizationReviewAndMergeability(t *testing.T) {
 	}
 	if !s.Mergeability.Mergeable {
 		t.Fatalf("expected mergeable: %+v", s.Mergeability)
+	}
+	if len(s.Diagnostics) != 0 {
+		t.Fatalf("successful snapshot should not persist transport diagnostics: %+v", s.Diagnostics)
 	}
 }
 
@@ -1242,4 +1349,58 @@ func numberedLines(n int) string {
 		fmt.Fprintf(&b, "line-%02d\n", i)
 	}
 	return b.String()
+}
+
+func githubJSONLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func decodeGithubLogRecords(t *testing.T, raw string) []map[string]any {
+	t.Helper()
+	lines := bytes.Split([]byte(raw), []byte("\n"))
+	records := make([]map[string]any, 0, len(lines))
+	for _, line := range lines {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal(line, &rec); err != nil {
+			t.Fatalf("decode log %s: %v", line, err)
+		}
+		records = append(records, rec)
+	}
+	return records
+}
+
+func findGithubLogRecord(t *testing.T, records []map[string]any, msg string) map[string]any {
+	t.Helper()
+	for _, rec := range records {
+		if rec["msg"] == msg {
+			return rec
+		}
+	}
+	t.Fatalf("missing log %q in %+v", msg, records)
+	return nil
+}
+
+func assertGithubLogField(t *testing.T, rec map[string]any, key, want string) {
+	t.Helper()
+	if got, _ := rec[key].(string); got != want {
+		t.Fatalf("%s=%q want %q in %+v", key, got, want, rec)
+	}
+}
+
+func assertGithubLogNumber(t *testing.T, rec map[string]any, key string, want float64) {
+	t.Helper()
+	if got, _ := rec[key].(float64); got != want {
+		t.Fatalf("%s=%v want %v in %+v", key, rec[key], want, rec)
+	}
+}
+
+func assertGithubLogBool(t *testing.T, rec map[string]any, key string, want bool) {
+	t.Helper()
+	if got, _ := rec[key].(bool); got != want {
+		t.Fatalf("%s=%v want %v in %+v", key, rec[key], want, rec)
+	}
 }

--- a/backend/internal/adapters/scm/github/provider_test.go
+++ b/backend/internal/adapters/scm/github/provider_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -87,15 +88,23 @@ func TestGraphQLBatchNormalizationReviewAndMergeability(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
-			threads := []map[string]any{
-				{"id": "human-thread", "isResolved": false, "path": "main.go", "line": 12, "comments": map[string]any{"nodes": []map[string]any{{"id": "c1", "body": "please change", "url": "https://example/comment", "author": map[string]any{"__typename": "User", "login": "alice"}}}}},
-				{"id": "bot-thread", "isResolved": false, "path": "lint.go", "line": 1, "comments": map[string]any{"nodes": []map[string]any{{"id": "c2", "body": "lint", "url": "https://example/bot", "author": map[string]any{"__typename": "Bot", "login": "review-bot"}}}}},
+			var req struct {
+				Query string `json:"query"`
 			}
-			writeGraphQLPR(t, w, 5, "feat/27", "SUCCESS", "APPROVED", threads)
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(req.Query, "reviewThreads") || strings.Contains(req.Query, "comments(first") {
+				t.Fatalf("main batch query should not fetch review threads/comments: %s", req.Query)
+			}
+			if !strings.Contains(req.Query, "contexts(first:20)") {
+				t.Fatalf("main batch query should request contexts(first:20): %s", req.Query)
+			}
+			writeGraphQLPR(t, w, 5, "feat/27", "SUCCESS", "APPROVED", nil)
 		case strings.Contains(r.URL.Path, "/check-runs"):
 			_, _ = w.Write([]byte(`{"check_runs":[{"name":"test","status":"completed","conclusion":"success","html_url":"https://checks"}]}`))
 		case strings.Contains(r.URL.Path, "/comments"):
-			_, _ = w.Write([]byte(`[]`))
+			_, _ = w.Write([]byte(`[{"id":1,"body":"please change","html_url":"https://example/comment","path":"main.go","line":12,"pull_request_review_id":10,"user":{"login":"alice","type":"User"}},{"id":2,"body":"lint","html_url":"https://example/bot","path":"lint.go","line":1,"pull_request_review_id":11,"user":{"login":"review-bot","type":"Bot"}}]`))
 		default:
 			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
 		}
@@ -122,23 +131,155 @@ func TestGraphQLBatchNormalizationReviewAndMergeability(t *testing.T) {
 	}
 }
 
+func TestETagGuardsReuseLatestSnapshotAndSkipGraphQL(t *testing.T) {
+	var graphQLCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/o/r/pulls":
+			if got := r.Header.Get("If-None-Match"); got != `"pulls"` {
+				t.Fatalf("pr-list If-None-Match = %q", got)
+			}
+			w.Header().Set("ETag", `"pulls"`)
+			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/check-runs"):
+			if got := r.Header.Get("If-None-Match"); got != `"checks"` {
+				t.Fatalf("check guard If-None-Match = %q", got)
+			}
+			w.Header().Set("ETag", `"checks"`)
+			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/comments"):
+			if got := r.Header.Get("If-None-Match"); got != `"reviews"` {
+				t.Fatalf("review guard If-None-Match = %q", got)
+			}
+			w.Header().Set("ETag", `"reviews"`)
+			w.WriteHeader(http.StatusNotModified)
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			graphQLCalls.Add(1)
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 5, CredentialHash: "cred"}
+	snap := domain.SCMSnapshot{SessionID: "s1", Subject: subj, Freshness: domain.SCMFreshnessFresh, ObservedAt: time.Date(2026, 5, 28, 11, 0, 0, 0, time.UTC), PR: &domain.SCMPullRequest{Number: 5, URL: "https://github.com/o/r/pull/5", State: domain.PROpen, HeadSHA: "sha"}, CI: domain.SCMCI{Summary: "passing"}}
+	if _, _, err := st.SaveSnapshot(ctx, snap); err != nil {
+		t.Fatal(err)
+	}
+	pullsBody := []byte(`[{"number":5,"html_url":"https://github.com/o/r/pull/5","head":{"ref":"feat/27"},"base":{"ref":"main"}}]`)
+	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cachePRList, Key: "open"}, ETag: `"pulls"`, Value: pullsBody, UpdatedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheCheckGuard, Key: "sha"}, ETag: `"checks"`, UpdatedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: cacheReviews, Key: "5"}, ETag: `"reviews"`, Value: []byte(`[]`), UpdatedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	res, err := p.ObserveSessions(ctx, observeReq(subj), st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if graphQLCalls.Load() != 0 {
+		t.Fatalf("GraphQL should have been skipped, calls=%d", graphQLCalls.Load())
+	}
+	if len(res.Snapshots) != 1 || res.Snapshots[0].Freshness != domain.SCMFreshnessUnchanged {
+		t.Fatalf("expected reused unchanged snapshot, got %+v", res.Snapshots)
+	}
+}
+
+func TestGraphQLBatchIsCappedAtTwentyFivePRs(t *testing.T) {
+	var graphQLCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/graphql":
+			graphQLCalls.Add(1)
+			var req struct {
+				Query string `json:"query"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatal(err)
+			}
+			if n := strings.Count(req.Query, "pullRequest(number:"); n > maxGraphQLBatchSize {
+				t.Fatalf("batch contained %d PRs, want <= %d", n, maxGraphQLBatchSize)
+			}
+			repo := map[string]any{}
+			for i := 1; i <= 26; i++ {
+				alias := fmt.Sprintf("pr%d", i)
+				if strings.Contains(req.Query, alias+": pullRequest") {
+					repo[alias] = graphQLPRPayload(i, fmt.Sprintf("feat/%d", i), "SUCCESS", "APPROVED", nil)
+				}
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"repository": repo, "rateLimit": map[string]any{"limit": 5000, "remaining": 4999, "resetAt": "2026-05-28T13:00:00Z"}}})
+		case strings.Contains(r.URL.Path, "/comments"):
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+	p := NewProvider(ProviderOptions{RESTBase: ts.URL, GraphQLURL: ts.URL + "/graphql", Token: StaticTokenSource("token")})
+	subjects := make([]domain.SCMSubject, 0, 26)
+	for i := 1; i <= 26; i++ {
+		subjects = append(subjects, domain.SCMSubject{SessionID: domain.SessionID(fmt.Sprintf("s%d", i)), ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: fmt.Sprintf("feat/%d", i), PRNumber: i})
+	}
+	res, err := p.ObserveSessions(context.Background(), ports.SCMObserveRequest{Subjects: subjects, Now: time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)}, store.NewMemoryStore())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if graphQLCalls.Load() != 2 {
+		t.Fatalf("GraphQL calls=%d, want 2", graphQLCalls.Load())
+	}
+	if len(res.Snapshots) != 26 {
+		t.Fatalf("snapshots=%d", len(res.Snapshots))
+	}
+}
+
 func observeReq(subj domain.SCMSubject) ports.SCMObserveRequest {
 	return ports.SCMObserveRequest{Subjects: []domain.SCMSubject{subj}, Now: time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)}
 }
 
 func writeGraphQLPR(t *testing.T, w http.ResponseWriter, number int, branch, ciState, reviewDecision string, threads []map[string]any) {
 	t.Helper()
+	alias := "pr" + strconv.Itoa(number)
+	resp := map[string]any{"data": map[string]any{"repository": map[string]any{alias: graphQLPRPayload(number, branch, ciState, reviewDecision, threads)}, "rateLimit": map[string]any{"limit": 5000, "remaining": 4999, "resetAt": "2026-05-28T13:00:00Z"}}}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func graphQLPRPayload(number int, branch, ciState, reviewDecision string, threads []map[string]any) map[string]any {
 	if threads == nil {
 		threads = []map[string]any{}
 	}
-	alias := "pr" + strconv.Itoa(number)
-	resp := map[string]any{"data": map[string]any{"repository": map[string]any{alias: map[string]any{
-		"number": number, "title": "PR", "url": "https://github.com/o/r/pull/" + strconv.Itoa(number), "state": "OPEN", "isDraft": false, "merged": false, "closed": false,
-		"headRefName": branch, "baseRefName": "main", "headRefOid": "sha", "additions": 1, "deletions": 2, "mergeable": "MERGEABLE", "reviewDecision": reviewDecision, "mergeStateStatus": "CLEAN",
-		"commits":       map[string]any{"nodes": []map[string]any{{"commit": map[string]any{"statusCheckRollup": map[string]any{"state": ciState, "contexts": map[string]any{"nodes": []map[string]any{{"__typename": "CheckRun", "name": "test", "status": "COMPLETED", "conclusion": "SUCCESS", "detailsUrl": "https://checks"}}}}}}}},
-		"reviewThreads": map[string]any{"nodes": threads},
-	}}, "rateLimit": map[string]any{"limit": 5000, "remaining": 4999, "resetAt": "2026-05-28T13:00:00Z"}}}
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		t.Fatal(err)
+	contexts := map[string]any{
+		"nodes":    []map[string]any{{"__typename": "CheckRun", "name": "test", "status": "COMPLETED", "conclusion": "SUCCESS", "detailsUrl": "https://checks"}},
+		"pageInfo": map[string]any{"hasNextPage": false},
+	}
+	rollup := map[string]any{"state": ciState, "contexts": contexts}
+	commit := map[string]any{"statusCheckRollup": rollup}
+	return map[string]any{
+		"number":           number,
+		"title":            "PR",
+		"url":              "https://github.com/o/r/pull/" + strconv.Itoa(number),
+		"state":            "OPEN",
+		"isDraft":          false,
+		"merged":           false,
+		"closed":           false,
+		"headRefName":      branch,
+		"baseRefName":      "main",
+		"headRefOid":       "sha",
+		"additions":        1,
+		"deletions":        2,
+		"mergeable":        "MERGEABLE",
+		"reviewDecision":   reviewDecision,
+		"mergeStateStatus": "CLEAN",
+		"commits":          map[string]any{"nodes": []map[string]any{{"commit": commit}}},
+		"reviewThreads":    map[string]any{"nodes": threads},
 	}
 }

--- a/backend/internal/cdc/event.go
+++ b/backend/internal/cdc/event.go
@@ -23,6 +23,8 @@ const (
 	EventPRCreated           EventType = "pr_created"
 	EventPRUpdated           EventType = "pr_updated"
 	EventPRCheckRecorded     EventType = "pr_check_recorded"
+	EventPRCommentRecorded   EventType = "pr_comment_recorded"
+	EventSCMSnapshotCreated  EventType = "scm_snapshot_created"
 	EventNotificationCreated EventType = "notification_created"
 	EventNotificationUpdated EventType = "notification_updated"
 )

--- a/backend/internal/domain/scm.go
+++ b/backend/internal/domain/scm.go
@@ -1,0 +1,436 @@
+package domain
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// SCMProvider identifies a source-control provider implementation. The Go
+// rewrite intentionally starts with GitHub as the first real provider, but the
+// normalized data model keeps the provider/host/repo identity explicit so later
+// providers cannot accidentally key by PR number alone.
+type SCMProvider string
+
+const (
+	SCMProviderGitHub SCMProvider = "github"
+)
+
+// SCMFreshness describes whether an observation fetched current provider truth,
+// reused cache because the provider returned 304, or could not fetch. The LCM
+// projection treats FreshnessUnavailable as Fetched=false so stale/unavailable
+// data never overwrites known lifecycle truth.
+type SCMFreshness string
+
+const (
+	SCMFreshnessFresh       SCMFreshness = "fresh"
+	SCMFreshnessUnchanged   SCMFreshness = "unchanged"
+	SCMFreshnessUnavailable SCMFreshness = "unavailable"
+)
+
+// SCMErrorKind is the normalized provider error vocabulary used in snapshots,
+// diagnostics and poll state. Provider adapters should wrap low-level failures
+// into one of these stable categories.
+type SCMErrorKind string
+
+const (
+	SCMErrorAuthFailed  SCMErrorKind = "auth_failed"
+	SCMErrorRateLimited SCMErrorKind = "rate_limited"
+	SCMErrorNotFound    SCMErrorKind = "not_found"
+	SCMErrorNetwork     SCMErrorKind = "network_error"
+	SCMErrorParse       SCMErrorKind = "parse_error"
+	SCMErrorUnsupported SCMErrorKind = "unsupported"
+	SCMErrorUnavailable SCMErrorKind = "unavailable"
+	SCMErrorCommand     SCMErrorKind = "command_error"
+)
+
+// SCMError is returned by providers and commands when a provider-specific
+// failure needs to cross a package boundary in normalized form.
+type SCMError struct {
+	Kind       SCMErrorKind `json:"kind"`
+	Operation  string       `json:"operation,omitempty"`
+	StatusCode int          `json:"statusCode,omitempty"`
+	RetryAfter time.Time    `json:"retryAfter,omitempty"`
+	Message    string       `json:"message"`
+	Cause      error        `json:"-"`
+}
+
+func (e *SCMError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	parts := []string{string(e.Kind)}
+	if e.Operation != "" {
+		parts = append(parts, e.Operation)
+	}
+	if e.StatusCode != 0 {
+		parts = append(parts, fmt.Sprintf("status=%d", e.StatusCode))
+	}
+	if e.Message != "" {
+		parts = append(parts, e.Message)
+	}
+	if e.Cause != nil {
+		parts = append(parts, e.Cause.Error())
+	}
+	return strings.Join(parts, ": ")
+}
+
+func (e *SCMError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+// SCMRepository is a globally-stable repository identity. Repo is owner/name.
+type SCMRepository struct {
+	Provider SCMProvider `json:"provider"`
+	Host     string      `json:"host"`
+	Repo     string      `json:"repo"`
+}
+
+func (r SCMRepository) Key() string {
+	return strings.Join([]string{string(r.Provider), normalizeHost(r.Host), strings.ToLower(r.Repo)}, "|")
+}
+
+func (r SCMRepository) OwnerName() (owner, name string) {
+	parts := strings.SplitN(r.Repo, "/", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "", r.Repo
+}
+
+func normalizeHost(h string) string {
+	h = strings.TrimSpace(strings.ToLower(h))
+	h = strings.TrimPrefix(h, "https://")
+	h = strings.TrimPrefix(h, "http://")
+	return strings.TrimSuffix(h, "/")
+}
+
+// SCMChangeRequestID prevents PR-number-only identity bugs.
+type SCMChangeRequestID struct {
+	Provider SCMProvider `json:"provider"`
+	Host     string      `json:"host"`
+	Repo     string      `json:"repo"`
+	Number   int         `json:"number"`
+}
+
+func (id SCMChangeRequestID) Key() string {
+	return strings.Join([]string{string(id.Provider), normalizeHost(id.Host), strings.ToLower(id.Repo), fmt.Sprintf("%d", id.Number)}, "|")
+}
+
+// PRState is the provider-normalized change-request state used in SCM
+// snapshots. It is intentionally separate from the session lifecycle state.
+type PRState string
+
+const (
+	PRNone   PRState = "none"
+	PROpen   PRState = "open"
+	PRDraft  PRState = "draft"
+	PRMerged PRState = "merged"
+	PRClosed PRState = "closed"
+)
+
+// SCMSubject binds an orchestrator session to a source branch and, once known,
+// to a concrete change request. CredentialHash is deliberately part of cache
+// scoping but not of PR identity.
+type SCMSubject struct {
+	SessionID      SessionID   `json:"sessionId"`
+	ProjectID      ProjectID   `json:"projectId"`
+	Provider       SCMProvider `json:"provider"`
+	Host           string      `json:"host"`
+	Repo           string      `json:"repo"`
+	Branch         string      `json:"branch"`
+	BaseBranch     string      `json:"baseBranch,omitempty"`
+	CredentialHash string      `json:"credentialHash,omitempty"`
+	PRNumber       int         `json:"prNumber,omitempty"`
+	PRURL          string      `json:"prUrl,omitempty"`
+	CreatedAt      time.Time   `json:"createdAt,omitempty"`
+	UpdatedAt      time.Time   `json:"updatedAt,omitempty"`
+}
+
+func (s SCMSubject) Repository() SCMRepository {
+	return SCMRepository{Provider: s.Provider, Host: s.Host, Repo: s.Repo}
+}
+
+func (s SCMSubject) ChangeRequestID() SCMChangeRequestID {
+	return SCMChangeRequestID{Provider: s.Provider, Host: s.Host, Repo: s.Repo, Number: s.PRNumber}
+}
+
+func (s SCMSubject) SubjectKey() string { return string(s.SessionID) }
+
+func (s SCMSubject) CacheScope() SCMProviderCacheScope {
+	return SCMProviderCacheScope{Provider: s.Provider, Host: s.Host, Repo: s.Repo, CredentialHash: s.CredentialHash}
+}
+
+// SCMSubjectFilter is used by stores/read models to find bindings.
+type SCMSubjectFilter struct {
+	ProjectID ProjectID
+	Provider  SCMProvider
+	Host      string
+	Repo      string
+}
+
+// SCMSnapshot is the latest normalized provider truth for a session. Revision is
+// assigned by the SCMStore and increments only when SemanticHash changes.
+type SCMSnapshot struct {
+	SessionID    SessionID       `json:"sessionId"`
+	Subject      SCMSubject      `json:"subject"`
+	Revision     int64           `json:"revision"`
+	SemanticHash string          `json:"semanticHash"`
+	Freshness    SCMFreshness    `json:"freshness"`
+	ObservedAt   time.Time       `json:"observedAt"`
+	PR           *SCMPullRequest `json:"pr,omitempty"`
+	CI           SCMCI           `json:"ci"`
+	Review       SCMReview       `json:"review"`
+	Mergeability SCMMergeability `json:"mergeability"`
+	RateLimit    *SCMRateLimit   `json:"rateLimit,omitempty"`
+	Diagnostics  []SCMDiagnostic `json:"diagnostics,omitempty"`
+}
+
+func (s SCMSnapshot) ChangeRequestID() SCMChangeRequestID {
+	if s.PR != nil && s.PR.Number > 0 {
+		return SCMChangeRequestID{Provider: s.Subject.Provider, Host: s.Subject.Host, Repo: s.Subject.Repo, Number: s.PR.Number}
+	}
+	return s.Subject.ChangeRequestID()
+}
+
+// SCMPullRequest holds provider-normalized PR metadata.
+type SCMPullRequest struct {
+	ID           SCMChangeRequestID `json:"id"`
+	Number       int                `json:"number"`
+	URL          string             `json:"url"`
+	Title        string             `json:"title,omitempty"`
+	State        PRState            `json:"state"`
+	Draft        bool               `json:"draft"`
+	Merged       bool               `json:"merged"`
+	SourceBranch string             `json:"sourceBranch"`
+	TargetBranch string             `json:"targetBranch"`
+	HeadSHA      string             `json:"headSha,omitempty"`
+	Additions    int                `json:"additions,omitempty"`
+	Deletions    int                `json:"deletions,omitempty"`
+}
+
+// SCMCI summarizes checks. Summary values intentionally mirror ports.CISummary
+// strings without importing ports into domain.
+type SCMCI struct {
+	Summary        string     `json:"summary"`
+	Checks         []SCMCheck `json:"checks,omitempty"`
+	FailureLogTail string     `json:"failureLogTail,omitempty"`
+}
+
+type SCMCheck struct {
+	Name       string `json:"name"`
+	Status     string `json:"status,omitempty"`
+	Conclusion string `json:"conclusion,omitempty"`
+	URL        string `json:"url,omitempty"`
+	Details    string `json:"details,omitempty"`
+	LogTail    string `json:"logTail,omitempty"`
+}
+
+// SCMReview captures both aggregate review decision and unresolved threads. A
+// thread is classified as bot when all unresolved comments in it are bot-authored;
+// mixed or human comments keep IsBot=false so humans outrank bots.
+type SCMReview struct {
+	Decision          string            `json:"decision"`
+	UnresolvedThreads []SCMReviewThread `json:"unresolvedThreads,omitempty"`
+	BotComments       []SCMReviewThread `json:"botComments,omitempty"`
+	HumanComments     []SCMReviewThread `json:"humanComments,omitempty"`
+}
+
+type SCMReviewThread struct {
+	ID       string             `json:"id"`
+	Path     string             `json:"path,omitempty"`
+	Line     int                `json:"line,omitempty"`
+	URL      string             `json:"url,omitempty"`
+	IsBot    bool               `json:"isBot"`
+	Comments []SCMReviewComment `json:"comments,omitempty"`
+}
+
+type SCMReviewComment struct {
+	ID       string `json:"id,omitempty"`
+	Author   string `json:"author,omitempty"`
+	Body     string `json:"body,omitempty"`
+	URL      string `json:"url,omitempty"`
+	IsBot    bool   `json:"isBot"`
+	Path     string `json:"path,omitempty"`
+	Line     int    `json:"line,omitempty"`
+	ThreadID string `json:"threadId,omitempty"`
+}
+
+type SCMMergeability struct {
+	Mergeable   bool     `json:"mergeable"`
+	CIPassing   bool     `json:"ciPassing"`
+	Approved    bool     `json:"approved"`
+	NoConflicts bool     `json:"noConflicts"`
+	BehindBase  bool     `json:"behindBase,omitempty"`
+	Conflict    bool     `json:"conflict,omitempty"`
+	Blockers    []string `json:"blockers,omitempty"`
+	RawState    string   `json:"rawState,omitempty"`
+	MergeState  string   `json:"mergeState,omitempty"`
+}
+
+type SCMRateLimit struct {
+	Limit     int       `json:"limit,omitempty"`
+	Remaining int       `json:"remaining,omitempty"`
+	ResetAt   time.Time `json:"resetAt,omitempty"`
+	Resource  string    `json:"resource,omitempty"`
+}
+
+type SCMDiagnostic struct {
+	Operation  string       `json:"operation"`
+	StatusCode int          `json:"statusCode,omitempty"`
+	ErrorKind  SCMErrorKind `json:"errorKind,omitempty"`
+	Message    string       `json:"message,omitempty"`
+	ETag       string       `json:"etag,omitempty"`
+	CacheHit   bool         `json:"cacheHit,omitempty"`
+	StartedAt  time.Time    `json:"startedAt,omitempty"`
+	DurationMS int64        `json:"durationMs,omitempty"`
+}
+
+// Provider cache keys are scoped by provider+host+repo+credential hash, with a
+// namespace/key inside that scope for ETags and opaque provider hints.
+type SCMProviderCacheScope struct {
+	Provider       SCMProvider `json:"provider"`
+	Host           string      `json:"host"`
+	Repo           string      `json:"repo"`
+	CredentialHash string      `json:"credentialHash,omitempty"`
+}
+
+func (s SCMProviderCacheScope) ScopeKey() string {
+	return strings.Join([]string{string(s.Provider), normalizeHost(s.Host), strings.ToLower(s.Repo), s.CredentialHash}, "|")
+}
+
+type SCMProviderCacheKey struct {
+	SCMProviderCacheScope
+	Namespace string `json:"namespace"`
+	Key       string `json:"key"`
+}
+
+func (k SCMProviderCacheKey) String() string {
+	return k.ScopeKey() + "|" + k.Namespace + "|" + k.Key
+}
+
+type SCMProviderCachePrefix struct {
+	SCMProviderCacheScope
+	Namespace string `json:"namespace,omitempty"`
+	KeyPrefix string `json:"keyPrefix,omitempty"`
+}
+
+func (p SCMProviderCachePrefix) Matches(k SCMProviderCacheKey) bool {
+	if p.Provider != "" && p.Provider != k.Provider {
+		return false
+	}
+	if p.Host != "" && normalizeHost(p.Host) != normalizeHost(k.Host) {
+		return false
+	}
+	if p.Repo != "" && strings.ToLower(p.Repo) != strings.ToLower(k.Repo) {
+		return false
+	}
+	if p.CredentialHash != "" && p.CredentialHash != k.CredentialHash {
+		return false
+	}
+	if p.Namespace != "" && p.Namespace != k.Namespace {
+		return false
+	}
+	if p.KeyPrefix != "" && !strings.HasPrefix(k.Key, p.KeyPrefix) {
+		return false
+	}
+	return true
+}
+
+type SCMProviderCacheEntry struct {
+	Key       SCMProviderCacheKey `json:"key"`
+	ETag      string              `json:"etag,omitempty"`
+	Value     json.RawMessage     `json:"value,omitempty"`
+	UpdatedAt time.Time           `json:"updatedAt"`
+	ExpiresAt time.Time           `json:"expiresAt,omitempty"`
+}
+
+func (e SCMProviderCacheEntry) Expired(now time.Time) bool {
+	return !e.ExpiresAt.IsZero() && !now.Before(e.ExpiresAt)
+}
+
+type SCMPollStateKey struct {
+	Provider SCMProvider `json:"provider"`
+	Host     string      `json:"host"`
+	Repo     string      `json:"repo"`
+}
+
+func (k SCMPollStateKey) String() string {
+	return strings.Join([]string{string(k.Provider), normalizeHost(k.Host), strings.ToLower(k.Repo)}, "|")
+}
+
+type SCMPollState struct {
+	Key             SCMPollStateKey `json:"key"`
+	ConsecutiveFail int             `json:"consecutiveFailures"`
+	LastSuccessAt   time.Time       `json:"lastSuccessAt,omitempty"`
+	LastFailureAt   time.Time       `json:"lastFailureAt,omitempty"`
+	BackoffUntil    time.Time       `json:"backoffUntil,omitempty"`
+	RateLimitUntil  time.Time       `json:"rateLimitUntil,omitempty"`
+	LastError       *SCMError       `json:"lastError,omitempty"`
+}
+
+// ComputeSCMSemanticHash hashes provider truth while deliberately ignoring
+// observation mechanics (ObservedAt, Revision, diagnostics, rate-limit data).
+// Stores use this to decide whether a new snapshot revision is warranted.
+func ComputeSCMSemanticHash(s SCMSnapshot) (string, error) {
+	s.Revision = 0
+	s.SemanticHash = ""
+	s.ObservedAt = time.Time{}
+	s.Subject.CreatedAt = time.Time{}
+	s.Subject.UpdatedAt = time.Time{}
+	if s.Freshness == SCMFreshnessUnchanged {
+		s.Freshness = SCMFreshnessFresh
+	}
+	s.Diagnostics = nil
+	s.RateLimit = nil
+	b, err := json.Marshal(s)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func MustSCMSemanticHash(s SCMSnapshot) string {
+	h, err := ComputeSCMSemanticHash(s)
+	if err != nil {
+		panic(err)
+	}
+	return h
+}
+
+func NormalizeSCMCI(summary string) string {
+	switch strings.ToLower(summary) {
+	case "success", "successful", "passed", "passing", "pass":
+		return "passing"
+	case "failure", "failed", "failing", "error", "timed_out", "cancelled", "action_required":
+		return "failing"
+	case "pending", "queued", "in_progress", "requested", "waiting", "expected":
+		return "pending"
+	case "", "none", "no_checks":
+		return "none"
+	default:
+		return strings.ToLower(summary)
+	}
+}
+
+func NormalizeSCMReviewDecision(decision string) string {
+	switch strings.ToUpper(strings.TrimSpace(decision)) {
+	case "APPROVED", "APPROVE":
+		return "approved"
+	case "CHANGES_REQUESTED", "REQUEST_CHANGES":
+		return "changes_requested"
+	case "REVIEW_REQUIRED", "PENDING", "COMMENTED":
+		return "pending"
+	case "", "NONE":
+		return "none"
+	default:
+		return strings.ToLower(decision)
+	}
+}

--- a/backend/internal/domain/scm.go
+++ b/backend/internal/domain/scm.go
@@ -411,17 +411,17 @@ func MustSCMSemanticHash(s SCMSnapshot) string {
 }
 
 func NormalizeSCMCI(summary string) string {
-	switch strings.ToLower(summary) {
+	switch strings.ToLower(strings.TrimSpace(summary)) {
 	case "success", "successful", "passed", "passing", "pass":
 		return "passing"
 	case "failure", "failed", "failing", "error", "timed_out", "cancelled", "action_required":
 		return "failing"
 	case "pending", "queued", "in_progress", "requested", "waiting", "expected":
 		return "pending"
-	case "", "none", "no_checks":
+	case "", "none", "no_checks", "neutral", "skipped", "stale", "not_required":
 		return "none"
 	default:
-		return strings.ToLower(summary)
+		return strings.ToLower(strings.TrimSpace(summary))
 	}
 }
 

--- a/backend/internal/domain/scm.go
+++ b/backend/internal/domain/scm.go
@@ -349,6 +349,10 @@ type SCMProviderCacheEntry struct {
 	Value     json.RawMessage     `json:"value,omitempty"`
 	UpdatedAt time.Time           `json:"updatedAt"`
 	ExpiresAt time.Time           `json:"expiresAt,omitempty"`
+	// MaxEntries is an optional provider-owned retention hint. It is intentionally
+	// not persisted so durable cache records remain provider data, while the store
+	// only enforces the generic cap requested by the writer.
+	MaxEntries int `json:"-"`
 }
 
 func (e SCMProviderCacheEntry) Expired(now time.Time) bool {

--- a/backend/internal/domain/scm.go
+++ b/backend/internal/domain/scm.go
@@ -9,14 +9,15 @@ import (
 	"time"
 )
 
-// SCMProvider identifies a source-control provider implementation. The Go
-// rewrite intentionally starts with GitHub as the first real provider, but the
-// normalized data model keeps the provider/host/repo identity explicit so later
+// SCMProvider identifies a source-control provider implementation. The
+// normalized data model keeps the provider/host/repo identity explicit so
 // providers cannot accidentally key by PR number alone.
 type SCMProvider string
 
 const (
-	SCMProviderGitHub SCMProvider = "github"
+	SCMProviderGitHub    SCMProvider = "github"
+	SCMProviderGitLab    SCMProvider = "gitlab"
+	SCMProviderBitbucket SCMProvider = "bitbucket"
 )
 
 // SCMFreshness describes whether an observation fetched current provider truth,

--- a/backend/internal/domain/session.go
+++ b/backend/internal/domain/session.go
@@ -64,4 +64,5 @@ type SessionRecord struct {
 type Session struct {
 	SessionRecord
 	Status SessionStatus `json:"status"`
+	SCM    *SCMSnapshot  `json:"scm,omitempty"`
 }

--- a/backend/internal/integration/lifecycle_sqlite_test.go
+++ b/backend/internal/integration/lifecycle_sqlite_test.go
@@ -7,6 +7,7 @@ package integration
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"path/filepath"
@@ -20,6 +21,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/lifecycle"
 	"github.com/aoagents/agent-orchestrator/backend/internal/notification"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	scmevents "github.com/aoagents/agent-orchestrator/backend/internal/scm/events"
 	"github.com/aoagents/agent-orchestrator/backend/internal/session"
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
 )
@@ -97,6 +99,7 @@ func (a storeAdapter) WritePR(ctx context.Context, pr ports.PRRow, checks []port
 		commentRows[i] = sqlite.PRCommentRow{
 			PRURL: pr.URL, CommentID: c.ID, Author: c.Author, File: c.File,
 			Line: int64(c.Line), Body: c.Body, Resolved: c.Resolved, CreatedAt: c.CreatedAt,
+			ThreadID: c.ThreadID, URL: c.URL, IsBot: c.IsBot,
 		}
 	}
 	return a.Store.WritePRObservation(ctx, row, checkRows, commentRows)
@@ -388,6 +391,97 @@ func TestHappyPath_Spawn_PR_Kill(t *testing.T) {
 		if !seen[want] {
 			t.Fatalf("missing change_log event %q (got: %v)", want, seen)
 		}
+	}
+}
+
+func TestSCMSnapshotEventFeedsLCMAndDerivedPRStorage(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := openLiveStack(t, t.TempDir())
+	defer st.close(t)
+	seedProject(t, st.store, "mer")
+
+	sess, err := st.sm.Spawn(ctx, ports.SpawnConfig{
+		ProjectID: "mer", Kind: domain.KindWorker, Branch: "feat/27", Prompt: "ship scm",
+	})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if err := st.lcm.ApplyActivitySignal(ctx, sess.ID, ports.ActivitySignal{
+		Valid: true, State: domain.ActivityActive, Source: domain.SourceHook, Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("activity: %v", err)
+	}
+	_ = st.messenger.drain()
+
+	prURL := "https://github.com/aoagents/agent-orchestrator/pull/28"
+	subj := domain.SCMSubject{
+		SessionID: sess.ID, ProjectID: "mer", Provider: domain.SCMProviderGitHub,
+		Host: "github.com", Repo: "aoagents/agent-orchestrator", Branch: "feat/27",
+		BaseBranch: "main", CredentialHash: "cred", PRNumber: 28, PRURL: prURL,
+	}
+	snap, changed, err := st.store.SaveSnapshot(ctx, domain.SCMSnapshot{
+		SessionID:  sess.ID,
+		Subject:    subj,
+		Freshness:  domain.SCMFreshnessFresh,
+		ObservedAt: time.Now(),
+		PR: &domain.SCMPullRequest{
+			Number: 28, URL: prURL, State: domain.PROpen, SourceBranch: "feat/27", TargetBranch: "main", HeadSHA: "sha1",
+		},
+		CI: domain.SCMCI{Summary: "failing", Checks: []domain.SCMCheck{{
+			Name: "build", Status: "completed", Conclusion: "failure", URL: "https://github.com/checks/1", LogTail: "last 20 lines",
+		}}},
+		Review: domain.SCMReview{
+			Decision: "changes_requested",
+			UnresolvedThreads: []domain.SCMReviewThread{{
+				ID: "thread-1", Path: "main.go", Line: 12, URL: "https://github.com/thread/1",
+				Comments: []domain.SCMReviewComment{{
+					ID: "comment-1", Author: "reviewer", Body: "fix this", URL: "https://github.com/comment/1", ThreadID: "thread-1",
+				}},
+			}},
+		},
+		Mergeability: domain.SCMMergeability{Conflict: true, NoConflicts: false, Blockers: []string{"merge conflicts"}, RawState: "DIRTY"},
+	})
+	if err != nil || !changed {
+		t.Fatalf("save scm snapshot changed=%v err=%v", changed, err)
+	}
+
+	rows, err := st.store.ReadChangeLogAfter(ctx, 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var event cdc.Event
+	for _, row := range rows {
+		if row.EventType == string(cdc.EventSCMSnapshotCreated) && row.SessionID == string(sess.ID) {
+			event = cdc.Event{
+				Seq: row.Seq, ProjectID: row.ProjectID, SessionID: row.SessionID,
+				Type: cdc.EventType(row.EventType), Payload: json.RawMessage(row.Payload), CreatedAt: row.CreatedAt,
+			}
+			break
+		}
+	}
+	if event.Type == "" {
+		t.Fatalf("missing scm snapshot event after saving revision %d", snap.Revision)
+	}
+	consumer := scmevents.NewConsumer(st.store, st.lcm, nil)
+	if err := consumer.Handle(ctx, event); err != nil {
+		t.Fatalf("consume scm event: %v", err)
+	}
+
+	pr, ok, err := st.store.GetPR(ctx, prURL)
+	if err != nil || !ok {
+		t.Fatalf("derived pr missing ok=%v err=%v", ok, err)
+	}
+	if pr.CIState != string(domain.CIFailing) || pr.ReviewDecision != string(domain.ReviewChangesRequest) || pr.Mergeability != string(domain.MergeConflicting) {
+		t.Fatalf("derived pr wrong: %+v", pr)
+	}
+	checks, err := st.store.ListChecks(ctx, prURL)
+	if err != nil || len(checks) != 1 || checks[0].CommitHash != "sha1" || checks[0].LogTail != "last 20 lines" {
+		t.Fatalf("derived checks wrong: %+v err=%v", checks, err)
+	}
+	comments, err := st.store.ListPRComments(ctx, prURL)
+	if err != nil || len(comments) != 1 || comments[0].ThreadID != "thread-1" || comments[0].URL == "" {
+		t.Fatalf("derived comments wrong: %+v err=%v", comments, err)
 	}
 }
 

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -7,7 +7,10 @@ package lifecycle
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -136,6 +139,21 @@ func (m *Manager) ApplyActivitySignal(ctx context.Context, id domain.SessionID, 
 	return m.runReactions(ctx, id, reactionContent{})
 }
 
+// ApplySCMObservation accepts the normalized SCM observer DTO and projects it
+// onto the existing PR observation lane. The SCM snapshot/store owns durable SCM
+// truth; the LCM consumes only the PR facts needed for canonical decisions and
+// reactions.
+func (m *Manager) ApplySCMObservation(ctx context.Context, id domain.SessionID, f ports.SCMFacts) error {
+	if !f.Fetched {
+		return nil
+	}
+	o, ok := scmFactsToPRObservation(f)
+	if !ok {
+		return nil
+	}
+	return m.ApplyPRObservation(ctx, id, o)
+}
+
 // ApplyPRObservation records the observed PR facts in the pr tables, terminates
 // the session on a merge, and fires the PR-driven reactions. A failed fetch is
 // dropped (failed probe != "PR closed").
@@ -201,6 +219,128 @@ func (m *Manager) writePR(ctx context.Context, id domain.SessionID, o ports.PROb
 		comments[i] = c
 	}
 	return m.pr.WritePR(ctx, row, checks, comments)
+}
+
+func scmFactsToPRObservation(f ports.SCMFacts) (ports.PRObservation, bool) {
+	if f.PRState == "" || f.PRState == domain.PRNone {
+		return ports.PRObservation{}, false
+	}
+	o := ports.PRObservation{
+		Fetched:      true,
+		URL:          f.PRURL,
+		Number:       f.PRNumber,
+		Draft:        f.Draft || f.PRState == domain.PRDraft,
+		Merged:       f.PRState == domain.PRMerged,
+		Closed:       f.PRState == domain.PRClosed || f.PRState == domain.PRMerged,
+		CI:           scmCIState(f.CISummary),
+		Review:       scmReviewDecision(f.ReviewDecision),
+		Mergeability: scmMergeability(f.Mergeability),
+	}
+	if o.URL == "" && o.Number == 0 {
+		return ports.PRObservation{}, false
+	}
+	for _, c := range f.CIFailedChecks {
+		o.Checks = append(o.Checks, ports.PRCheckRow{
+			Name:    firstNonEmpty(c.Name, "check"),
+			Status:  prCheckStatus(c),
+			URL:     c.URL,
+			LogTail: firstNonEmpty(c.LogTail, c.Details),
+		})
+	}
+	if f.CIFailureLogTail != nil && *f.CIFailureLogTail != "" && len(o.Checks) == 0 && o.CI == domain.CIFailing {
+		o.Checks = append(o.Checks, ports.PRCheckRow{Name: "ci", Status: "failed", LogTail: *f.CIFailureLogTail})
+	}
+	for _, c := range f.PendingComments {
+		o.Comments = append(o.Comments, ports.PRComment{
+			ID:       reviewCommentID(c),
+			Author:   c.Author,
+			File:     c.Path,
+			Line:     c.Line,
+			Body:     c.Body,
+			Resolved: false,
+		})
+	}
+	return o, true
+}
+
+func scmCIState(s ports.CISummary) domain.CIState {
+	switch s {
+	case ports.CIFailing:
+		return domain.CIFailing
+	case ports.CIPassing:
+		return domain.CIPassing
+	case ports.CIPending:
+		return domain.CIPending
+	default:
+		return domain.CIUnknown
+	}
+}
+
+func scmReviewDecision(d ports.ReviewDecision) domain.ReviewDecision {
+	switch d {
+	case ports.ReviewApproved:
+		return domain.ReviewApproved
+	case ports.ReviewChangesRequested:
+		return domain.ReviewChangesRequest
+	case ports.ReviewPending:
+		return domain.ReviewRequired
+	default:
+		return domain.ReviewNone
+	}
+}
+
+func scmMergeability(m ports.Mergeability) domain.Mergeability {
+	switch {
+	case m.Conflict || (!m.NoConflicts && len(m.Blockers) > 0):
+		return domain.MergeConflicting
+	case m.Mergeable:
+		return domain.MergeMergeable
+	case m.BehindBase || len(m.Blockers) > 0:
+		return domain.MergeBlocked
+	case m.Unknown:
+		return domain.MergeUnknown
+	default:
+		return domain.MergeUnknown
+	}
+}
+
+func prCheckStatus(c ports.CICheck) string {
+	v := strings.ToLower(strings.TrimSpace(firstNonEmpty(c.Conclusion, c.Status)))
+	switch v {
+	case "success", "successful", "passed", "passing", "pass":
+		return "passed"
+	case "failure", "failed", "failing", "error", "timed_out", "cancelled", "action_required", "startup_failure":
+		return "failed"
+	case "queued", "requested", "waiting", "expected":
+		return "queued"
+	case "in_progress", "pending":
+		return "in_progress"
+	case "skipped", "neutral", "stale":
+		return "skipped"
+	default:
+		if v == "" {
+			return "unknown"
+		}
+		return v
+	}
+}
+
+func reviewCommentID(c ports.ReviewComment) string {
+	if c.ThreadID != "" && c.URL != "" {
+		return c.ThreadID + "|" + c.URL
+	}
+	seed := fmt.Sprintf("%s|%s|%s|%d|%s|%s", c.ThreadID, c.URL, c.Author, c.Line, c.Path, c.Body)
+	sum := sha256.Sum256([]byte(seed))
+	return hex.EncodeToString(sum[:])
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // ---- mutation commands from the Session Manager ----

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -241,14 +241,15 @@ func scmFactsToPRObservation(f ports.SCMFacts) (ports.PRObservation, bool) {
 	}
 	for _, c := range f.CIFailedChecks {
 		o.Checks = append(o.Checks, ports.PRCheckRow{
-			Name:    firstNonEmpty(c.Name, "check"),
-			Status:  prCheckStatus(c),
-			URL:     c.URL,
-			LogTail: firstNonEmpty(c.LogTail, c.Details),
+			Name:       firstNonEmpty(c.Name, "check"),
+			CommitHash: f.HeadSHA,
+			Status:     prCheckStatus(c),
+			URL:        c.URL,
+			LogTail:    firstNonEmpty(c.LogTail, c.Details),
 		})
 	}
 	if f.CIFailureLogTail != nil && *f.CIFailureLogTail != "" && len(o.Checks) == 0 && o.CI == domain.CIFailing {
-		o.Checks = append(o.Checks, ports.PRCheckRow{Name: "ci", Status: "failed", LogTail: *f.CIFailureLogTail})
+		o.Checks = append(o.Checks, ports.PRCheckRow{Name: "ci", CommitHash: f.HeadSHA, Status: "failed", LogTail: *f.CIFailureLogTail})
 	}
 	for _, c := range f.PendingComments {
 		o.Comments = append(o.Comments, ports.PRComment{
@@ -258,6 +259,9 @@ func scmFactsToPRObservation(f ports.SCMFacts) (ports.PRObservation, bool) {
 			Line:     c.Line,
 			Body:     c.Body,
 			Resolved: false,
+			ThreadID: c.ThreadID,
+			URL:      c.URL,
+			IsBot:    c.IsBot,
 		})
 	}
 	return o, true

--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -291,14 +291,14 @@ func scmReviewDecision(d ports.ReviewDecision) domain.ReviewDecision {
 
 func scmMergeability(m ports.Mergeability) domain.Mergeability {
 	switch {
-	case m.Conflict || (!m.NoConflicts && len(m.Blockers) > 0):
+	case m.Unknown:
+		return domain.MergeUnknown
+	case m.Conflict:
 		return domain.MergeConflicting
 	case m.Mergeable:
 		return domain.MergeMergeable
 	case m.BehindBase || len(m.Blockers) > 0:
 		return domain.MergeBlocked
-	case m.Unknown:
-		return domain.MergeUnknown
 	default:
 		return domain.MergeUnknown
 	}

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -307,6 +307,17 @@ func TestPR_FailedFetchIsDropped(t *testing.T) {
 	}
 }
 
+func TestSCMMergeabilityUnknownWithBlockerIsNotConflict(t *testing.T) {
+	got := scmMergeability(ports.Mergeability{
+		Unknown:     true,
+		NoConflicts: false,
+		Blockers:    []string{"merge status unknown (GitHub is computing)"},
+	})
+	if got != domain.MergeUnknown {
+		t.Fatalf("unknown mergeability should stay unknown, got %q", got)
+	}
+}
+
 // ---- explicit kill ----
 
 func TestKill_TerminatesWithoutReacting(t *testing.T) {

--- a/backend/internal/observe/poller/registry.go
+++ b/backend/internal/observe/poller/registry.go
@@ -1,0 +1,81 @@
+package poller
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+)
+
+// Poller is the common daemon start/stop seam for background observers. Each
+// poller owns its own cadence internally; the registry just starts all of them
+// under the daemon context and waits for clean shutdown.
+type Poller interface {
+	Name() string
+	Start(context.Context) <-chan struct{}
+}
+
+type Func struct {
+	PollerName string
+	StartFunc  func(context.Context) <-chan struct{}
+}
+
+func (f Func) Name() string { return f.PollerName }
+
+func (f Func) Start(ctx context.Context) <-chan struct{} {
+	if f.StartFunc == nil {
+		done := make(chan struct{})
+		close(done)
+		return done
+	}
+	return f.StartFunc(ctx)
+}
+
+type Registry struct {
+	logger  *slog.Logger
+	pollers []Poller
+	done    []<-chan struct{}
+}
+
+func NewRegistry(logger *slog.Logger) *Registry {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Registry{logger: logger}
+}
+
+func (r *Registry) Register(p Poller) error {
+	if p == nil {
+		return nil
+	}
+	name := p.Name()
+	if name == "" {
+		return fmt.Errorf("poller name is required")
+	}
+	for _, existing := range r.pollers {
+		if existing.Name() == name {
+			return fmt.Errorf("poller %q already registered", name)
+		}
+	}
+	r.pollers = append(r.pollers, p)
+	return nil
+}
+
+func (r *Registry) Start(ctx context.Context) {
+	for _, p := range r.pollers {
+		r.logger.Debug("poller starting", "name", p.Name())
+		r.done = append(r.done, p.Start(ctx))
+	}
+}
+
+func (r *Registry) Stop() {
+	var wg sync.WaitGroup
+	for _, ch := range r.done {
+		wg.Add(1)
+		go func(done <-chan struct{}) {
+			defer wg.Done()
+			<-done
+		}(ch)
+	}
+	wg.Wait()
+}

--- a/backend/internal/observe/reaper/reaper_test.go
+++ b/backend/internal/observe/reaper/reaper_test.go
@@ -34,6 +34,9 @@ func (l *fakeLCM) TickEscalations(context.Context, time.Time) error { l.escalate
 func (l *fakeLCM) ApplyActivitySignal(context.Context, domain.SessionID, ports.ActivitySignal) error {
 	return nil
 }
+func (l *fakeLCM) ApplySCMObservation(context.Context, domain.SessionID, ports.SCMFacts) error {
+	return nil
+}
 func (l *fakeLCM) ApplyPRObservation(context.Context, domain.SessionID, ports.PRObservation) error {
 	return nil
 }

--- a/backend/internal/ports/facts.go
+++ b/backend/internal/ports/facts.go
@@ -24,6 +24,7 @@ type SCMFacts struct {
 	Draft            bool
 	PRNumber         int
 	PRURL            string
+	HeadSHA          string
 	CISummary        CISummary
 	ReviewDecision   ReviewDecision
 	Mergeability     Mergeability
@@ -170,8 +171,9 @@ type PRCheckRow struct {
 	CreatedAt  time.Time
 }
 
-// PRComment is one review comment. Review feedback is injected into the agent
-// regardless of author, so there is no bot/human distinction.
+// PRComment is one review comment in the derived PR read model. The SCM facts
+// carry provider-specific thread/comment metadata; preserving it here keeps the
+// storage/read path from collapsing bot/human routing and thread URLs.
 type PRComment struct {
 	ID        string
 	Author    string
@@ -180,4 +182,7 @@ type PRComment struct {
 	Body      string
 	Resolved  bool
 	CreatedAt time.Time
+	ThreadID  string
+	URL       string
+	IsBot     bool
 }

--- a/backend/internal/ports/facts.go
+++ b/backend/internal/ports/facts.go
@@ -9,6 +9,80 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 )
 
+// SCMFacts is produced by the SCM observer and handed to ApplySCMObservation.
+//
+// Fetched is the failed-fetch guard: when false, the provider query errored or
+// was rate-limited and the rest of the struct must NOT be interpreted as "no PR"
+// or "PR closed".
+type SCMFacts struct {
+	Fetched          bool
+	ObservedAt       time.Time
+	PRState          domain.PRState
+	Draft            bool
+	PRNumber         int
+	PRURL            string
+	CISummary        CISummary
+	ReviewDecision   ReviewDecision
+	Mergeability     Mergeability
+	PendingComments  []ReviewComment
+	CIFailedChecks   []CICheck
+	CIFailureLogTail *string
+}
+
+type CISummary string
+
+const (
+	CIPending CISummary = "pending"
+	CIPassing CISummary = "passing"
+	CIFailing CISummary = "failing"
+	CINone    CISummary = "none"
+)
+
+type ReviewDecision string
+
+const (
+	ReviewApproved         ReviewDecision = "approved"
+	ReviewChangesRequested ReviewDecision = "changes_requested"
+	ReviewPending          ReviewDecision = "pending"
+	ReviewNone             ReviewDecision = "none"
+)
+
+// Mergeability carries provider merge gates. The LCM projects it into the
+// existing domain.Mergeability display state; the richer fields stay available
+// to reactions.
+type Mergeability struct {
+	Mergeable   bool
+	CIPassing   bool
+	Approved    bool
+	NoConflicts bool
+	Conflict    bool
+	BehindBase  bool
+	Unknown     bool
+	Blockers    []string
+}
+
+type CICheck struct {
+	Name       string
+	Status     string
+	Conclusion string
+	URL        string
+	Details    string
+	LogTail    string
+}
+
+// ReviewComment carries provider review-thread details. IsBot lets the SCM
+// provider distinguish bot comments from human review feedback without putting
+// provider-specific bot rules in the common observer.
+type ReviewComment struct {
+	Author   string
+	Body     string
+	IsBot    bool
+	URL      string
+	Path     string
+	Line     int
+	ThreadID string
+}
+
 // ProbeResult is a single liveness reading. "failed" (the probe errored/timed
 // out) and "unknown" (ran but couldn't tell) are kept distinct from dead — both
 // route to the detecting quarantine, never to a death conclusion.

--- a/backend/internal/ports/facts.go
+++ b/backend/internal/ports/facts.go
@@ -14,6 +14,9 @@ import (
 // Fetched is the failed-fetch guard: when false, the provider query errored or
 // was rate-limited and the rest of the struct must NOT be interpreted as "no PR"
 // or "PR closed".
+//
+// CIFailureLogTail is a pointer because it is only populated when CI is failing;
+// it stays off the hot poll path unless a reaction needs failure context.
 type SCMFacts struct {
 	Fetched          bool
 	ObservedAt       time.Time

--- a/backend/internal/ports/inbound.go
+++ b/backend/internal/ports/inbound.go
@@ -13,6 +13,7 @@ import (
 type LifecycleManager interface {
 	ApplyRuntimeObservation(ctx context.Context, id domain.SessionID, f RuntimeFacts) error
 	ApplyActivitySignal(ctx context.Context, id domain.SessionID, s ActivitySignal) error
+	ApplySCMObservation(ctx context.Context, id domain.SessionID, f SCMFacts) error
 	ApplyPRObservation(ctx context.Context, id domain.SessionID, o PRObservation) error
 
 	// OnSpawnCompleted marks a session live and records its handles. It works for

--- a/backend/internal/ports/scm.go
+++ b/backend/internal/ports/scm.go
@@ -1,0 +1,122 @@
+package ports
+
+import (
+	"context"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// SCMProvider is the observation-side provider contract. Implementations own
+// provider-specific HTTP/GraphQL behavior and return normalized snapshots only;
+// they do not import lifecycle/session packages.
+type SCMProvider interface {
+	Provider() domain.SCMProvider
+	ObserveSessions(ctx context.Context, req SCMObserveRequest, cache SCMProviderCache) (SCMObserveResult, error)
+}
+
+type SCMObserveRequest struct {
+	Subjects []domain.SCMSubject
+	Now      time.Time
+}
+
+type SCMObserveResult struct {
+	Snapshots    []domain.SCMSnapshot
+	Subjects     []domain.SCMSubject // updated bindings, e.g. branch -> PR discovery
+	PollStates   []domain.SCMPollState
+	Diagnostics  []domain.SCMDiagnostic
+	RateLimit    *domain.SCMRateLimit
+	Unavailable  bool
+	ProviderName domain.SCMProvider
+}
+
+// SCMProviderCache is the small cache surface providers need for ETags and
+// positive branch->PR mappings. SCMStore implements it; tests can inject an
+// in-memory cache directly.
+type SCMProviderCache interface {
+	GetProviderCache(ctx context.Context, key domain.SCMProviderCacheKey) (domain.SCMProviderCacheEntry, bool, error)
+	PutProviderCache(ctx context.Context, entry domain.SCMProviderCacheEntry) error
+	DeleteProviderCache(ctx context.Context, prefix domain.SCMProviderCachePrefix) error
+}
+
+// SCMStore owns durable SCM state. SaveSnapshot assigns monotonic revisions and
+// returns changed=false when the semantic hash is unchanged.
+type SCMStore interface {
+	SCMProviderCache
+	UpsertSubject(ctx context.Context, subject domain.SCMSubject) error
+	GetSubject(ctx context.Context, sessionID domain.SessionID) (domain.SCMSubject, bool, error)
+	ListSubjects(ctx context.Context, filter domain.SCMSubjectFilter) ([]domain.SCMSubject, error)
+	DeleteSubject(ctx context.Context, sessionID domain.SessionID) error
+
+	SaveSnapshot(ctx context.Context, snapshot domain.SCMSnapshot) (saved domain.SCMSnapshot, changed bool, err error)
+	GetLatestSnapshot(ctx context.Context, sessionID domain.SessionID) (domain.SCMSnapshot, bool, error)
+	ListLatestSnapshots(ctx context.Context, project domain.ProjectID) ([]domain.SCMSnapshot, error)
+
+	GetPollState(ctx context.Context, key domain.SCMPollStateKey) (domain.SCMPollState, bool, error)
+	PutPollState(ctx context.Context, state domain.SCMPollState) error
+}
+
+// SCMCommandProvider executes provider mutations. A command result is an audit
+// record, never lifecycle truth; observer refresh must land before the LCM sees
+// the state change.
+type SCMCommandProvider interface {
+	Provider() domain.SCMProvider
+	Merge(ctx context.Context, req SCMCommandRequest) (SCMCommandResult, error)
+	Close(ctx context.Context, req SCMCommandRequest) (SCMCommandResult, error)
+	Comment(ctx context.Context, req SCMCommandRequest) (SCMCommandResult, error)
+	Assign(ctx context.Context, req SCMCommandRequest) (SCMCommandResult, error)
+	Checkout(ctx context.Context, req SCMCommandRequest) (SCMCommandResult, error)
+	Capabilities() SCMCommandCapabilities
+}
+
+type SCMCommand string
+
+const (
+	SCMCommandMerge    SCMCommand = "merge"
+	SCMCommandClose    SCMCommand = "close"
+	SCMCommandComment  SCMCommand = "comment"
+	SCMCommandAssign   SCMCommand = "assign"
+	SCMCommandCheckout SCMCommand = "checkout"
+)
+
+type SCMCommandRequest struct {
+	Subject       domain.SCMSubject
+	ChangeRequest domain.SCMChangeRequestID
+	Command       SCMCommand
+	Message       string
+	Body          string
+	Assignees     []string
+	MergeMethod   string
+	CommitTitle   string
+	CommitMessage string
+	WorkspacePath string
+	Actor         string
+	Now           time.Time
+}
+
+type SCMCommandResult struct {
+	Provider      domain.SCMProvider        `json:"provider"`
+	Command       SCMCommand                `json:"command"`
+	ChangeRequest domain.SCMChangeRequestID `json:"changeRequest"`
+	URL           string                    `json:"url,omitempty"`
+	SHA           string                    `json:"sha,omitempty"`
+	Message       string                    `json:"message,omitempty"`
+	PerformedAt   time.Time                 `json:"performedAt"`
+	Diagnostics   []domain.SCMDiagnostic    `json:"diagnostics,omitempty"`
+}
+
+type SCMCommandCapabilities struct {
+	Merge    bool `json:"merge"`
+	Close    bool `json:"close"`
+	Comment  bool `json:"comment"`
+	Assign   bool `json:"assign"`
+	Checkout bool `json:"checkout"`
+}
+
+// SCMObserver is the inbound scheduler/refresh contract exposed to API and
+// command layers.
+type SCMObserver interface {
+	Refresh(ctx context.Context, subjects []domain.SCMSubject) error
+	RefreshSession(ctx context.Context, sessionID domain.SessionID) error
+	Invalidate(ctx context.Context, subject domain.SCMSubject, reason string) error
+}

--- a/backend/internal/ports/scm.go
+++ b/backend/internal/ports/scm.go
@@ -8,7 +8,7 @@ import (
 )
 
 // SCMProvider is the observation-side provider contract. Implementations own
-// provider-specific HTTP/GraphQL behavior and return normalized snapshots only;
+// provider-specific network/API behavior and return normalized snapshots only;
 // they do not import lifecycle/session packages.
 type SCMProvider interface {
 	Provider() domain.SCMProvider

--- a/backend/internal/project/manager.go
+++ b/backend/internal/project/manager.go
@@ -104,10 +104,11 @@ func (m *manager) Add(ctx context.Context, in AddInput) (Project, error) {
 	}
 
 	row := ProjectRow{
-		ID:           string(id),
-		Path:         path,
-		DisplayName:  name,
-		RegisteredAt: time.Now(),
+		ID:            string(id),
+		Path:          path,
+		RepoOriginURL: gitRemoteOrigin(path),
+		DisplayName:   name,
+		RegisteredAt:  time.Now(),
 	}
 	if err := m.store.Upsert(ctx, row); err != nil {
 		return Project{}, err
@@ -234,6 +235,14 @@ func isGitRepo(path string) bool {
 		return true
 	}
 	return top == path
+}
+
+func gitRemoteOrigin(path string) string {
+	out, err := exec.Command("git", "-C", path, "remote", "get-url", "origin").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 func defaultProjectID(path string) domain.ProjectID {

--- a/backend/internal/scm/command/service.go
+++ b/backend/internal/scm/command/service.go
@@ -1,0 +1,153 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// AuditSink records command attempts. It can be backed by the future durable
+// audit log; the command service never treats audit success as lifecycle truth.
+type AuditSink interface {
+	RecordSCMCommand(ctx context.Context, result ports.SCMCommandResult, err error) error
+}
+
+// Refresher is satisfied by observer.Observer and intentionally mirrors the
+// small part commands need: invalidate caches and schedule a refresh.
+type Refresher interface {
+	Invalidate(ctx context.Context, subject domain.SCMSubject, reason string) error
+}
+
+type Service struct {
+	Store     ports.SCMStore
+	Providers map[domain.SCMProvider]ports.SCMCommandProvider
+	Audit     AuditSink
+	Refresh   Refresher
+	Clock     func() time.Time
+}
+
+func New(store ports.SCMStore, refresh Refresher, providers ...ports.SCMCommandProvider) *Service {
+	s := &Service{Store: store, Refresh: refresh, Providers: map[domain.SCMProvider]ports.SCMCommandProvider{}, Clock: time.Now}
+	for _, p := range providers {
+		if p != nil {
+			s.Providers[p.Provider()] = p
+		}
+	}
+	return s
+}
+
+func (s *Service) MergeChangeRequest(ctx context.Context, sessionID domain.SessionID, opts ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
+	return s.run(ctx, sessionID, ports.SCMCommandMerge, opts)
+}
+
+func (s *Service) CloseChangeRequest(ctx context.Context, sessionID domain.SessionID, opts ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
+	return s.run(ctx, sessionID, ports.SCMCommandClose, opts)
+}
+
+func (s *Service) CommentOnChangeRequest(ctx context.Context, sessionID domain.SessionID, body string) (ports.SCMCommandResult, error) {
+	return s.run(ctx, sessionID, ports.SCMCommandComment, ports.SCMCommandRequest{Body: body})
+}
+
+func (s *Service) AssignChangeRequest(ctx context.Context, sessionID domain.SessionID, assignees []string) (ports.SCMCommandResult, error) {
+	return s.run(ctx, sessionID, ports.SCMCommandAssign, ports.SCMCommandRequest{Assignees: assignees})
+}
+
+func (s *Service) CheckoutChangeRequest(ctx context.Context, sessionID domain.SessionID, workspacePath string) (ports.SCMCommandResult, error) {
+	return s.run(ctx, sessionID, ports.SCMCommandCheckout, ports.SCMCommandRequest{WorkspacePath: workspacePath})
+}
+
+func (s *Service) run(ctx context.Context, sessionID domain.SessionID, cmd ports.SCMCommand, req ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
+	if s.Store == nil {
+		return ports.SCMCommandResult{}, fmt.Errorf("scm command: nil store")
+	}
+	if s.Clock == nil {
+		s.Clock = time.Now
+	}
+	subj, ok, err := s.Store.GetSubject(ctx, sessionID)
+	if err != nil {
+		return ports.SCMCommandResult{}, err
+	}
+	if !ok {
+		return ports.SCMCommandResult{}, fmt.Errorf("scm command: subject %s not found", sessionID)
+	}
+	provider := s.Providers[subj.Provider]
+	if provider == nil {
+		return ports.SCMCommandResult{}, &domain.SCMError{Kind: domain.SCMErrorUnsupported, Operation: string(cmd), Message: fmt.Sprintf("provider %q not registered", subj.Provider)}
+	}
+	req.Subject = subj
+	req.ChangeRequest = subj.ChangeRequestID()
+	req.Command = cmd
+	req.Now = s.Clock()
+	var res ports.SCMCommandResult
+	switch cmd {
+	case ports.SCMCommandMerge:
+		if !provider.Capabilities().Merge {
+			return res, capabilityError(cmd)
+		}
+		res, err = provider.Merge(ctx, req)
+	case ports.SCMCommandClose:
+		if !provider.Capabilities().Close {
+			return res, capabilityError(cmd)
+		}
+		res, err = provider.Close(ctx, req)
+	case ports.SCMCommandComment:
+		if !provider.Capabilities().Comment {
+			return res, capabilityError(cmd)
+		}
+		res, err = provider.Comment(ctx, req)
+	case ports.SCMCommandAssign:
+		if !provider.Capabilities().Assign {
+			return res, capabilityError(cmd)
+		}
+		res, err = provider.Assign(ctx, req)
+	case ports.SCMCommandCheckout:
+		if !provider.Capabilities().Checkout {
+			return res, capabilityError(cmd)
+		}
+		res, err = provider.Checkout(ctx, req)
+	default:
+		err = capabilityError(cmd)
+	}
+	if s.Audit != nil {
+		_ = s.Audit.RecordSCMCommand(ctx, res, err)
+	}
+	if err != nil {
+		return res, err
+	}
+	if err := s.invalidateAfterCommand(ctx, subj, cmd); err != nil {
+		return res, err
+	}
+	if s.Refresh != nil {
+		if err := s.Refresh.Invalidate(ctx, subj, string(cmd)); err != nil {
+			return res, err
+		}
+	}
+	return res, nil
+}
+
+func (s *Service) invalidateAfterCommand(ctx context.Context, subj domain.SCMSubject, cmd ports.SCMCommand) error {
+	scope := subj.CacheScope()
+	prefixes := []domain.SCMProviderCachePrefix{{SCMProviderCacheScope: scope, Namespace: "pr-list"}, {SCMProviderCacheScope: scope, Namespace: "branch-map"}}
+	switch cmd {
+	case ports.SCMCommandMerge, ports.SCMCommandClose:
+		prefixes = append(prefixes,
+			domain.SCMProviderCachePrefix{SCMProviderCacheScope: scope, Namespace: "checks"},
+			domain.SCMProviderCachePrefix{SCMProviderCacheScope: scope, Namespace: "reviews"},
+		)
+	case ports.SCMCommandComment:
+		prefixes = append(prefixes, domain.SCMProviderCachePrefix{SCMProviderCacheScope: scope, Namespace: "reviews"})
+	}
+	for _, p := range prefixes {
+		if err := s.Store.DeleteProviderCache(ctx, p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func capabilityError(cmd ports.SCMCommand) error {
+	return &domain.SCMError{Kind: domain.SCMErrorUnsupported, Operation: string(cmd), Message: "command unsupported by provider"}
+}

--- a/backend/internal/scm/command/service.go
+++ b/backend/internal/scm/command/service.go
@@ -21,6 +21,10 @@ type Refresher interface {
 	Invalidate(ctx context.Context, subject domain.SCMSubject, reason string) error
 }
 
+type cacheInvalidationProvider interface {
+	CacheInvalidationPrefixes(subject domain.SCMSubject, cmd ports.SCMCommand) []domain.SCMProviderCachePrefix
+}
+
 type Service struct {
 	Store     ports.SCMStore
 	Providers map[domain.SCMProvider]ports.SCMCommandProvider
@@ -120,7 +124,7 @@ func (s *Service) run(ctx context.Context, sessionID domain.SessionID, cmd ports
 	if cmd == ports.SCMCommandCheckout {
 		return res, nil
 	}
-	if err := s.invalidateAfterCommand(ctx, subj, cmd); err != nil {
+	if err := s.invalidateAfterCommand(ctx, provider, subj, cmd); err != nil {
 		return res, err
 	}
 	if s.Refresh != nil {
@@ -131,18 +135,12 @@ func (s *Service) run(ctx context.Context, sessionID domain.SessionID, cmd ports
 	return res, nil
 }
 
-func (s *Service) invalidateAfterCommand(ctx context.Context, subj domain.SCMSubject, cmd ports.SCMCommand) error {
-	scope := subj.CacheScope()
-	prefixes := []domain.SCMProviderCachePrefix{{SCMProviderCacheScope: scope, Namespace: "pr-list"}, {SCMProviderCacheScope: scope, Namespace: "branch-map"}}
-	switch cmd {
-	case ports.SCMCommandMerge, ports.SCMCommandClose:
-		prefixes = append(prefixes,
-			domain.SCMProviderCachePrefix{SCMProviderCacheScope: scope, Namespace: "checks"},
-			domain.SCMProviderCachePrefix{SCMProviderCacheScope: scope, Namespace: "reviews"},
-		)
-	case ports.SCMCommandComment:
-		prefixes = append(prefixes, domain.SCMProviderCachePrefix{SCMProviderCacheScope: scope, Namespace: "reviews"})
+func (s *Service) invalidateAfterCommand(ctx context.Context, provider ports.SCMCommandProvider, subj domain.SCMSubject, cmd ports.SCMCommand) error {
+	invalidator, ok := provider.(cacheInvalidationProvider)
+	if !ok {
+		return nil
 	}
+	prefixes := invalidator.CacheInvalidationPrefixes(subj, cmd)
 	for _, p := range prefixes {
 		if err := s.Store.DeleteProviderCache(ctx, p); err != nil {
 			return err

--- a/backend/internal/scm/command/service.go
+++ b/backend/internal/scm/command/service.go
@@ -3,10 +3,12 @@ package command
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	scmlog "github.com/aoagents/agent-orchestrator/backend/internal/scm/logging"
 )
 
 // AuditSink records command attempts. It can be backed by the future durable
@@ -32,6 +34,7 @@ type Service struct {
 	Audit     AuditSink
 	Refresh   Refresher
 	Clock     func() time.Time
+	Logger    *slog.Logger
 }
 
 func New(store ports.SCMStore, refresh Refresher, providers ...ports.SCMCommandProvider) *Service {
@@ -65,94 +68,205 @@ func (s *Service) CheckoutChangeRequest(ctx context.Context, sessionID domain.Se
 }
 
 func (s *Service) run(ctx context.Context, sessionID domain.SessionID, cmd ports.SCMCommand, req ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
+	ctx, _ = scmlog.EnsureCorrelationID(ctx)
+	logger := scmlog.Logger(s.Logger)
+	started := time.Now()
 	if s.Store == nil {
-		return ports.SCMCommandResult{}, fmt.Errorf("scm command: nil store")
+		err := fmt.Errorf("scm command: nil store")
+		logCommandFailed(ctx, logger, ports.SCMCommandRequest{Command: cmd}, scmlog.DurationMS(started), err)
+		return ports.SCMCommandResult{}, err
 	}
 	if s.Clock == nil {
 		s.Clock = time.Now
 	}
 	subj, ok, err := s.Store.GetSubject(ctx, sessionID)
 	if err != nil {
+		logCommandFailed(ctx, logger, ports.SCMCommandRequest{Command: cmd, Subject: domain.SCMSubject{SessionID: sessionID}}, scmlog.DurationMS(started), err)
 		return ports.SCMCommandResult{}, err
 	}
 	if !ok {
-		return ports.SCMCommandResult{}, fmt.Errorf("scm command: subject %s not found", sessionID)
-	}
-	if subj.PRNumber == 0 {
-		return ports.SCMCommandResult{}, &domain.SCMError{Kind: domain.SCMErrorNotFound, Operation: string(cmd), Message: "no change request bound to session"}
-	}
-	provider := s.Providers[subj.Provider]
-	if provider == nil {
-		return ports.SCMCommandResult{}, &domain.SCMError{Kind: domain.SCMErrorUnsupported, Operation: string(cmd), Message: fmt.Sprintf("provider %q not registered", subj.Provider)}
+		err := fmt.Errorf("scm command: subject %s not found", sessionID)
+		logCommandFailed(ctx, logger, ports.SCMCommandRequest{Command: cmd, Subject: domain.SCMSubject{SessionID: sessionID}}, scmlog.DurationMS(started), err)
+		return ports.SCMCommandResult{}, err
 	}
 	req.Subject = subj
 	req.ChangeRequest = subj.ChangeRequestID()
 	req.Command = cmd
 	req.Now = s.Clock()
+	if subj.PRNumber == 0 {
+		err := &domain.SCMError{Kind: domain.SCMErrorNotFound, Operation: string(cmd), Message: "no change request bound to session"}
+		res := commandResultForError(req, err)
+		logCommandFailed(ctx, logger, req, scmlog.DurationMS(started), err)
+		return res, err
+	}
+	provider := s.Providers[subj.Provider]
+	if provider == nil {
+		err := &domain.SCMError{Kind: domain.SCMErrorUnsupported, Operation: string(cmd), Message: fmt.Sprintf("provider %q not registered", subj.Provider)}
+		res := commandResultForError(req, err)
+		logCommandFailed(ctx, logger, req, scmlog.DurationMS(started), err)
+		return res, err
+	}
+	logger.Info(scmlog.EventCommandStarted, scmlog.Args(scmlog.Add(scmlog.CommandAttrs(req), scmlog.CorrelationAttr(ctx)))...)
 	var res ports.SCMCommandResult
 	switch cmd {
 	case ports.SCMCommandMerge:
 		if !provider.Capabilities().Merge {
-			return res, capabilityError(cmd)
+			err = capabilityError(cmd)
+			res = commandResultForError(req, err)
+			break
 		}
 		res, err = provider.Merge(ctx, req)
 	case ports.SCMCommandClose:
 		if !provider.Capabilities().Close {
-			return res, capabilityError(cmd)
+			err = capabilityError(cmd)
+			res = commandResultForError(req, err)
+			break
 		}
 		res, err = provider.Close(ctx, req)
 	case ports.SCMCommandComment:
 		if !provider.Capabilities().Comment {
-			return res, capabilityError(cmd)
+			err = capabilityError(cmd)
+			res = commandResultForError(req, err)
+			break
 		}
 		res, err = provider.Comment(ctx, req)
 	case ports.SCMCommandAssign:
 		if !provider.Capabilities().Assign {
-			return res, capabilityError(cmd)
+			err = capabilityError(cmd)
+			res = commandResultForError(req, err)
+			break
 		}
 		res, err = provider.Assign(ctx, req)
 	case ports.SCMCommandCheckout:
 		if !provider.Capabilities().Checkout {
-			return res, capabilityError(cmd)
+			err = capabilityError(cmd)
+			res = commandResultForError(req, err)
+			break
 		}
 		res, err = provider.Checkout(ctx, req)
 	default:
 		err = capabilityError(cmd)
+		res = commandResultForError(req, err)
+	}
+	res = normalizeResult(res, req)
+	if err != nil {
+		res = attachErrorDiagnostic(res, req, err)
 	}
 	if s.Audit != nil {
-		_ = s.Audit.RecordSCMCommand(ctx, res, err)
+		if auditErr := s.Audit.RecordSCMCommand(ctx, res, err); auditErr != nil {
+			attrs := scmlog.Add(scmlog.CommandAttrs(req), scmlog.CorrelationAttr(ctx))
+			attrs = append(attrs, scmlog.ErrorAttrs(auditErr)...)
+			logger.Warn(scmlog.EventCommandAuditFailed, scmlog.Args(attrs)...)
+		}
 	}
 	if err != nil {
+		logCommandFailed(ctx, logger, req, scmlog.DurationMS(started), err)
 		return res, err
 	}
+	logCommandCompleted(ctx, logger, req, scmlog.DurationMS(started))
 	if cmd == ports.SCMCommandCheckout {
 		return res, nil
 	}
-	if err := s.invalidateAfterCommand(ctx, provider, subj, cmd); err != nil {
+	if invalidated, err := s.invalidateAfterCommand(ctx, provider, subj, cmd); err != nil {
+		logCommandFailed(ctx, logger, req, scmlog.DurationMS(started), err)
 		return res, err
+	} else if invalidated > 0 {
+		attrs := scmlog.Add(scmlog.CommandAttrs(req),
+			scmlog.CorrelationAttr(ctx),
+			slog.Int("cache_prefix_count", invalidated),
+		)
+		logger.Debug(scmlog.EventCommandCacheInvalid, scmlog.Args(attrs)...)
 	}
 	if s.Refresh != nil {
 		if err := s.Refresh.Refresh(ctx, []domain.SCMSubject{subj}); err != nil {
+			attrs := scmlog.Add(scmlog.CommandAttrs(req),
+				scmlog.CorrelationAttr(ctx),
+				slog.Int64(scmlog.FieldDurationMS, scmlog.DurationMS(started)),
+			)
+			attrs = append(attrs, scmlog.ErrorAttrs(err)...)
+			logger.Warn(scmlog.EventCommandRefreshFailed, scmlog.Args(attrs)...)
 			return res, err
 		}
 	}
 	return res, nil
 }
 
-func (s *Service) invalidateAfterCommand(ctx context.Context, provider ports.SCMCommandProvider, subj domain.SCMSubject, cmd ports.SCMCommand) error {
+func (s *Service) invalidateAfterCommand(ctx context.Context, provider ports.SCMCommandProvider, subj domain.SCMSubject, cmd ports.SCMCommand) (int, error) {
 	invalidator, ok := provider.(cacheInvalidationProvider)
 	if !ok {
-		return nil
+		return 0, nil
 	}
 	prefixes := invalidator.CacheInvalidationPrefixes(subj, cmd)
 	for _, p := range prefixes {
 		if err := s.Store.DeleteProviderCache(ctx, p); err != nil {
-			return err
+			return 0, err
 		}
 	}
-	return nil
+	return len(prefixes), nil
 }
 
 func capabilityError(cmd ports.SCMCommand) error {
 	return &domain.SCMError{Kind: domain.SCMErrorUnsupported, Operation: string(cmd), Message: "command unsupported by provider"}
+}
+
+func normalizeResult(res ports.SCMCommandResult, req ports.SCMCommandRequest) ports.SCMCommandResult {
+	if res.Provider == "" {
+		res.Provider = req.Subject.Provider
+	}
+	if res.Command == "" {
+		res.Command = req.Command
+	}
+	if res.ChangeRequest.Number == 0 {
+		res.ChangeRequest = req.ChangeRequest
+	}
+	if res.PerformedAt.IsZero() {
+		res.PerformedAt = req.Now
+	}
+	return res
+}
+
+func commandResultForError(req ports.SCMCommandRequest, err error) ports.SCMCommandResult {
+	return attachErrorDiagnostic(normalizeResult(ports.SCMCommandResult{}, req), req, err)
+}
+
+func attachErrorDiagnostic(res ports.SCMCommandResult, req ports.SCMCommandRequest, err error) ports.SCMCommandResult {
+	if len(res.Diagnostics) == 0 {
+		res.Diagnostics = append(res.Diagnostics, scmlog.DiagnosticFromError(string(req.Command), err))
+		return res
+	}
+	for i := range res.Diagnostics {
+		if res.Diagnostics[i].ErrorKind == "" {
+			res.Diagnostics[i].ErrorKind = scmlog.ErrorKind(err)
+		}
+		if res.Diagnostics[i].StatusCode == 0 {
+			if se, ok := scmlog.SCMError(err); ok {
+				res.Diagnostics[i].StatusCode = se.StatusCode
+			}
+		}
+		if res.Diagnostics[i].Message == "" {
+			res.Diagnostics[i].Message = scmlog.SafeDiagnosticMessage(err)
+		}
+	}
+	return res
+}
+
+func logCommandCompleted(ctx context.Context, logger *slog.Logger, req ports.SCMCommandRequest, durationMS int64) {
+	attrs := scmlog.Add(scmlog.CommandAttrs(req),
+		scmlog.CorrelationAttr(ctx),
+		slog.Int64(scmlog.FieldDurationMS, durationMS),
+	)
+	logger.Info(scmlog.EventCommandCompleted, scmlog.Args(attrs)...)
+}
+
+func logCommandFailed(ctx context.Context, logger *slog.Logger, req ports.SCMCommandRequest, durationMS int64, err error) {
+	attrs := scmlog.Add(scmlog.CommandAttrs(req),
+		scmlog.CorrelationAttr(ctx),
+		slog.Int64(scmlog.FieldDurationMS, durationMS),
+	)
+	attrs = append(attrs, scmlog.ErrorAttrs(err)...)
+	if _, ok := scmlog.SCMError(err); ok {
+		logger.Warn(scmlog.EventCommandFailed, scmlog.Args(attrs)...)
+		return
+	}
+	logger.Error(scmlog.EventCommandFailed, scmlog.Args(attrs)...)
 }

--- a/backend/internal/scm/command/service.go
+++ b/backend/internal/scm/command/service.go
@@ -117,6 +117,9 @@ func (s *Service) run(ctx context.Context, sessionID domain.SessionID, cmd ports
 	if err != nil {
 		return res, err
 	}
+	if cmd == ports.SCMCommandCheckout {
+		return res, nil
+	}
 	if err := s.invalidateAfterCommand(ctx, subj, cmd); err != nil {
 		return res, err
 	}

--- a/backend/internal/scm/command/service.go
+++ b/backend/internal/scm/command/service.go
@@ -16,9 +16,10 @@ type AuditSink interface {
 }
 
 // Refresher is satisfied by observer.Observer and intentionally mirrors the
-// small part commands need: invalidate caches and schedule a refresh.
+// small part commands need: schedule a refresh after provider-specific cache
+// invalidation has already been applied.
 type Refresher interface {
-	Invalidate(ctx context.Context, subject domain.SCMSubject, reason string) error
+	Refresh(ctx context.Context, subjects []domain.SCMSubject) error
 }
 
 type cacheInvalidationProvider interface {
@@ -77,6 +78,9 @@ func (s *Service) run(ctx context.Context, sessionID domain.SessionID, cmd ports
 	if !ok {
 		return ports.SCMCommandResult{}, fmt.Errorf("scm command: subject %s not found", sessionID)
 	}
+	if subj.PRNumber == 0 {
+		return ports.SCMCommandResult{}, &domain.SCMError{Kind: domain.SCMErrorNotFound, Operation: string(cmd), Message: "no change request bound to session"}
+	}
 	provider := s.Providers[subj.Provider]
 	if provider == nil {
 		return ports.SCMCommandResult{}, &domain.SCMError{Kind: domain.SCMErrorUnsupported, Operation: string(cmd), Message: fmt.Sprintf("provider %q not registered", subj.Provider)}
@@ -128,7 +132,7 @@ func (s *Service) run(ctx context.Context, sessionID domain.SessionID, cmd ports
 		return res, err
 	}
 	if s.Refresh != nil {
-		if err := s.Refresh.Invalidate(ctx, subj, string(cmd)); err != nil {
+		if err := s.Refresh.Refresh(ctx, []domain.SCMSubject{subj}); err != nil {
 			return res, err
 		}
 	}

--- a/backend/internal/scm/command/service_test.go
+++ b/backend/internal/scm/command/service_test.go
@@ -1,0 +1,69 @@
+package command
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/aoagents/agent-orchestrator/backend/internal/scm/store"
+)
+
+type fakeCommandProvider struct{ called ports.SCMCommand }
+
+func (f *fakeCommandProvider) Provider() domain.SCMProvider { return domain.SCMProviderGitHub }
+func (f *fakeCommandProvider) Capabilities() ports.SCMCommandCapabilities {
+	return ports.SCMCommandCapabilities{Merge: true, Close: true, Comment: true, Assign: true, Checkout: true}
+}
+func (f *fakeCommandProvider) Merge(_ context.Context, r ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
+	f.called = ports.SCMCommandMerge
+	return ports.SCMCommandResult{Provider: domain.SCMProviderGitHub, Command: r.Command, ChangeRequest: r.ChangeRequest}, nil
+}
+func (f *fakeCommandProvider) Close(context.Context, ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
+	return ports.SCMCommandResult{}, nil
+}
+func (f *fakeCommandProvider) Comment(context.Context, ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
+	return ports.SCMCommandResult{}, nil
+}
+func (f *fakeCommandProvider) Assign(context.Context, ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
+	return ports.SCMCommandResult{}, nil
+}
+func (f *fakeCommandProvider) Checkout(context.Context, ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
+	return ports.SCMCommandResult{}, nil
+}
+
+type fakeRefresh struct{ called bool }
+
+func (f *fakeRefresh) Invalidate(context.Context, domain.SCMSubject, string) error {
+	f.called = true
+	return nil
+}
+
+func TestMergeInvalidatesProviderCacheAndRefreshes(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 7, CredentialHash: "cred"}
+	if err := st.UpsertSubject(ctx, subj); err != nil {
+		t.Fatal(err)
+	}
+	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: "checks", Key: "sha"}
+	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: "etag"}); err != nil {
+		t.Fatal(err)
+	}
+	provider := &fakeCommandProvider{}
+	refresh := &fakeRefresh{}
+	svc := New(st, refresh, provider)
+	res, err := svc.MergeChangeRequest(ctx, "s1", ports.SCMCommandRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if provider.called != ports.SCMCommandMerge || res.ChangeRequest.Number != 7 {
+		t.Fatalf("provider called=%s result=%+v", provider.called, res)
+	}
+	if _, ok, _ := st.GetProviderCache(ctx, key); ok {
+		t.Fatal("merge should invalidate check cache")
+	}
+	if !refresh.called {
+		t.Fatal("command should trigger observer refresh")
+	}
+}

--- a/backend/internal/scm/command/service_test.go
+++ b/backend/internal/scm/command/service_test.go
@@ -28,8 +28,9 @@ func (f *fakeCommandProvider) Comment(context.Context, ports.SCMCommandRequest) 
 func (f *fakeCommandProvider) Assign(context.Context, ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
 	return ports.SCMCommandResult{}, nil
 }
-func (f *fakeCommandProvider) Checkout(context.Context, ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
-	return ports.SCMCommandResult{}, nil
+func (f *fakeCommandProvider) Checkout(_ context.Context, r ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
+	f.called = ports.SCMCommandCheckout
+	return ports.SCMCommandResult{Provider: domain.SCMProviderGitHub, Command: r.Command, ChangeRequest: r.ChangeRequest}, nil
 }
 
 type fakeRefresh struct{ called bool }
@@ -65,5 +66,33 @@ func TestMergeInvalidatesProviderCacheAndRefreshes(t *testing.T) {
 	}
 	if !refresh.called {
 		t.Fatal("command should trigger observer refresh")
+	}
+}
+
+func TestCheckoutDoesNotInvalidateOrRefreshProviderCache(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 7, CredentialHash: "cred"}
+	if err := st.UpsertSubject(ctx, subj); err != nil {
+		t.Fatal(err)
+	}
+	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: "checks", Key: "sha"}
+	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: "etag"}); err != nil {
+		t.Fatal(err)
+	}
+	provider := &fakeCommandProvider{}
+	refresh := &fakeRefresh{}
+	svc := New(st, refresh, provider)
+	if _, err := svc.CheckoutChangeRequest(ctx, "s1", "/tmp/workspace"); err != nil {
+		t.Fatal(err)
+	}
+	if provider.called != ports.SCMCommandCheckout {
+		t.Fatalf("provider called=%s", provider.called)
+	}
+	if _, ok, _ := st.GetProviderCache(ctx, key); !ok {
+		t.Fatal("checkout should not invalidate provider cache")
+	}
+	if refresh.called {
+		t.Fatal("checkout should not trigger observer refresh")
 	}
 }

--- a/backend/internal/scm/command/service_test.go
+++ b/backend/internal/scm/command/service_test.go
@@ -1,18 +1,25 @@
 package command
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	scmlog "github.com/aoagents/agent-orchestrator/backend/internal/scm/logging"
 	"github.com/aoagents/agent-orchestrator/backend/internal/scm/store"
 )
 
 type fakeCommandProvider struct {
 	called        ports.SCMCommand
 	invalidations []domain.SCMProviderCachePrefix
+	err           error
 }
 
 func (f *fakeCommandProvider) Provider() domain.SCMProvider { return domain.SCMProviderGitHub }
@@ -21,33 +28,46 @@ func (f *fakeCommandProvider) Capabilities() ports.SCMCommandCapabilities {
 }
 func (f *fakeCommandProvider) Merge(_ context.Context, r ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
 	f.called = ports.SCMCommandMerge
-	return ports.SCMCommandResult{Provider: domain.SCMProviderGitHub, Command: r.Command, ChangeRequest: r.ChangeRequest}, nil
+	return ports.SCMCommandResult{Provider: domain.SCMProviderGitHub, Command: r.Command, ChangeRequest: r.ChangeRequest}, f.err
 }
 func (f *fakeCommandProvider) Close(context.Context, ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
 	f.called = ports.SCMCommandClose
-	return ports.SCMCommandResult{}, nil
+	return ports.SCMCommandResult{}, f.err
 }
 func (f *fakeCommandProvider) Comment(context.Context, ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
 	f.called = ports.SCMCommandComment
-	return ports.SCMCommandResult{}, nil
+	return ports.SCMCommandResult{}, f.err
 }
 func (f *fakeCommandProvider) Assign(context.Context, ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
 	f.called = ports.SCMCommandAssign
-	return ports.SCMCommandResult{}, nil
+	return ports.SCMCommandResult{}, f.err
 }
 func (f *fakeCommandProvider) Checkout(_ context.Context, r ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
 	f.called = ports.SCMCommandCheckout
-	return ports.SCMCommandResult{Provider: domain.SCMProviderGitHub, Command: r.Command, ChangeRequest: r.ChangeRequest}, nil
+	return ports.SCMCommandResult{Provider: domain.SCMProviderGitHub, Command: r.Command, ChangeRequest: r.ChangeRequest}, f.err
 }
 func (f *fakeCommandProvider) CacheInvalidationPrefixes(domain.SCMSubject, ports.SCMCommand) []domain.SCMProviderCachePrefix {
 	return f.invalidations
 }
 
-type fakeRefresh struct{ called bool }
+type fakeRefresh struct {
+	called bool
+	err    error
+}
 
 func (f *fakeRefresh) Refresh(context.Context, []domain.SCMSubject) error {
 	f.called = true
-	return nil
+	return f.err
+}
+
+type fakeAudit struct {
+	called bool
+	err    error
+}
+
+func (f *fakeAudit) RecordSCMCommand(context.Context, ports.SCMCommandResult, error) error {
+	f.called = true
+	return f.err
 }
 
 func TestMergeInvalidatesProviderCacheAndRefreshes(t *testing.T) {
@@ -77,6 +97,99 @@ func TestMergeInvalidatesProviderCacheAndRefreshes(t *testing.T) {
 	if !refresh.called {
 		t.Fatal("command should trigger observer refresh")
 	}
+}
+
+func TestCommandServiceLogsStartedCompletedAndCacheInvalidated(t *testing.T) {
+	ctx := scmlog.WithCorrelationID(context.Background(), "corr-command")
+	st := store.NewMemoryStore()
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/45", PRNumber: 45, CredentialHash: "cred"}
+	if err := st.UpsertSubject(ctx, subj); err != nil {
+		t.Fatal(err)
+	}
+	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: "provider-checks", Key: "sha"}
+	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: "etag"}); err != nil {
+		t.Fatal(err)
+	}
+	var logs bytes.Buffer
+	provider := &fakeCommandProvider{invalidations: []domain.SCMProviderCachePrefix{{SCMProviderCacheScope: subj.CacheScope(), Namespace: "provider-checks"}}}
+	svc := New(st, nil, provider)
+	svc.Logger = jsonLogger(&logs)
+	if _, err := svc.MergeChangeRequest(ctx, "s1", ports.SCMCommandRequest{Actor: "ao"}); err != nil {
+		t.Fatal(err)
+	}
+	records := decodeLogRecords(t, logs.String())
+	started := findLogRecord(t, records, scmlog.EventCommandStarted)
+	assertLogField(t, started, scmlog.FieldCorrelationID, "corr-command")
+	assertLogField(t, started, scmlog.FieldProvider, "github")
+	assertLogField(t, started, scmlog.FieldRepo, "o/r")
+	assertLogField(t, started, scmlog.FieldCommand, string(ports.SCMCommandMerge))
+	assertLogField(t, started, scmlog.FieldActor, "ao")
+	assertLogNumber(t, started, scmlog.FieldChangeRequestNumber, 45)
+	if _, ok := started["pr_number"]; ok {
+		t.Fatal("command log used provider-specific pr_number field")
+	}
+	completed := findLogRecord(t, records, scmlog.EventCommandCompleted)
+	assertLogNumber(t, completed, scmlog.FieldChangeRequestNumber, 45)
+	findLogRecord(t, records, scmlog.EventCommandCacheInvalid)
+}
+
+func TestCommandServiceLogsFailuresWithoutCommentBodyAndAttachesDiagnostic(t *testing.T) {
+	ctx := scmlog.WithCorrelationID(context.Background(), "corr-command-fail")
+	st := store.NewMemoryStore()
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/45", PRNumber: 45}
+	if err := st.UpsertSubject(ctx, subj); err != nil {
+		t.Fatal(err)
+	}
+	commentBody := "SECRET_COMMENT_BODY"
+	providerErr := &domain.SCMError{Kind: domain.SCMErrorAuthFailed, Operation: "github.command.comment", StatusCode: 401, Message: "bad credentials"}
+	var logs bytes.Buffer
+	svc := New(st, nil, &fakeCommandProvider{err: providerErr})
+	svc.Logger = jsonLogger(&logs)
+	res, err := svc.CommentOnChangeRequest(ctx, "s1", commentBody)
+	if err == nil {
+		t.Fatal("expected command error")
+	}
+	records := decodeLogRecords(t, logs.String())
+	failed := findLogRecord(t, records, scmlog.EventCommandFailed)
+	assertLogField(t, failed, scmlog.FieldCorrelationID, "corr-command-fail")
+	assertLogField(t, failed, scmlog.FieldErrorKind, string(domain.SCMErrorAuthFailed))
+	assertLogNumber(t, failed, scmlog.FieldStatusCode, 401)
+	if strings.Contains(logs.String(), commentBody) {
+		t.Fatalf("comment body leaked into command logs: %s", logs.String())
+	}
+	if len(res.Diagnostics) != 1 || res.Diagnostics[0].ErrorKind != domain.SCMErrorAuthFailed || res.Diagnostics[0].StatusCode != 401 {
+		t.Fatalf("bad command diagnostics: %+v", res.Diagnostics)
+	}
+}
+
+func TestCommandServiceLogsAuditAndRefreshFailuresSeparately(t *testing.T) {
+	ctx := scmlog.WithCorrelationID(context.Background(), "corr-command-after")
+	st := store.NewMemoryStore()
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/45", PRNumber: 45}
+	if err := st.UpsertSubject(ctx, subj); err != nil {
+		t.Fatal(err)
+	}
+	var logs bytes.Buffer
+	audit := &fakeAudit{err: fmt.Errorf("audit down")}
+	refresh := &fakeRefresh{err: &domain.SCMError{Kind: domain.SCMErrorNetwork, Operation: "observe", Message: "refresh down"}}
+	svc := New(st, refresh, &fakeCommandProvider{})
+	svc.Audit = audit
+	svc.Logger = jsonLogger(&logs)
+	res, err := svc.MergeChangeRequest(ctx, "s1", ports.SCMCommandRequest{})
+	if err == nil {
+		t.Fatal("expected refresh error")
+	}
+	if !audit.called || !refresh.called {
+		t.Fatalf("audit=%v refresh=%v", audit.called, refresh.called)
+	}
+	if res.Command != ports.SCMCommandMerge || res.ChangeRequest.Number != 45 {
+		t.Fatalf("command result hidden by refresh failure: %+v", res)
+	}
+	records := decodeLogRecords(t, logs.String())
+	findLogRecord(t, records, scmlog.EventCommandCompleted)
+	findLogRecord(t, records, scmlog.EventCommandAuditFailed)
+	refreshFailed := findLogRecord(t, records, scmlog.EventCommandRefreshFailed)
+	assertLogField(t, refreshFailed, scmlog.FieldErrorKind, string(domain.SCMErrorNetwork))
 }
 
 func TestCheckoutDoesNotInvalidateOrRefreshProviderCache(t *testing.T) {
@@ -154,5 +267,52 @@ func TestCommandRejectsSessionWithoutBoundChangeRequest(t *testing.T) {
 	}
 	if provider.called != "" {
 		t.Fatalf("provider should not be called, got %s", provider.called)
+	}
+}
+
+func jsonLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func decodeLogRecords(t *testing.T, raw string) []map[string]any {
+	t.Helper()
+	lines := bytes.Split([]byte(raw), []byte("\n"))
+	records := make([]map[string]any, 0, len(lines))
+	for _, line := range lines {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal(line, &rec); err != nil {
+			t.Fatalf("decode log %s: %v", line, err)
+		}
+		records = append(records, rec)
+	}
+	return records
+}
+
+func findLogRecord(t *testing.T, records []map[string]any, msg string) map[string]any {
+	t.Helper()
+	for _, rec := range records {
+		if rec["msg"] == msg {
+			return rec
+		}
+	}
+	t.Fatalf("missing log %q in %+v", msg, records)
+	return nil
+}
+
+func assertLogField(t *testing.T, rec map[string]any, key, want string) {
+	t.Helper()
+	if got, _ := rec[key].(string); got != want {
+		t.Fatalf("%s=%q want %q in %+v", key, got, want, rec)
+	}
+}
+
+func assertLogNumber(t *testing.T, rec map[string]any, key string, want float64) {
+	t.Helper()
+	if got, _ := rec[key].(float64); got != want {
+		t.Fatalf("%s=%v want %v in %+v", key, rec[key], want, rec)
 	}
 }

--- a/backend/internal/scm/command/service_test.go
+++ b/backend/internal/scm/command/service_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -23,12 +24,15 @@ func (f *fakeCommandProvider) Merge(_ context.Context, r ports.SCMCommandRequest
 	return ports.SCMCommandResult{Provider: domain.SCMProviderGitHub, Command: r.Command, ChangeRequest: r.ChangeRequest}, nil
 }
 func (f *fakeCommandProvider) Close(context.Context, ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
+	f.called = ports.SCMCommandClose
 	return ports.SCMCommandResult{}, nil
 }
 func (f *fakeCommandProvider) Comment(context.Context, ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
+	f.called = ports.SCMCommandComment
 	return ports.SCMCommandResult{}, nil
 }
 func (f *fakeCommandProvider) Assign(context.Context, ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
+	f.called = ports.SCMCommandAssign
 	return ports.SCMCommandResult{}, nil
 }
 func (f *fakeCommandProvider) Checkout(_ context.Context, r ports.SCMCommandRequest) (ports.SCMCommandResult, error) {
@@ -41,7 +45,7 @@ func (f *fakeCommandProvider) CacheInvalidationPrefixes(domain.SCMSubject, ports
 
 type fakeRefresh struct{ called bool }
 
-func (f *fakeRefresh) Invalidate(context.Context, domain.SCMSubject, string) error {
+func (f *fakeRefresh) Refresh(context.Context, []domain.SCMSubject) error {
 	f.called = true
 	return nil
 }
@@ -100,5 +104,55 @@ func TestCheckoutDoesNotInvalidateOrRefreshProviderCache(t *testing.T) {
 	}
 	if refresh.called {
 		t.Fatal("checkout should not trigger observer refresh")
+	}
+}
+
+func TestCommentInvalidatesOnlyProviderReviewCache(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 7, CredentialHash: "cred"}
+	if err := st.UpsertSubject(ctx, subj); err != nil {
+		t.Fatal(err)
+	}
+	reviewKey := domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: "reviews", Key: "7"}
+	checkKey := domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: "checks", Key: "sha"}
+	for _, key := range []domain.SCMProviderCacheKey{reviewKey, checkKey} {
+		if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: key.Namespace}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	provider := &fakeCommandProvider{invalidations: []domain.SCMProviderCachePrefix{{SCMProviderCacheScope: subj.CacheScope(), Namespace: "reviews"}}}
+	refresh := &fakeRefresh{}
+	svc := New(st, refresh, provider)
+	if _, err := svc.CommentOnChangeRequest(ctx, "s1", "hello"); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := st.GetProviderCache(ctx, reviewKey); ok {
+		t.Fatal("review cache should be invalidated")
+	}
+	if _, ok, _ := st.GetProviderCache(ctx, checkKey); !ok {
+		t.Fatal("check cache should remain after comment")
+	}
+	if !refresh.called {
+		t.Fatal("comment should refresh after precise invalidation")
+	}
+}
+
+func TestCommandRejectsSessionWithoutBoundChangeRequest(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27"}
+	if err := st.UpsertSubject(ctx, subj); err != nil {
+		t.Fatal(err)
+	}
+	provider := &fakeCommandProvider{}
+	svc := New(st, nil, provider)
+	_, err := svc.MergeChangeRequest(ctx, "s1", ports.SCMCommandRequest{})
+	var scmErr *domain.SCMError
+	if !errors.As(err, &scmErr) || scmErr.Kind != domain.SCMErrorNotFound {
+		t.Fatalf("err=%T %[1]v", err)
+	}
+	if provider.called != "" {
+		t.Fatalf("provider should not be called, got %s", provider.called)
 	}
 }

--- a/backend/internal/scm/command/service_test.go
+++ b/backend/internal/scm/command/service_test.go
@@ -9,7 +9,10 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/scm/store"
 )
 
-type fakeCommandProvider struct{ called ports.SCMCommand }
+type fakeCommandProvider struct {
+	called        ports.SCMCommand
+	invalidations []domain.SCMProviderCachePrefix
+}
 
 func (f *fakeCommandProvider) Provider() domain.SCMProvider { return domain.SCMProviderGitHub }
 func (f *fakeCommandProvider) Capabilities() ports.SCMCommandCapabilities {
@@ -32,6 +35,9 @@ func (f *fakeCommandProvider) Checkout(_ context.Context, r ports.SCMCommandRequ
 	f.called = ports.SCMCommandCheckout
 	return ports.SCMCommandResult{Provider: domain.SCMProviderGitHub, Command: r.Command, ChangeRequest: r.ChangeRequest}, nil
 }
+func (f *fakeCommandProvider) CacheInvalidationPrefixes(domain.SCMSubject, ports.SCMCommand) []domain.SCMProviderCachePrefix {
+	return f.invalidations
+}
 
 type fakeRefresh struct{ called bool }
 
@@ -47,11 +53,11 @@ func TestMergeInvalidatesProviderCacheAndRefreshes(t *testing.T) {
 	if err := st.UpsertSubject(ctx, subj); err != nil {
 		t.Fatal(err)
 	}
-	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: "checks", Key: "sha"}
+	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: "provider-checks", Key: "sha"}
 	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: "etag"}); err != nil {
 		t.Fatal(err)
 	}
-	provider := &fakeCommandProvider{}
+	provider := &fakeCommandProvider{invalidations: []domain.SCMProviderCachePrefix{{SCMProviderCacheScope: subj.CacheScope(), Namespace: "provider-checks"}}}
 	refresh := &fakeRefresh{}
 	svc := New(st, refresh, provider)
 	res, err := svc.MergeChangeRequest(ctx, "s1", ports.SCMCommandRequest{})
@@ -76,7 +82,7 @@ func TestCheckoutDoesNotInvalidateOrRefreshProviderCache(t *testing.T) {
 	if err := st.UpsertSubject(ctx, subj); err != nil {
 		t.Fatal(err)
 	}
-	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: "checks", Key: "sha"}
+	key := domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: "provider-checks", Key: "sha"}
 	if err := st.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: "etag"}); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/scm/events/consumer.go
+++ b/backend/internal/scm/events/consumer.go
@@ -1,0 +1,76 @@
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/aoagents/agent-orchestrator/backend/internal/scm/observer"
+)
+
+// Consumer is the production seam between durable SCM snapshots and the LCM.
+// The observer writes scm_snapshots; SQLite emits change_log rows; this consumer
+// loads the latest snapshot and applies normalized facts. Provider adapters and
+// the common observer do not call lifecycle directly in production.
+type Consumer struct {
+	Store  ports.SCMStore
+	LCM    ports.LifecycleManager
+	Logger *slog.Logger
+
+	mu      sync.Mutex
+	applied map[domain.SessionID]int64
+}
+
+func NewConsumer(store ports.SCMStore, lcm ports.LifecycleManager, logger *slog.Logger) *Consumer {
+	return &Consumer{Store: store, LCM: lcm, Logger: logger, applied: map[domain.SessionID]int64{}}
+}
+
+func (c *Consumer) Handle(ctx context.Context, event cdc.Event) error {
+	if event.Type != cdc.EventSCMSnapshotCreated {
+		return nil
+	}
+	if c.Store == nil || c.LCM == nil {
+		return nil
+	}
+	var payload struct {
+		SessionID string `json:"sessionId"`
+		Revision  int64  `json:"revision"`
+	}
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		return fmt.Errorf("decode scm snapshot event %d: %w", event.Seq, err)
+	}
+	sessionID := domain.SessionID(payload.SessionID)
+	if sessionID == "" {
+		sessionID = domain.SessionID(event.SessionID)
+	}
+	if sessionID == "" {
+		return fmt.Errorf("scm snapshot event %d missing session id", event.Seq)
+	}
+	snap, ok, err := c.Store.GetLatestSnapshot(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("scm snapshot event %d points at missing latest snapshot for %s", event.Seq, sessionID)
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.applied == nil {
+		c.applied = map[domain.SessionID]int64{}
+	}
+	if snap.Revision > 0 && c.applied[sessionID] >= snap.Revision {
+		return nil
+	}
+	if err := c.LCM.ApplySCMObservation(ctx, sessionID, observer.FactsFromSnapshot(snap)); err != nil {
+		return err
+	}
+	if snap.Revision > c.applied[sessionID] {
+		c.applied[sessionID] = snap.Revision
+	}
+	return nil
+}

--- a/backend/internal/scm/events/consumer_test.go
+++ b/backend/internal/scm/events/consumer_test.go
@@ -1,0 +1,82 @@
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	scmstore "github.com/aoagents/agent-orchestrator/backend/internal/scm/store"
+)
+
+func TestConsumerAppliesLatestSnapshotOnce(t *testing.T) {
+	ctx := context.Background()
+	store := scmstore.NewMemoryStore()
+	subj := domain.SCMSubject{
+		SessionID: "mer-1", ProjectID: "mer", Provider: domain.SCMProviderGitHub,
+		Host: "github.com", Repo: "aoagents/agent-orchestrator", Branch: "feat/27", PRNumber: 28,
+		PRURL: "https://github.com/aoagents/agent-orchestrator/pull/28",
+	}
+	snap, changed, err := store.SaveSnapshot(ctx, domain.SCMSnapshot{
+		SessionID:  subj.SessionID,
+		Subject:    subj,
+		Freshness:  domain.SCMFreshnessFresh,
+		ObservedAt: time.Now(),
+		PR: &domain.SCMPullRequest{
+			Number: subj.PRNumber, URL: subj.PRURL, State: domain.PRDraft, Draft: true,
+		},
+		CI: domain.SCMCI{Summary: "failing"},
+	})
+	if err != nil || !changed {
+		t.Fatalf("save snapshot changed=%v err=%v", changed, err)
+	}
+	lcm := &captureLCM{}
+	consumer := NewConsumer(store, lcm, nil)
+	payload, _ := json.Marshal(map[string]any{"sessionId": string(subj.SessionID), "revision": snap.Revision})
+	event := cdc.Event{Seq: 1, ProjectID: "mer", SessionID: string(subj.SessionID), Type: cdc.EventSCMSnapshotCreated, Payload: payload}
+	if err := consumer.Handle(ctx, event); err != nil {
+		t.Fatal(err)
+	}
+	if err := consumer.Handle(ctx, event); err != nil {
+		t.Fatal(err)
+	}
+	if lcm.calls != 1 {
+		t.Fatalf("consumer should apply event once, got %d calls", lcm.calls)
+	}
+	if !lcm.last.Fetched || lcm.last.PRState != domain.PRDraft || !lcm.last.Draft || lcm.last.CISummary != ports.CIFailing {
+		t.Fatalf("facts not projected correctly: %+v", lcm.last)
+	}
+}
+
+type captureLCM struct {
+	calls int
+	last  ports.SCMFacts
+}
+
+func (c *captureLCM) ApplySCMObservation(_ context.Context, _ domain.SessionID, f ports.SCMFacts) error {
+	c.calls++
+	c.last = f
+	return nil
+}
+func (c *captureLCM) ApplyRuntimeObservation(context.Context, domain.SessionID, ports.RuntimeFacts) error {
+	return nil
+}
+func (c *captureLCM) ApplyActivitySignal(context.Context, domain.SessionID, ports.ActivitySignal) error {
+	return nil
+}
+func (c *captureLCM) ApplyPRObservation(context.Context, domain.SessionID, ports.PRObservation) error {
+	return nil
+}
+func (c *captureLCM) OnSpawnCompleted(context.Context, domain.SessionID, ports.SpawnOutcome) error {
+	return nil
+}
+func (c *captureLCM) OnKillRequested(context.Context, domain.SessionID, domain.TerminationReason) error {
+	return nil
+}
+func (c *captureLCM) TickEscalations(context.Context, time.Time) error { return nil }
+func (c *captureLCM) RunningSessions(context.Context) ([]domain.SessionRecord, error) {
+	return nil, nil
+}

--- a/backend/internal/scm/logging/logging.go
+++ b/backend/internal/scm/logging/logging.go
@@ -1,0 +1,337 @@
+package logging
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const (
+	FieldCorrelationID       = "correlation_id"
+	FieldProvider            = "provider"
+	FieldHost                = "host"
+	FieldRepo                = "repo"
+	FieldProjectID           = "project_id"
+	FieldSessionID           = "session_id"
+	FieldSessionCount        = "session_count"
+	FieldSnapshotCount       = "snapshot_count"
+	FieldChangedCount        = "changed_count"
+	FieldChangeRequestNumber = "change_request_number"
+	FieldOperation           = "operation"
+	FieldCommand             = "command"
+	FieldActor               = "actor"
+	FieldFreshness           = "freshness"
+	FieldDurationMS          = "duration_ms"
+	FieldMethod              = "method"
+	FieldEndpointTemplate    = "endpoint_template"
+	FieldStatusCode          = "status_code"
+	FieldErrorKind           = "error_kind"
+	FieldCacheHit            = "cache_hit"
+	FieldETagPresent         = "etag_present"
+	FieldRateLimitLimit      = "rate_limit_limit"
+	FieldRateLimitRemaining  = "rate_limit_remaining"
+	FieldRateLimitReset      = "rate_limit_reset"
+	FieldBackoffUntil        = "backoff_until"
+	FieldRateLimitUntil      = "rate_limit_until"
+)
+
+const (
+	EventObserveStarted       = "scm.observe.started"
+	EventObserveCompleted     = "scm.observe.completed"
+	EventObserveFailed        = "scm.observe.failed"
+	EventSnapshotSaved        = "scm.snapshot.saved"
+	EventSnapshotUnchanged    = "scm.snapshot.unchanged"
+	EventSnapshotUnavailable  = "scm.snapshot.unavailable"
+	EventCommandStarted       = "scm.command.started"
+	EventCommandCompleted     = "scm.command.completed"
+	EventCommandFailed        = "scm.command.failed"
+	EventCommandCacheInvalid  = "scm.command.cache_invalidated"
+	EventCommandRefreshFailed = "scm.command.refresh_failed"
+	EventCommandAuditFailed   = "scm.command.audit_failed"
+	EventTransportRequest     = "scm.transport.request"
+	EventTransportResponse    = "scm.transport.response"
+	EventTransportFailed      = "scm.transport.failed"
+	EventTransportRateLimited = "scm.transport.rate_limited"
+)
+
+const maxDiagnosticMessage = 300
+
+type correlationKey struct{}
+
+// Logger returns the supplied logger or slog.Default when nil.
+func Logger(logger *slog.Logger) *slog.Logger {
+	if logger != nil {
+		return logger
+	}
+	return slog.Default()
+}
+
+// WithCorrelationID stores an already-safe correlation id in ctx.
+func WithCorrelationID(ctx context.Context, id string) context.Context {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, correlationKey{}, id)
+}
+
+// CorrelationID returns the SCM correlation id from ctx, if any.
+func CorrelationID(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	id, _ := ctx.Value(correlationKey{}).(string)
+	return id
+}
+
+// EnsureCorrelationID returns a context carrying a correlation id and that id.
+func EnsureCorrelationID(ctx context.Context) (context.Context, string) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if id := CorrelationID(ctx); id != "" {
+		return ctx, id
+	}
+	id := newCorrelationID()
+	return WithCorrelationID(ctx, id), id
+}
+
+func newCorrelationID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err == nil {
+		return hex.EncodeToString(b[:])
+	}
+	return hex.EncodeToString([]byte(time.Now().UTC().Format("20060102150405.000000000")))
+}
+
+func CorrelationAttr(ctx context.Context) slog.Attr {
+	return slog.String(FieldCorrelationID, CorrelationID(ctx))
+}
+
+func SubjectAttrs(subj domain.SCMSubject) []slog.Attr {
+	attrs := []slog.Attr{
+		slog.String(FieldProvider, string(subj.Provider)),
+		slog.String(FieldHost, subj.Host),
+		slog.String(FieldRepo, subj.Repo),
+		slog.String(FieldProjectID, string(subj.ProjectID)),
+	}
+	if subj.SessionID != "" {
+		attrs = append(attrs, slog.String(FieldSessionID, string(subj.SessionID)))
+	}
+	if subj.PRNumber > 0 {
+		attrs = append(attrs, slog.Int(FieldChangeRequestNumber, subj.PRNumber))
+	}
+	return attrs
+}
+
+func RepositoryAttrs(provider domain.SCMProvider, host, repo string, projectID domain.ProjectID) []slog.Attr {
+	return []slog.Attr{
+		slog.String(FieldProvider, string(provider)),
+		slog.String(FieldHost, host),
+		slog.String(FieldRepo, repo),
+		slog.String(FieldProjectID, string(projectID)),
+	}
+}
+
+func SnapshotAttrs(snap domain.SCMSnapshot) []slog.Attr {
+	attrs := SubjectAttrs(snap.Subject)
+	if snap.SessionID != "" && snap.Subject.SessionID == "" {
+		attrs = append(attrs, slog.String(FieldSessionID, string(snap.SessionID)))
+	}
+	if snap.PR != nil && snap.PR.Number > 0 && snap.Subject.PRNumber == 0 {
+		attrs = append(attrs, slog.Int(FieldChangeRequestNumber, snap.PR.Number))
+	}
+	if snap.Freshness != "" {
+		attrs = append(attrs, slog.String(FieldFreshness, string(snap.Freshness)))
+	}
+	return attrs
+}
+
+func CommandAttrs(req ports.SCMCommandRequest) []slog.Attr {
+	attrs := SubjectAttrs(req.Subject)
+	attrs = append(attrs, slog.String(FieldCommand, string(req.Command)))
+	if req.Actor != "" {
+		attrs = append(attrs, slog.String(FieldActor, req.Actor))
+	}
+	if req.ChangeRequest.Number > 0 && req.Subject.PRNumber != req.ChangeRequest.Number {
+		attrs = append(attrs, slog.Int(FieldChangeRequestNumber, req.ChangeRequest.Number))
+	}
+	return attrs
+}
+
+func RateLimitAttrs(rl *domain.SCMRateLimit) []slog.Attr {
+	if rl == nil {
+		return nil
+	}
+	attrs := []slog.Attr{
+		slog.Int(FieldRateLimitLimit, rl.Limit),
+		slog.Int(FieldRateLimitRemaining, rl.Remaining),
+	}
+	if !rl.ResetAt.IsZero() {
+		attrs = append(attrs, slog.Time(FieldRateLimitReset, rl.ResetAt))
+	}
+	return attrs
+}
+
+func PollStateAttrs(states []domain.SCMPollState) []slog.Attr {
+	var backoff time.Time
+	var rateLimit time.Time
+	for _, st := range states {
+		if !st.BackoffUntil.IsZero() && (backoff.IsZero() || st.BackoffUntil.Before(backoff)) {
+			backoff = st.BackoffUntil
+		}
+		if !st.RateLimitUntil.IsZero() && (rateLimit.IsZero() || st.RateLimitUntil.Before(rateLimit)) {
+			rateLimit = st.RateLimitUntil
+		}
+	}
+	attrs := []slog.Attr{}
+	if !backoff.IsZero() {
+		attrs = append(attrs, slog.Time(FieldBackoffUntil, backoff))
+	}
+	if !rateLimit.IsZero() {
+		attrs = append(attrs, slog.Time(FieldRateLimitUntil, rateLimit))
+	}
+	return attrs
+}
+
+func ErrorAttrs(err error) []slog.Attr {
+	kind := ErrorKind(err)
+	attrs := []slog.Attr{}
+	if kind != "" {
+		attrs = append(attrs, slog.String(FieldErrorKind, string(kind)))
+	}
+	var se *domain.SCMError
+	if errors.As(err, &se) {
+		if se.StatusCode != 0 {
+			attrs = append(attrs, slog.Int(FieldStatusCode, se.StatusCode))
+		}
+		if !se.RetryAfter.IsZero() {
+			attrs = append(attrs, slog.Time(FieldRateLimitUntil, se.RetryAfter))
+		}
+	}
+	return attrs
+}
+
+func ErrorKind(err error) domain.SCMErrorKind {
+	if err == nil {
+		return ""
+	}
+	var se *domain.SCMError
+	if errors.As(err, &se) && se.Kind != "" {
+		return se.Kind
+	}
+	return domain.SCMErrorUnavailable
+}
+
+func SCMError(err error) (*domain.SCMError, bool) {
+	var se *domain.SCMError
+	if errors.As(err, &se) {
+		return se, true
+	}
+	return nil, false
+}
+
+func DurationMS(started time.Time) int64 {
+	if started.IsZero() {
+		return 0
+	}
+	return time.Since(started).Milliseconds()
+}
+
+func Freshness(snapshots []domain.SCMSnapshot, unavailable bool) domain.SCMFreshness {
+	if unavailable {
+		return domain.SCMFreshnessUnavailable
+	}
+	if len(snapshots) == 0 {
+		return ""
+	}
+	freshness := snapshots[0].Freshness
+	for _, snap := range snapshots[1:] {
+		if snap.Freshness != freshness {
+			return "mixed"
+		}
+	}
+	return freshness
+}
+
+func DiagnosticFromError(operation string, err error) domain.SCMDiagnostic {
+	d := domain.SCMDiagnostic{Operation: operation, ErrorKind: domain.SCMErrorUnavailable, Message: SafeDiagnosticMessage(err)}
+	var se *domain.SCMError
+	if errors.As(err, &se) {
+		d.Operation = firstNonEmpty(se.Operation, operation)
+		d.ErrorKind = se.Kind
+		d.StatusCode = se.StatusCode
+		d.Message = SafeDiagnosticMessage(se)
+	}
+	return d
+}
+
+func SafeDiagnosticMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	var se *domain.SCMError
+	if errors.As(err, &se) {
+		msg := se.Message
+		if msg == "" && se.StatusCode != 0 {
+			msg = http.StatusText(se.StatusCode)
+		}
+		return truncateOneLine(msg, maxDiagnosticMessage)
+	}
+	return "operation failed"
+}
+
+func StatusMessage(status int, _ []byte, jsonMessage string) string {
+	if strings.TrimSpace(jsonMessage) != "" {
+		return truncateOneLine(jsonMessage, maxDiagnosticMessage)
+	}
+	if text := http.StatusText(status); text != "" {
+		return text
+	}
+	return "provider request failed"
+}
+
+func Add(attrs []slog.Attr, more ...slog.Attr) []slog.Attr {
+	return append(attrs, more...)
+}
+
+func Args(attrs []slog.Attr) []any {
+	args := make([]any, 0, len(attrs))
+	for _, attr := range attrs {
+		if attr.Key == "" {
+			continue
+		}
+		args = append(args, attr)
+	}
+	return args
+}
+
+func truncateOneLine(s string, limit int) string {
+	s = strings.TrimSpace(s)
+	s = strings.Join(strings.Fields(s), " ")
+	if limit <= 0 || len(s) <= limit {
+		return s
+	}
+	if limit <= 1 {
+		return s[:limit]
+	}
+	if limit <= 3 {
+		return s[:limit]
+	}
+	return s[:limit-3] + "..."
+}
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}

--- a/backend/internal/scm/observer/observer.go
+++ b/backend/internal/scm/observer/observer.go
@@ -207,7 +207,7 @@ func FactsFromSnapshot(s domain.SCMSnapshot) ports.SCMFacts {
 		Blockers:    append([]string(nil), s.Mergeability.Blockers...),
 	}
 	for _, check := range s.CI.Checks {
-		if isFailedConclusion(check.Conclusion) || isFailedConclusion(check.Status) {
+		if failedCompletedCheck(check) {
 			f.CIFailedChecks = append(f.CIFailedChecks, ports.CICheck{Name: check.Name, Status: check.Status, Conclusion: check.Conclusion, URL: check.URL, Details: check.Details, LogTail: check.LogTail})
 		}
 	}
@@ -255,8 +255,19 @@ func reviewDecision(s string) ports.ReviewDecision {
 }
 
 func isFailedConclusion(s string) bool {
-	s = strings.ToLower(s)
+	s = strings.ToLower(strings.TrimSpace(s))
 	return s == "failure" || s == "failed" || s == "failing" || s == "error" || s == "timed_out" || s == "cancelled" || s == "action_required"
+}
+
+func failedCompletedCheck(check domain.SCMCheck) bool {
+	if check.Conclusion != "" {
+		status := strings.ToLower(strings.TrimSpace(check.Status))
+		if status == "" || status == "completed" || status == "complete" {
+			return isFailedConclusion(check.Conclusion)
+		}
+		return false
+	}
+	return isFailedConclusion(check.Status)
 }
 
 func firstNonEmpty(a, b string) string {

--- a/backend/internal/scm/observer/observer.go
+++ b/backend/internal/scm/observer/observer.go
@@ -282,6 +282,7 @@ func FactsFromSnapshot(s domain.SCMSnapshot) ports.SCMFacts {
 	f.Draft = s.PR.Draft
 	f.PRNumber = s.PR.Number
 	f.PRURL = s.PR.URL
+	f.HeadSHA = s.PR.HeadSHA
 	f.CISummary = ciSummary(s.CI.Summary)
 	f.ReviewDecision = reviewDecision(s.Review.Decision)
 	f.Mergeability = ports.Mergeability{

--- a/backend/internal/scm/observer/observer.go
+++ b/backend/internal/scm/observer/observer.go
@@ -1,0 +1,317 @@
+package observer
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// Observer coordinates provider polling, durable snapshot writes, event fanout
+// and lifecycle application. It owns no provider-specific logic.
+type Observer struct {
+	Store     ports.SCMStore
+	LCM       ports.LifecycleManager
+	Providers map[domain.SCMProvider]ports.SCMProvider
+	Clock     func() time.Time
+
+	// OnSnapshot is the first-pass in-process fanout hook for API/dashboard live
+	// updates. Durable outbox/replay can replace it later without changing
+	// provider adapters.
+	OnSnapshot func(context.Context, domain.SCMSnapshot) error
+}
+
+var _ ports.SCMObserver = (*Observer)(nil)
+
+func New(store ports.SCMStore, lcm ports.LifecycleManager, providers ...ports.SCMProvider) *Observer {
+	o := &Observer{Store: store, LCM: lcm, Providers: map[domain.SCMProvider]ports.SCMProvider{}, Clock: time.Now}
+	for _, p := range providers {
+		if p != nil {
+			o.Providers[p.Provider()] = p
+		}
+	}
+	return o
+}
+
+func (o *Observer) RefreshSession(ctx context.Context, sessionID domain.SessionID) error {
+	subj, ok, err := o.Store.GetSubject(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("scm observer: subject %s not found", sessionID)
+	}
+	return o.Refresh(ctx, []domain.SCMSubject{subj})
+}
+
+func (o *Observer) Invalidate(ctx context.Context, subject domain.SCMSubject, reason string) error {
+	prefix := domain.SCMProviderCachePrefix{SCMProviderCacheScope: subject.CacheScope()}
+	if err := o.Store.DeleteProviderCache(ctx, prefix); err != nil {
+		return err
+	}
+	return o.Refresh(ctx, []domain.SCMSubject{subject})
+}
+
+func (o *Observer) Refresh(ctx context.Context, subjects []domain.SCMSubject) error {
+	if o.Store == nil {
+		return fmt.Errorf("scm observer: nil store")
+	}
+	if o.Clock == nil {
+		o.Clock = time.Now
+	}
+	byProvider := map[domain.SCMProvider][]domain.SCMSubject{}
+	for _, subj := range subjects {
+		if subj.Provider == "" {
+			subj.Provider = domain.SCMProviderGitHub
+		}
+		if subj.SessionID == "" {
+			continue
+		}
+		byProvider[subj.Provider] = append(byProvider[subj.Provider], subj)
+	}
+
+	var firstErr error
+	for providerID, group := range byProvider {
+		provider := o.Providers[providerID]
+		if provider == nil {
+			if firstErr == nil {
+				firstErr = &domain.SCMError{Kind: domain.SCMErrorUnsupported, Operation: "observe", Message: fmt.Sprintf("provider %q not registered", providerID)}
+			}
+			continue
+		}
+		res, err := provider.ObserveSessions(ctx, ports.SCMObserveRequest{Subjects: group, Now: o.Clock()}, o.Store)
+		for _, subj := range res.Subjects {
+			if upsertErr := o.Store.UpsertSubject(ctx, subj); upsertErr != nil {
+				return upsertErr
+			}
+		}
+		for _, st := range res.PollStates {
+			if pollErr := o.Store.PutPollState(ctx, st); pollErr != nil {
+				return pollErr
+			}
+		}
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			for _, subj := range group {
+				if saveErr := o.saveAndApply(ctx, unavailableSnapshot(subj, o.Clock(), err)); saveErr != nil && firstErr == nil {
+					firstErr = saveErr
+				}
+			}
+			continue
+		}
+		for _, snap := range res.Snapshots {
+			if saveErr := o.saveAndApply(ctx, snap); saveErr != nil {
+				return saveErr
+			}
+		}
+	}
+	return firstErr
+}
+
+func (o *Observer) saveAndApply(ctx context.Context, snap domain.SCMSnapshot) error {
+	saved, changed, err := o.Store.SaveSnapshot(ctx, snap)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+	if o.OnSnapshot != nil {
+		if err := o.OnSnapshot(ctx, saved); err != nil {
+			return err
+		}
+	}
+	if o.LCM != nil {
+		if err := o.LCM.ApplySCMObservation(ctx, saved.SessionID, FactsFromSnapshot(saved)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func unavailableSnapshot(subj domain.SCMSubject, now time.Time, err error) domain.SCMSnapshot {
+	d := domain.SCMDiagnostic{Operation: "observe", ErrorKind: domain.SCMErrorUnavailable, Message: errString(err)}
+	if se, ok := err.(*domain.SCMError); ok {
+		d.ErrorKind = se.Kind
+		d.StatusCode = se.StatusCode
+		d.Operation = se.Operation
+	}
+	return domain.SCMSnapshot{SessionID: subj.SessionID, Subject: subj, Freshness: domain.SCMFreshnessUnavailable, ObservedAt: now, Diagnostics: []domain.SCMDiagnostic{d}}
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+// FactsFromSnapshot projects normalized SCM snapshots into the existing LCM DTO.
+func FactsFromSnapshot(s domain.SCMSnapshot) ports.SCMFacts {
+	f := ports.SCMFacts{ObservedAt: s.ObservedAt, Fetched: s.Freshness != domain.SCMFreshnessUnavailable}
+	if !f.Fetched {
+		return f
+	}
+	if s.PR == nil {
+		f.PRState = domain.PRNone
+		return f
+	}
+	f.PRState = s.PR.State
+	f.Draft = s.PR.Draft
+	f.PRNumber = s.PR.Number
+	f.PRURL = s.PR.URL
+	f.CISummary = ciSummary(s.CI.Summary)
+	f.ReviewDecision = reviewDecision(s.Review.Decision)
+	f.Mergeability = ports.Mergeability{
+		Mergeable:   s.Mergeability.Mergeable,
+		CIPassing:   s.Mergeability.CIPassing,
+		Approved:    s.Mergeability.Approved,
+		NoConflicts: s.Mergeability.NoConflicts,
+		Blockers:    append([]string(nil), s.Mergeability.Blockers...),
+	}
+	for _, check := range s.CI.Checks {
+		if isFailedConclusion(check.Conclusion) || isFailedConclusion(check.Status) {
+			f.CIFailedChecks = append(f.CIFailedChecks, ports.CICheck{Name: check.Name, Status: check.Status, Conclusion: check.Conclusion, URL: check.URL, Details: check.Details, LogTail: check.LogTail})
+		}
+	}
+	if s.CI.FailureLogTail != "" {
+		tail := s.CI.FailureLogTail
+		f.CIFailureLogTail = &tail
+	}
+	for _, th := range s.Review.UnresolvedThreads {
+		for _, c := range th.Comments {
+			f.PendingComments = append(f.PendingComments, ports.ReviewComment{Author: c.Author, Body: c.Body, IsBot: c.IsBot, URL: firstNonEmpty(c.URL, th.URL), Path: firstNonEmpty(c.Path, th.Path), Line: firstNonZero(c.Line, th.Line), ThreadID: firstNonEmpty(c.ThreadID, th.ID)})
+		}
+	}
+	return f
+}
+
+func ciSummary(s string) ports.CISummary {
+	switch domain.NormalizeSCMCI(s) {
+	case "passing":
+		return ports.CIPassing
+	case "failing":
+		return ports.CIFailing
+	case "pending":
+		return ports.CIPending
+	default:
+		return ports.CINone
+	}
+}
+
+func reviewDecision(s string) ports.ReviewDecision {
+	switch domain.NormalizeSCMReviewDecision(s) {
+	case "approved":
+		return ports.ReviewApproved
+	case "changes_requested":
+		return ports.ReviewChangesRequested
+	case "pending":
+		return ports.ReviewPending
+	default:
+		return ports.ReviewNone
+	}
+}
+
+func isFailedConclusion(s string) bool {
+	s = strings.ToLower(s)
+	return s == "failure" || s == "failed" || s == "failing" || s == "error" || s == "timed_out" || s == "cancelled" || s == "action_required"
+}
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}
+
+func firstNonZero(a, b int) int {
+	if a != 0 {
+		return a
+	}
+	return b
+}
+
+// SubjectConfig tells the observer how to bind sessions to GitHub subjects.
+type SubjectConfig struct {
+	Provider       domain.SCMProvider
+	Host           string
+	Repo           string
+	BaseBranch     string
+	CredentialHash string
+}
+
+// SubjectsFromSessions creates/updates SCM subjects from active sessions. Repo
+// and provider come from config; branch and known PR metadata can be present on
+// the SessionRecord metadata. Terminal sessions are intentionally ignored.
+func SubjectsFromSessions(sessions []domain.Session, cfg SubjectConfig) []domain.SCMSubject {
+	if cfg.Provider == "" {
+		cfg.Provider = domain.SCMProviderGitHub
+	}
+	if cfg.Host == "" {
+		cfg.Host = "github.com"
+	}
+	out := make([]domain.SCMSubject, 0, len(sessions))
+	for _, s := range sessions {
+		if isTerminalSession(s.Lifecycle.Session.State) {
+			continue
+		}
+		branch := metadataFirst(s.Metadata, "branch", "scm.branch", "github.branch")
+		if branch == "" {
+			continue
+		}
+		repo := metadataFirst(s.Metadata, "repo", "repository", "github.repo")
+		if repo == "" {
+			repo = cfg.Repo
+		}
+		if repo == "" {
+			continue
+		}
+		prURL := metadataFirst(s.Metadata, "prUrl", "prURL", "github.prUrl")
+		prNumber := parsePRNumber(metadataFirst(s.Metadata, "prNumber", "github.prNumber"), prURL)
+		out = append(out, domain.SCMSubject{SessionID: s.ID, ProjectID: s.ProjectID, Provider: cfg.Provider, Host: cfg.Host, Repo: repo, Branch: branch, BaseBranch: cfg.BaseBranch, CredentialHash: cfg.CredentialHash, PRNumber: prNumber, PRURL: prURL})
+	}
+	return out
+}
+
+func isTerminalSession(s domain.SessionState) bool {
+	return s == domain.SessionDone || s == domain.SessionTerminated
+}
+
+func metadataFirst(m map[string]string, keys ...string) string {
+	for _, k := range keys {
+		if v := strings.TrimSpace(m[k]); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func parsePRNumber(raw, prURL string) int {
+	if raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil {
+			return n
+		}
+	}
+	if prURL == "" {
+		return 0
+	}
+	u, err := url.Parse(prURL)
+	if err != nil {
+		return 0
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	for i := 0; i < len(parts)-1; i++ {
+		if parts[i] == "pull" {
+			n, _ := strconv.Atoi(parts[i+1])
+			return n
+		}
+	}
+	return 0
+}

--- a/backend/internal/scm/observer/observer.go
+++ b/backend/internal/scm/observer/observer.go
@@ -3,6 +3,7 @@ package observer
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"strconv"
 	"strings"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	scmlog "github.com/aoagents/agent-orchestrator/backend/internal/scm/logging"
 )
 
 // Observer coordinates provider polling, durable snapshot writes, event fanout
@@ -19,6 +21,7 @@ type Observer struct {
 	LCM       ports.LifecycleManager
 	Providers map[domain.SCMProvider]ports.SCMProvider
 	Clock     func() time.Time
+	Logger    *slog.Logger
 
 	// OnSnapshot is the first-pass in-process fanout hook for API/dashboard live
 	// updates. Durable outbox/replay can replace it later without changing
@@ -58,13 +61,17 @@ func (o *Observer) Invalidate(ctx context.Context, subject domain.SCMSubject, re
 }
 
 func (o *Observer) Refresh(ctx context.Context, subjects []domain.SCMSubject) error {
+	ctx, _ = scmlog.EnsureCorrelationID(ctx)
+	logger := scmlog.Logger(o.Logger)
 	if o.Store == nil {
-		return fmt.Errorf("scm observer: nil store")
+		err := fmt.Errorf("scm observer: nil store")
+		logger.Error(scmlog.EventObserveFailed, scmlog.Args(scmlog.Add(scmlog.ErrorAttrs(err), scmlog.CorrelationAttr(ctx)))...)
+		return err
 	}
 	if o.Clock == nil {
 		o.Clock = time.Now
 	}
-	byProvider := map[domain.SCMProvider][]domain.SCMSubject{}
+	byGroup := map[observeGroupKey][]domain.SCMSubject{}
 	defaultProvider, hasDefaultProvider := o.singleProvider()
 	var firstErr error
 	for _, subj := range subjects {
@@ -75,30 +82,44 @@ func (o *Observer) Refresh(ctx context.Context, subjects []domain.SCMSubject) er
 			subj.Provider = defaultProvider
 		}
 		if subj.Provider == "" {
+			err := &domain.SCMError{Kind: domain.SCMErrorUnsupported, Operation: "observe", Message: "subject provider is required when observer has zero or multiple providers"}
+			logObserveFailure(ctx, logger, subj, 1, 0, 0, 0, nil, err)
 			if firstErr == nil {
-				firstErr = &domain.SCMError{Kind: domain.SCMErrorUnsupported, Operation: "observe", Message: "subject provider is required when observer has zero or multiple providers"}
+				firstErr = err
 			}
 			continue
 		}
-		byProvider[subj.Provider] = append(byProvider[subj.Provider], subj)
+		key := observeGroupKey{Provider: subj.Provider, Host: subj.Host, Repo: subj.Repo, ProjectID: subj.ProjectID}
+		byGroup[key] = append(byGroup[key], subj)
 	}
 
-	for providerID, group := range byProvider {
-		provider := o.Providers[providerID]
+	for key, group := range byGroup {
+		provider := o.Providers[key.Provider]
+		started := time.Now()
+		startAttrs := scmlog.Add(scmlog.RepositoryAttrs(key.Provider, key.Host, key.Repo, key.ProjectID),
+			scmlog.CorrelationAttr(ctx),
+			slog.Int(scmlog.FieldSessionCount, len(group)),
+		)
+		logger.Info(scmlog.EventObserveStarted, scmlog.Args(startAttrs)...)
 		if provider == nil {
+			err := &domain.SCMError{Kind: domain.SCMErrorUnsupported, Operation: "observe", Message: fmt.Sprintf("provider %q not registered", key.Provider)}
+			logObserveFailure(ctx, logger, group[0], len(group), 0, 0, scmlog.DurationMS(started), nil, err)
 			if firstErr == nil {
-				firstErr = &domain.SCMError{Kind: domain.SCMErrorUnsupported, Operation: "observe", Message: fmt.Sprintf("provider %q not registered", providerID)}
+				firstErr = err
 			}
 			continue
 		}
 		res, err := provider.ObserveSessions(ctx, ports.SCMObserveRequest{Subjects: group, Now: o.Clock()}, o.Store)
+		changedCount := 0
 		for _, subj := range res.Subjects {
 			if upsertErr := o.Store.UpsertSubject(ctx, subj); upsertErr != nil {
+				logObserveFailure(ctx, logger, group[0], len(group), len(res.Snapshots), changedCount, scmlog.DurationMS(started), nil, upsertErr)
 				return upsertErr
 			}
 		}
 		for _, st := range res.PollStates {
 			if pollErr := o.Store.PutPollState(ctx, st); pollErr != nil {
+				logObserveFailure(ctx, logger, group[0], len(group), len(res.Snapshots), changedCount, scmlog.DurationMS(started), nil, pollErr)
 				return pollErr
 			}
 		}
@@ -108,8 +129,17 @@ func (o *Observer) Refresh(ctx context.Context, subjects []domain.SCMSubject) er
 			}
 			saved := map[domain.SessionID]bool{}
 			for _, snap := range res.Snapshots {
-				if saveErr := o.saveAndApply(ctx, snap); saveErr != nil && firstErr == nil {
-					firstErr = saveErr
+				changed, saveErr := o.saveAndApply(ctx, snap)
+				if saveErr != nil {
+					logObserveFailure(ctx, logger, snap.Subject, len(group), len(res.Snapshots), changedCount, scmlog.DurationMS(started), res.PollStates, saveErr)
+					if firstErr == nil {
+						firstErr = saveErr
+					}
+				} else {
+					if changed {
+						changedCount++
+					}
+					logSnapshot(ctx, logger, snap, changed)
 				}
 				saved[snap.SessionID] = true
 			}
@@ -117,19 +147,56 @@ func (o *Observer) Refresh(ctx context.Context, subjects []domain.SCMSubject) er
 				if saved[subj.SessionID] {
 					continue
 				}
-				if saveErr := o.saveAndApply(ctx, unavailableSnapshot(subj, o.Clock(), err)); saveErr != nil && firstErr == nil {
-					firstErr = saveErr
+				snap := unavailableSnapshot(subj, o.Clock(), err)
+				changed, saveErr := o.saveAndApply(ctx, snap)
+				if saveErr != nil {
+					logObserveFailure(ctx, logger, subj, len(group), len(res.Snapshots), changedCount, scmlog.DurationMS(started), res.PollStates, saveErr)
+					if firstErr == nil {
+						firstErr = saveErr
+					}
+				} else {
+					if changed {
+						changedCount++
+					}
+					logSnapshot(ctx, logger, snap, changed)
 				}
 			}
+			logObserveFailure(ctx, logger, group[0], len(group), len(res.Snapshots), changedCount, scmlog.DurationMS(started), res.PollStates, err)
 			continue
 		}
 		for _, snap := range res.Snapshots {
-			if saveErr := o.saveAndApply(ctx, snap); saveErr != nil {
+			changed, saveErr := o.saveAndApply(ctx, snap)
+			if saveErr != nil {
+				logObserveFailure(ctx, logger, snap.Subject, len(group), len(res.Snapshots), changedCount, scmlog.DurationMS(started), res.PollStates, saveErr)
 				return saveErr
 			}
+			if changed {
+				changedCount++
+			}
+			logSnapshot(ctx, logger, snap, changed)
 		}
+		attrs := scmlog.Add(scmlog.RepositoryAttrs(key.Provider, key.Host, key.Repo, key.ProjectID),
+			scmlog.CorrelationAttr(ctx),
+			slog.Int(scmlog.FieldSessionCount, len(group)),
+			slog.Int(scmlog.FieldSnapshotCount, len(res.Snapshots)),
+			slog.Int(scmlog.FieldChangedCount, changedCount),
+			slog.Int64(scmlog.FieldDurationMS, scmlog.DurationMS(started)),
+		)
+		if freshness := scmlog.Freshness(res.Snapshots, res.Unavailable); freshness != "" {
+			attrs = append(attrs, slog.String(scmlog.FieldFreshness, string(freshness)))
+		}
+		attrs = append(attrs, scmlog.RateLimitAttrs(res.RateLimit)...)
+		attrs = append(attrs, scmlog.PollStateAttrs(res.PollStates)...)
+		logger.Info(scmlog.EventObserveCompleted, scmlog.Args(attrs)...)
 	}
 	return firstErr
+}
+
+type observeGroupKey struct {
+	Provider  domain.SCMProvider
+	Host      string
+	Repo      string
+	ProjectID domain.ProjectID
 }
 
 func (o *Observer) singleProvider() (domain.SCMProvider, bool) {
@@ -142,42 +209,65 @@ func (o *Observer) singleProvider() (domain.SCMProvider, bool) {
 	return "", false
 }
 
-func (o *Observer) saveAndApply(ctx context.Context, snap domain.SCMSnapshot) error {
+func (o *Observer) saveAndApply(ctx context.Context, snap domain.SCMSnapshot) (bool, error) {
 	saved, changed, err := o.Store.SaveSnapshot(ctx, snap)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if !changed {
-		return nil
+		return false, nil
 	}
 	if o.OnSnapshot != nil {
 		if err := o.OnSnapshot(ctx, saved); err != nil {
-			return err
+			return true, err
 		}
 	}
 	if o.LCM != nil {
 		if err := o.LCM.ApplySCMObservation(ctx, saved.SessionID, FactsFromSnapshot(saved)); err != nil {
-			return err
+			return true, err
 		}
 	}
-	return nil
+	return true, nil
 }
 
 func unavailableSnapshot(subj domain.SCMSubject, now time.Time, err error) domain.SCMSnapshot {
-	d := domain.SCMDiagnostic{Operation: "observe", ErrorKind: domain.SCMErrorUnavailable, Message: errString(err)}
-	if se, ok := err.(*domain.SCMError); ok {
-		d.ErrorKind = se.Kind
-		d.StatusCode = se.StatusCode
-		d.Operation = se.Operation
-	}
+	d := scmlog.DiagnosticFromError("observe", err)
 	return domain.SCMSnapshot{SessionID: subj.SessionID, Subject: subj, Freshness: domain.SCMFreshnessUnavailable, ObservedAt: now, Diagnostics: []domain.SCMDiagnostic{d}}
 }
 
-func errString(err error) string {
-	if err == nil {
-		return ""
+func logObserveFailure(ctx context.Context, logger *slog.Logger, subj domain.SCMSubject, sessionCount, snapshotCount, changedCount int, durationMS int64, pollStates []domain.SCMPollState, err error) {
+	attrs := scmlog.Add(scmlog.SubjectAttrs(subj),
+		scmlog.CorrelationAttr(ctx),
+		slog.Int(scmlog.FieldSessionCount, sessionCount),
+		slog.Int(scmlog.FieldSnapshotCount, snapshotCount),
+		slog.Int(scmlog.FieldChangedCount, changedCount),
+		slog.Int64(scmlog.FieldDurationMS, durationMS),
+	)
+	attrs = append(attrs, scmlog.ErrorAttrs(err)...)
+	attrs = append(attrs, scmlog.PollStateAttrs(pollStates)...)
+	if _, ok := scmlog.SCMError(err); ok {
+		logger.Warn(scmlog.EventObserveFailed, scmlog.Args(attrs)...)
+		return
 	}
-	return err.Error()
+	logger.Error(scmlog.EventObserveFailed, scmlog.Args(attrs)...)
+}
+
+func logSnapshot(ctx context.Context, logger *slog.Logger, snap domain.SCMSnapshot, changed bool) {
+	attrs := scmlog.Add(scmlog.SnapshotAttrs(snap), scmlog.CorrelationAttr(ctx))
+	for _, diag := range snap.Diagnostics {
+		if diag.ErrorKind != "" {
+			attrs = append(attrs, slog.String(scmlog.FieldErrorKind, string(diag.ErrorKind)))
+			break
+		}
+	}
+	switch {
+	case snap.Freshness == domain.SCMFreshnessUnavailable:
+		logger.Warn(scmlog.EventSnapshotUnavailable, scmlog.Args(attrs)...)
+	case changed:
+		logger.Debug(scmlog.EventSnapshotSaved, scmlog.Args(attrs)...)
+	default:
+		logger.Debug(scmlog.EventSnapshotUnchanged, scmlog.Args(attrs)...)
+	}
 }
 
 // FactsFromSnapshot projects normalized SCM snapshots into the existing LCM DTO.

--- a/backend/internal/scm/observer/observer.go
+++ b/backend/internal/scm/observer/observer.go
@@ -106,7 +106,17 @@ func (o *Observer) Refresh(ctx context.Context, subjects []domain.SCMSubject) er
 			if firstErr == nil {
 				firstErr = err
 			}
+			saved := map[domain.SessionID]bool{}
+			for _, snap := range res.Snapshots {
+				if saveErr := o.saveAndApply(ctx, snap); saveErr != nil && firstErr == nil {
+					firstErr = saveErr
+				}
+				saved[snap.SessionID] = true
+			}
 			for _, subj := range group {
+				if saved[subj.SessionID] {
+					continue
+				}
 				if saveErr := o.saveAndApply(ctx, unavailableSnapshot(subj, o.Clock(), err)); saveErr != nil && firstErr == nil {
 					firstErr = saveErr
 				}
@@ -191,6 +201,9 @@ func FactsFromSnapshot(s domain.SCMSnapshot) ports.SCMFacts {
 		CIPassing:   s.Mergeability.CIPassing,
 		Approved:    s.Mergeability.Approved,
 		NoConflicts: s.Mergeability.NoConflicts,
+		Conflict:    s.Mergeability.Conflict,
+		BehindBase:  s.Mergeability.BehindBase,
+		Unknown:     mergeabilityUnknown(s.Mergeability),
 		Blockers:    append([]string(nil), s.Mergeability.Blockers...),
 	}
 	for _, check := range s.CI.Checks {
@@ -208,6 +221,11 @@ func FactsFromSnapshot(s domain.SCMSnapshot) ports.SCMFacts {
 		}
 	}
 	return f
+}
+
+func mergeabilityUnknown(m domain.SCMMergeability) bool {
+	raw := strings.ToUpper(strings.TrimSpace(m.RawState))
+	return raw == "" || raw == "UNKNOWN"
 }
 
 func ciSummary(s string) ports.CISummary {

--- a/backend/internal/scm/observer/observer.go
+++ b/backend/internal/scm/observer/observer.go
@@ -65,17 +65,24 @@ func (o *Observer) Refresh(ctx context.Context, subjects []domain.SCMSubject) er
 		o.Clock = time.Now
 	}
 	byProvider := map[domain.SCMProvider][]domain.SCMSubject{}
+	defaultProvider, hasDefaultProvider := o.singleProvider()
+	var firstErr error
 	for _, subj := range subjects {
-		if subj.Provider == "" {
-			subj.Provider = domain.SCMProviderGitHub
-		}
 		if subj.SessionID == "" {
+			continue
+		}
+		if subj.Provider == "" && hasDefaultProvider {
+			subj.Provider = defaultProvider
+		}
+		if subj.Provider == "" {
+			if firstErr == nil {
+				firstErr = &domain.SCMError{Kind: domain.SCMErrorUnsupported, Operation: "observe", Message: "subject provider is required when observer has zero or multiple providers"}
+			}
 			continue
 		}
 		byProvider[subj.Provider] = append(byProvider[subj.Provider], subj)
 	}
 
-	var firstErr error
 	for providerID, group := range byProvider {
 		provider := o.Providers[providerID]
 		if provider == nil {
@@ -113,6 +120,16 @@ func (o *Observer) Refresh(ctx context.Context, subjects []domain.SCMSubject) er
 		}
 	}
 	return firstErr
+}
+
+func (o *Observer) singleProvider() (domain.SCMProvider, bool) {
+	if len(o.Providers) != 1 {
+		return "", false
+	}
+	for id := range o.Providers {
+		return id, true
+	}
+	return "", false
 }
 
 func (o *Observer) saveAndApply(ctx context.Context, snap domain.SCMSnapshot) error {
@@ -238,7 +255,7 @@ func firstNonZero(a, b int) int {
 	return b
 }
 
-// SubjectConfig tells the observer how to bind sessions to GitHub subjects.
+// SubjectConfig tells the observer how to bind sessions to SCM subjects.
 type SubjectConfig struct {
 	Provider       domain.SCMProvider
 	Host           string
@@ -251,31 +268,37 @@ type SubjectConfig struct {
 // and provider come from config; branch and known PR metadata can be present on
 // the SessionRecord metadata. Terminal sessions are intentionally ignored.
 func SubjectsFromSessions(sessions []domain.Session, cfg SubjectConfig) []domain.SCMSubject {
-	if cfg.Provider == "" {
-		cfg.Provider = domain.SCMProviderGitHub
-	}
-	if cfg.Host == "" {
-		cfg.Host = "github.com"
-	}
 	out := make([]domain.SCMSubject, 0, len(sessions))
 	for _, s := range sessions {
 		if isTerminalSession(s.Lifecycle.Session.State) {
 			continue
 		}
-		branch := metadataFirst(s.Metadata, "branch", "scm.branch", "github.branch")
+		provider := domain.SCMProvider(metadataFirst(s.Metadata, "provider", "scm.provider"))
+		if provider == "" {
+			provider = cfg.Provider
+		}
+		if provider == "" {
+			continue
+		}
+		host := metadataFirst(s.Metadata, "host", "scm.host")
+		if host == "" {
+			host = cfg.Host
+		}
+		providerPrefix := string(provider)
+		branch := metadataFirst(s.Metadata, metadataKeys(providerPrefix, "branch")...)
 		if branch == "" {
 			continue
 		}
-		repo := metadataFirst(s.Metadata, "repo", "repository", "github.repo")
+		repo := metadataFirst(s.Metadata, append(metadataKeys(providerPrefix, "repo"), "repository")...)
 		if repo == "" {
 			repo = cfg.Repo
 		}
 		if repo == "" {
 			continue
 		}
-		prURL := metadataFirst(s.Metadata, "prUrl", "prURL", "github.prUrl")
-		prNumber := parsePRNumber(metadataFirst(s.Metadata, "prNumber", "github.prNumber"), prURL)
-		out = append(out, domain.SCMSubject{SessionID: s.ID, ProjectID: s.ProjectID, Provider: cfg.Provider, Host: cfg.Host, Repo: repo, Branch: branch, BaseBranch: cfg.BaseBranch, CredentialHash: cfg.CredentialHash, PRNumber: prNumber, PRURL: prURL})
+		prURL := metadataFirst(s.Metadata, metadataKeys(providerPrefix, "prUrl", "prURL")...)
+		prNumber := parsePRNumber(metadataFirst(s.Metadata, metadataKeys(providerPrefix, "prNumber")...), prURL)
+		out = append(out, domain.SCMSubject{SessionID: s.ID, ProjectID: s.ProjectID, Provider: provider, Host: host, Repo: repo, Branch: branch, BaseBranch: cfg.BaseBranch, CredentialHash: cfg.CredentialHash, PRNumber: prNumber, PRURL: prURL})
 	}
 	return out
 }
@@ -293,6 +316,17 @@ func metadataFirst(m map[string]string, keys ...string) string {
 	return ""
 }
 
+func metadataKeys(providerPrefix string, names ...string) []string {
+	keys := make([]string, 0, len(names)*3)
+	for _, name := range names {
+		keys = append(keys, name, "scm."+name)
+		if providerPrefix != "" {
+			keys = append(keys, providerPrefix+"."+name)
+		}
+	}
+	return keys
+}
+
 func parsePRNumber(raw, prURL string) int {
 	if raw != "" {
 		if n, err := strconv.Atoi(raw); err == nil {
@@ -308,7 +342,8 @@ func parsePRNumber(raw, prURL string) int {
 	}
 	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 	for i := 0; i < len(parts)-1; i++ {
-		if parts[i] == "pull" {
+		switch parts[i] {
+		case "pull", "pulls", "pull-requests", "merge_requests", "merge-requests":
 			n, _ := strconv.Atoi(parts[i+1])
 			return n
 		}

--- a/backend/internal/scm/observer/observer.go
+++ b/backend/internal/scm/observer/observer.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
@@ -383,89 +381,33 @@ type SubjectConfig struct {
 	CredentialHash string
 }
 
-// SubjectsFromSessions creates/updates SCM subjects from active sessions. Repo
-// and provider come from config; branch and known PR metadata can be present on
-// the SessionRecord metadata. Terminal sessions are intentionally ignored.
+// SubjectsFromSessions creates/updates SCM subjects from active sessions. Repo,
+// provider and host come from observer config; the source branch comes from the
+// typed SessionRecord metadata. Terminal sessions are intentionally ignored.
 func SubjectsFromSessions(sessions []domain.Session, cfg SubjectConfig) []domain.SCMSubject {
 	out := make([]domain.SCMSubject, 0, len(sessions))
 	for _, s := range sessions {
 		if isTerminalSession(s.Lifecycle.Session.State) {
 			continue
 		}
-		provider := domain.SCMProvider(metadataFirst(s.Metadata, "provider", "scm.provider"))
-		if provider == "" {
-			provider = cfg.Provider
-		}
+		provider := cfg.Provider
 		if provider == "" {
 			continue
 		}
-		host := metadataFirst(s.Metadata, "host", "scm.host")
-		if host == "" {
-			host = cfg.Host
-		}
-		providerPrefix := string(provider)
-		branch := metadataFirst(s.Metadata, metadataKeys(providerPrefix, "branch")...)
+		host := cfg.Host
+		branch := strings.TrimSpace(s.Metadata.Branch)
 		if branch == "" {
 			continue
 		}
-		repo := metadataFirst(s.Metadata, append(metadataKeys(providerPrefix, "repo"), "repository")...)
-		if repo == "" {
-			repo = cfg.Repo
-		}
+		repo := cfg.Repo
 		if repo == "" {
 			continue
 		}
-		prURL := metadataFirst(s.Metadata, metadataKeys(providerPrefix, "prUrl", "prURL")...)
-		prNumber := parsePRNumber(metadataFirst(s.Metadata, metadataKeys(providerPrefix, "prNumber")...), prURL)
-		out = append(out, domain.SCMSubject{SessionID: s.ID, ProjectID: s.ProjectID, Provider: provider, Host: host, Repo: repo, Branch: branch, BaseBranch: cfg.BaseBranch, CredentialHash: cfg.CredentialHash, PRNumber: prNumber, PRURL: prURL})
+		out = append(out, domain.SCMSubject{SessionID: s.ID, ProjectID: s.ProjectID, Provider: provider, Host: host, Repo: repo, Branch: branch, BaseBranch: cfg.BaseBranch, CredentialHash: cfg.CredentialHash})
 	}
 	return out
 }
 
 func isTerminalSession(s domain.SessionState) bool {
 	return s == domain.SessionDone || s == domain.SessionTerminated
-}
-
-func metadataFirst(m map[string]string, keys ...string) string {
-	for _, k := range keys {
-		if v := strings.TrimSpace(m[k]); v != "" {
-			return v
-		}
-	}
-	return ""
-}
-
-func metadataKeys(providerPrefix string, names ...string) []string {
-	keys := make([]string, 0, len(names)*3)
-	for _, name := range names {
-		keys = append(keys, name, "scm."+name)
-		if providerPrefix != "" {
-			keys = append(keys, providerPrefix+"."+name)
-		}
-	}
-	return keys
-}
-
-func parsePRNumber(raw, prURL string) int {
-	if raw != "" {
-		if n, err := strconv.Atoi(raw); err == nil {
-			return n
-		}
-	}
-	if prURL == "" {
-		return 0
-	}
-	u, err := url.Parse(prURL)
-	if err != nil {
-		return 0
-	}
-	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
-	for i := 0; i < len(parts)-1; i++ {
-		switch parts[i] {
-		case "pull", "pulls", "pull-requests", "merge_requests", "merge-requests":
-			n, _ := strconv.Atoi(parts[i+1])
-			return n
-		}
-	}
-	return 0
 }

--- a/backend/internal/scm/observer/observer_test.go
+++ b/backend/internal/scm/observer/observer_test.go
@@ -265,6 +265,84 @@ func TestSubjectsFromSessionsUsesConfigAndTypedBranchMetadataWithoutGitHubDefaul
 	}
 }
 
+func TestSchedulerDerivesSubjectsPreservesBindingsAndSkipsBackoff(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	session := domain.SessionRecord{
+		ID:        "p1-1",
+		ProjectID: "p1",
+		Lifecycle: domain.CanonicalSessionLifecycle{
+			Session: domain.SessionSubstate{State: domain.SessionWorking},
+		},
+		Metadata: domain.SessionMetadata{Branch: "feat/27"},
+	}
+	if err := st.UpsertSubject(ctx, domain.SCMSubject{
+		SessionID: "p1-1", ProjectID: "p1", Provider: domain.SCMProviderGitHub,
+		Host: "github.com", Repo: "aoagents/agent-orchestrator", Branch: "feat/old",
+		CredentialHash: "cred", PRNumber: 28, PRURL: "https://github.com/aoagents/agent-orchestrator/pull/28",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PutPollState(ctx, domain.SCMPollState{
+		Key:          domain.SCMPollStateKey{Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "aoagents/agent-orchestrator"},
+		BackoffUntil: now.Add(time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	obs := &captureObserver{}
+	sched := &Scheduler{
+		Observer: obs,
+		Store:    st,
+		Projects: projectSourceStub{projects: []ProjectConfig{{
+			ID: "p1", RepoOriginURL: "https://github.com/aoagents/agent-orchestrator.git",
+		}}},
+		Sessions: sessionSourceStub{sessions: []domain.SessionRecord{session}},
+		Clock:    func() time.Time { return now },
+	}
+	subjects, err := sched.DeriveSubjects(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(subjects) != 1 {
+		t.Fatalf("subjects=%+v", subjects)
+	}
+	got := subjects[0]
+	if got.Provider != domain.SCMProviderGitHub || got.Host != "github.com" || got.Repo != "aoagents/agent-orchestrator" ||
+		got.Branch != "feat/27" || got.PRNumber != 28 || got.CredentialHash != "cred" {
+		t.Fatalf("derived subject did not preserve/resolve fields: %+v", got)
+	}
+	if err := sched.Poll(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if len(obs.refreshed) != 0 {
+		t.Fatalf("backoff should skip refresh, got %+v", obs.refreshed)
+	}
+}
+
+type captureObserver struct{ refreshed []domain.SCMSubject }
+
+func (c *captureObserver) Refresh(_ context.Context, subjects []domain.SCMSubject) error {
+	c.refreshed = append(c.refreshed, subjects...)
+	return nil
+}
+func (c *captureObserver) RefreshSession(context.Context, domain.SessionID) error { return nil }
+func (c *captureObserver) Invalidate(context.Context, domain.SCMSubject, string) error {
+	return nil
+}
+
+type projectSourceStub struct{ projects []ProjectConfig }
+
+func (p projectSourceStub) ListSCMProjects(context.Context) ([]ProjectConfig, error) {
+	return p.projects, nil
+}
+
+type sessionSourceStub struct{ sessions []domain.SessionRecord }
+
+func (s sessionSourceStub) ListSCMSessions(context.Context) ([]domain.SessionRecord, error) {
+	return s.sessions, nil
+}
+
 func jsonLogger(buf *bytes.Buffer) *slog.Logger {
 	return slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 }

--- a/backend/internal/scm/observer/observer_test.go
+++ b/backend/internal/scm/observer/observer_test.go
@@ -84,6 +84,34 @@ func TestObserverPersistsSnapshotFansOutAndAppliesLCMFacts(t *testing.T) {
 	}
 }
 
+func TestObserverProjectsDraftAndFailingCIToLCMFacts(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 7}
+	snap := domain.SCMSnapshot{
+		SessionID:  "s1",
+		Subject:    subj,
+		Freshness:  domain.SCMFreshnessFresh,
+		ObservedAt: now,
+		PR:         &domain.SCMPullRequest{Number: 7, URL: "https://github.com/o/r/pull/7", State: domain.PRDraft, Draft: true},
+		CI:         domain.SCMCI{Summary: "failing", Checks: []domain.SCMCheck{{Name: "test", Status: "completed", Conclusion: "failure"}}},
+	}
+	st := store.NewMemoryStore()
+	lcm := &fakeLCM{}
+	o := New(st, lcm, fakeProvider{res: ports.SCMObserveResult{ProviderName: domain.SCMProviderGitHub, Subjects: []domain.SCMSubject{subj}, Snapshots: []domain.SCMSnapshot{snap}}})
+	o.Clock = func() time.Time { return now }
+	if err := o.Refresh(ctx, []domain.SCMSubject{subj}); err != nil {
+		t.Fatal(err)
+	}
+	if len(lcm.facts) != 1 {
+		t.Fatalf("facts=%+v", lcm.facts)
+	}
+	got := lcm.facts[0]
+	if got.PRState != domain.PRDraft || !got.Draft || got.CISummary != ports.CIFailing || len(got.CIFailedChecks) != 1 {
+		t.Fatalf("draft/failing CI facts not projected: %+v", got)
+	}
+}
+
 func TestFactsFromUnavailableSnapshotIsNotFetched(t *testing.T) {
 	facts := FactsFromSnapshot(domain.SCMSnapshot{Freshness: domain.SCMFreshnessUnavailable})
 	if facts.Fetched {

--- a/backend/internal/scm/observer/observer_test.go
+++ b/backend/internal/scm/observer/observer_test.go
@@ -1,0 +1,78 @@
+package observer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/aoagents/agent-orchestrator/backend/internal/scm/store"
+)
+
+type fakeProvider struct{ res ports.SCMObserveResult }
+
+func (f fakeProvider) Provider() domain.SCMProvider { return domain.SCMProviderGitHub }
+func (f fakeProvider) ObserveSessions(context.Context, ports.SCMObserveRequest, ports.SCMProviderCache) (ports.SCMObserveResult, error) {
+	return f.res, nil
+}
+
+type fakeLCM struct{ facts []ports.SCMFacts }
+
+func (f *fakeLCM) ApplySCMObservation(_ context.Context, _ domain.SessionID, facts ports.SCMFacts) error {
+	f.facts = append(f.facts, facts)
+	return nil
+}
+func (f *fakeLCM) ApplyRuntimeObservation(context.Context, domain.SessionID, ports.RuntimeFacts) error {
+	return nil
+}
+func (f *fakeLCM) ApplyActivitySignal(context.Context, domain.SessionID, ports.ActivitySignal) error {
+	return nil
+}
+func (f *fakeLCM) OnSpawnInitiated(context.Context, domain.SessionRecord) error { return nil }
+func (f *fakeLCM) OnSpawnCompleted(context.Context, domain.SessionID, ports.SpawnOutcome) error {
+	return nil
+}
+func (f *fakeLCM) OnKillRequested(context.Context, domain.SessionID, ports.KillReason) error {
+	return nil
+}
+func (f *fakeLCM) TickEscalations(context.Context, time.Time) error { return nil }
+func (f *fakeLCM) RunningSessions(context.Context) ([]domain.SessionRecord, error) {
+	return nil, nil
+}
+
+func TestObserverPersistsSnapshotFansOutAndAppliesLCMFacts(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 7}
+	snap := domain.SCMSnapshot{SessionID: "s1", Subject: subj, Freshness: domain.SCMFreshnessFresh, ObservedAt: now, PR: &domain.SCMPullRequest{Number: 7, URL: "https://github.com/o/r/pull/7", State: domain.PROpen}, CI: domain.SCMCI{Summary: "failing", Checks: []domain.SCMCheck{{Name: "test", Conclusion: "failure"}}}}
+	st := store.NewMemoryStore()
+	lcm := &fakeLCM{}
+	var events int
+	o := New(st, lcm, fakeProvider{res: ports.SCMObserveResult{ProviderName: domain.SCMProviderGitHub, Subjects: []domain.SCMSubject{subj}, Snapshots: []domain.SCMSnapshot{snap}}})
+	o.Clock = func() time.Time { return now }
+	o.OnSnapshot = func(context.Context, domain.SCMSnapshot) error { events++; return nil }
+	if err := o.Refresh(ctx, []domain.SCMSubject{subj}); err != nil {
+		t.Fatal(err)
+	}
+	latest, ok, err := st.GetLatestSnapshot(ctx, "s1")
+	if err != nil || !ok {
+		t.Fatalf("latest ok=%v err=%v", ok, err)
+	}
+	if latest.Revision != 1 || latest.SemanticHash == "" {
+		t.Fatalf("latest revision/hash %+v", latest)
+	}
+	if events != 1 {
+		t.Fatalf("fanout events=%d", events)
+	}
+	if len(lcm.facts) != 1 || lcm.facts[0].CISummary != ports.CIFailing || !lcm.facts[0].Fetched {
+		t.Fatalf("facts=%+v", lcm.facts)
+	}
+}
+
+func TestFactsFromUnavailableSnapshotIsNotFetched(t *testing.T) {
+	facts := FactsFromSnapshot(domain.SCMSnapshot{Freshness: domain.SCMFreshnessUnavailable})
+	if facts.Fetched {
+		t.Fatal("unavailable snapshot must project to Fetched=false")
+	}
+}

--- a/backend/internal/scm/observer/observer_test.go
+++ b/backend/internal/scm/observer/observer_test.go
@@ -10,11 +10,14 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/scm/store"
 )
 
-type fakeProvider struct{ res ports.SCMObserveResult }
+type fakeProvider struct {
+	res ports.SCMObserveResult
+	err error
+}
 
 func (f fakeProvider) Provider() domain.SCMProvider { return domain.SCMProviderGitHub }
 func (f fakeProvider) ObserveSessions(context.Context, ports.SCMObserveRequest, ports.SCMProviderCache) (ports.SCMObserveResult, error) {
-	return f.res, nil
+	return f.res, f.err
 }
 
 type echoProvider struct {
@@ -85,6 +88,37 @@ func TestFactsFromUnavailableSnapshotIsNotFetched(t *testing.T) {
 	facts := FactsFromSnapshot(domain.SCMSnapshot{Freshness: domain.SCMFreshnessUnavailable})
 	if facts.Fetched {
 		t.Fatal("unavailable snapshot must project to Fetched=false")
+	}
+}
+
+func TestObserverPersistsProviderSnapshotsEvenWhenProviderReturnsError(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 7}
+	snap := domain.SCMSnapshot{
+		SessionID:  "s1",
+		Subject:    subj,
+		Freshness:  domain.SCMFreshnessUnavailable,
+		ObservedAt: now,
+		PR:         &domain.SCMPullRequest{Number: 7, URL: "https://github.com/o/r/pull/7", State: domain.PROpen},
+		CI:         domain.SCMCI{Summary: "passing"},
+		Review:     domain.SCMReview{UnresolvedThreads: []domain.SCMReviewThread{{ID: "thread-old"}}},
+	}
+	st := store.NewMemoryStore()
+	o := New(st, nil, fakeProvider{
+		res: ports.SCMObserveResult{ProviderName: domain.SCMProviderGitHub, Subjects: []domain.SCMSubject{subj}, Snapshots: []domain.SCMSnapshot{snap}},
+		err: &domain.SCMError{Kind: domain.SCMErrorNetwork, Operation: "github.graphql_pr_batch", Message: "down"},
+	})
+	o.Clock = func() time.Time { return now }
+	if err := o.Refresh(ctx, []domain.SCMSubject{subj}); err == nil {
+		t.Fatal("expected provider error")
+	}
+	latest, ok, err := st.GetLatestSnapshot(ctx, "s1")
+	if err != nil || !ok {
+		t.Fatalf("latest ok=%v err=%v", ok, err)
+	}
+	if latest.PR == nil || latest.PR.Number != 7 || latest.CI.Summary != "passing" || len(latest.Review.UnresolvedThreads) != 1 {
+		t.Fatalf("provider snapshot was not preserved: %+v", latest)
 	}
 }
 

--- a/backend/internal/scm/observer/observer_test.go
+++ b/backend/internal/scm/observer/observer_test.go
@@ -1,12 +1,16 @@
 package observer
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	scmlog "github.com/aoagents/agent-orchestrator/backend/internal/scm/logging"
 	"github.com/aoagents/agent-orchestrator/backend/internal/scm/store"
 )
 
@@ -112,6 +116,74 @@ func TestObserverProjectsDraftAndFailingCIToLCMFacts(t *testing.T) {
 	}
 }
 
+func TestObserverLogsProviderNeutralObserveEvents(t *testing.T) {
+	ctx := scmlog.WithCorrelationID(context.Background(), "corr-observe")
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/45", PRNumber: 45}
+	snap := domain.SCMSnapshot{SessionID: "s1", Subject: subj, Freshness: domain.SCMFreshnessFresh, ObservedAt: now, PR: &domain.SCMPullRequest{Number: 45, URL: "https://github.com/o/r/pull/45", State: domain.PROpen}}
+	var logs bytes.Buffer
+	st := store.NewMemoryStore()
+	o := New(st, nil, fakeProvider{res: ports.SCMObserveResult{ProviderName: domain.SCMProviderGitHub, Subjects: []domain.SCMSubject{subj}, Snapshots: []domain.SCMSnapshot{snap}}})
+	o.Clock = func() time.Time { return now }
+	o.Logger = jsonLogger(&logs)
+	if err := o.Refresh(ctx, []domain.SCMSubject{subj}); err != nil {
+		t.Fatal(err)
+	}
+	records := decodeLogRecords(t, logs.String())
+	started := findLogRecord(t, records, scmlog.EventObserveStarted)
+	assertLogField(t, started, scmlog.FieldCorrelationID, "corr-observe")
+	assertLogField(t, started, scmlog.FieldProvider, "github")
+	assertLogField(t, started, scmlog.FieldHost, "github.com")
+	assertLogField(t, started, scmlog.FieldRepo, "o/r")
+	assertLogField(t, started, scmlog.FieldProjectID, "p1")
+	assertLogNumber(t, started, scmlog.FieldSessionCount, 1)
+	if _, ok := started["pr_number"]; ok {
+		t.Fatal("observer log used provider-specific pr_number field")
+	}
+	completed := findLogRecord(t, records, scmlog.EventObserveCompleted)
+	assertLogField(t, completed, scmlog.FieldCorrelationID, "corr-observe")
+	assertLogField(t, completed, scmlog.FieldFreshness, "fresh")
+	assertLogNumber(t, completed, scmlog.FieldSnapshotCount, 1)
+	assertLogNumber(t, completed, scmlog.FieldChangedCount, 1)
+	saved := findLogRecord(t, records, scmlog.EventSnapshotSaved)
+	assertLogNumber(t, saved, scmlog.FieldChangeRequestNumber, 45)
+}
+
+func TestObserverFailureLogsAndPersistsConciseDiagnostic(t *testing.T) {
+	ctx := scmlog.WithCorrelationID(context.Background(), "corr-fail")
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/45", PRNumber: 45}
+	err := &domain.SCMError{Kind: domain.SCMErrorRateLimited, Operation: "github.graphql_pr_batch", StatusCode: 403, Message: "rate limit exceeded " + string(bytes.Repeat([]byte("x"), 500))}
+	var logs bytes.Buffer
+	st := store.NewMemoryStore()
+	o := New(st, nil, fakeProvider{res: ports.SCMObserveResult{ProviderName: domain.SCMProviderGitHub}, err: err})
+	o.Clock = func() time.Time { return now }
+	o.Logger = jsonLogger(&logs)
+	if gotErr := o.Refresh(ctx, []domain.SCMSubject{subj}); gotErr == nil {
+		t.Fatal("expected observe error")
+	}
+	records := decodeLogRecords(t, logs.String())
+	failed := findLogRecord(t, records, scmlog.EventObserveFailed)
+	assertLogField(t, failed, scmlog.FieldCorrelationID, "corr-fail")
+	assertLogField(t, failed, scmlog.FieldErrorKind, string(domain.SCMErrorRateLimited))
+	assertLogNumber(t, failed, scmlog.FieldStatusCode, 403)
+	findLogRecord(t, records, scmlog.EventSnapshotUnavailable)
+	latest, ok, gotErr := st.GetLatestSnapshot(ctx, "s1")
+	if gotErr != nil || !ok {
+		t.Fatalf("latest ok=%v err=%v", ok, gotErr)
+	}
+	if len(latest.Diagnostics) != 1 {
+		t.Fatalf("diagnostics=%+v", latest.Diagnostics)
+	}
+	diag := latest.Diagnostics[0]
+	if diag.Operation != "github.graphql_pr_batch" || diag.ErrorKind != domain.SCMErrorRateLimited || diag.StatusCode != 403 {
+		t.Fatalf("bad diagnostic: %+v", diag)
+	}
+	if len(diag.Message) > 300 {
+		t.Fatalf("diagnostic message too large: %d", len(diag.Message))
+	}
+}
+
 func TestFactsFromUnavailableSnapshotIsNotFetched(t *testing.T) {
 	facts := FactsFromSnapshot(domain.SCMSnapshot{Freshness: domain.SCMFreshnessUnavailable})
 	if facts.Fetched {
@@ -194,5 +266,52 @@ func TestSubjectsFromSessionsUsesProviderMetadataWithoutGitHubDefaults(t *testin
 	got := subjects[0]
 	if got.Provider != domain.SCMProviderGitLab || got.Host != "gitlab.com" || got.Repo != "group/repo" || got.Branch != "feat/27" || got.PRNumber != 12 {
 		t.Fatalf("bad subject: %+v", got)
+	}
+}
+
+func jsonLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func decodeLogRecords(t *testing.T, raw string) []map[string]any {
+	t.Helper()
+	lines := bytes.Split([]byte(raw), []byte("\n"))
+	records := make([]map[string]any, 0, len(lines))
+	for _, line := range lines {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal(line, &rec); err != nil {
+			t.Fatalf("decode log %s: %v", line, err)
+		}
+		records = append(records, rec)
+	}
+	return records
+}
+
+func findLogRecord(t *testing.T, records []map[string]any, msg string) map[string]any {
+	t.Helper()
+	for _, rec := range records {
+		if rec["msg"] == msg {
+			return rec
+		}
+	}
+	t.Fatalf("missing log %q in %+v", msg, records)
+	return nil
+}
+
+func assertLogField(t *testing.T, rec map[string]any, key, want string) {
+	t.Helper()
+	if got, _ := rec[key].(string); got != want {
+		t.Fatalf("%s=%q want %q in %+v", key, got, want, rec)
+	}
+}
+
+func assertLogNumber(t *testing.T, rec map[string]any, key string, want float64) {
+	t.Helper()
+	if got, _ := rec[key].(float64); got != want {
+		t.Fatalf("%s=%v want %v in %+v", key, rec[key], want, rec)
 	}
 }

--- a/backend/internal/scm/observer/observer_test.go
+++ b/backend/internal/scm/observer/observer_test.go
@@ -47,11 +47,13 @@ func (f *fakeLCM) ApplyRuntimeObservation(context.Context, domain.SessionID, por
 func (f *fakeLCM) ApplyActivitySignal(context.Context, domain.SessionID, ports.ActivitySignal) error {
 	return nil
 }
-func (f *fakeLCM) OnSpawnInitiated(context.Context, domain.SessionRecord) error { return nil }
+func (f *fakeLCM) ApplyPRObservation(context.Context, domain.SessionID, ports.PRObservation) error {
+	return nil
+}
 func (f *fakeLCM) OnSpawnCompleted(context.Context, domain.SessionID, ports.SpawnOutcome) error {
 	return nil
 }
-func (f *fakeLCM) OnKillRequested(context.Context, domain.SessionID, ports.KillReason) error {
+func (f *fakeLCM) OnKillRequested(context.Context, domain.SessionID, domain.TerminationReason) error {
 	return nil
 }
 func (f *fakeLCM) TickEscalations(context.Context, time.Time) error { return nil }
@@ -245,26 +247,20 @@ func TestObserverRequiresProviderWhenMultipleProvidersRegistered(t *testing.T) {
 	}
 }
 
-func TestSubjectsFromSessionsUsesProviderMetadataWithoutGitHubDefaults(t *testing.T) {
+func TestSubjectsFromSessionsUsesConfigAndTypedBranchMetadataWithoutGitHubDefaults(t *testing.T) {
 	sessions := []domain.Session{{
 		SessionRecord: domain.SessionRecord{
 			ID:        "s1",
 			ProjectID: "p1",
-			Metadata: map[string]string{
-				"scm.provider":  "gitlab",
-				"scm.host":      "gitlab.com",
-				"gitlab.repo":   "group/repo",
-				"gitlab.branch": "feat/27",
-				"gitlab.prUrl":  "https://gitlab.com/group/repo/-/merge_requests/12",
-			},
+			Metadata:  domain.SessionMetadata{Branch: "feat/27"},
 		},
 	}}
-	subjects := SubjectsFromSessions(sessions, SubjectConfig{})
+	subjects := SubjectsFromSessions(sessions, SubjectConfig{Provider: domain.SCMProviderGitLab, Host: "gitlab.com", Repo: "group/repo"})
 	if len(subjects) != 1 {
 		t.Fatalf("subjects=%d", len(subjects))
 	}
 	got := subjects[0]
-	if got.Provider != domain.SCMProviderGitLab || got.Host != "gitlab.com" || got.Repo != "group/repo" || got.Branch != "feat/27" || got.PRNumber != 12 {
+	if got.Provider != domain.SCMProviderGitLab || got.Host != "gitlab.com" || got.Repo != "group/repo" || got.Branch != "feat/27" || got.PRNumber != 0 {
 		t.Fatalf("bad subject: %+v", got)
 	}
 }

--- a/backend/internal/scm/observer/observer_test.go
+++ b/backend/internal/scm/observer/observer_test.go
@@ -17,6 +17,17 @@ func (f fakeProvider) ObserveSessions(context.Context, ports.SCMObserveRequest, 
 	return f.res, nil
 }
 
+type echoProvider struct {
+	provider domain.SCMProvider
+	seen     []domain.SCMSubject
+}
+
+func (e *echoProvider) Provider() domain.SCMProvider { return e.provider }
+func (e *echoProvider) ObserveSessions(_ context.Context, req ports.SCMObserveRequest, _ ports.SCMProviderCache) (ports.SCMObserveResult, error) {
+	e.seen = append([]domain.SCMSubject(nil), req.Subjects...)
+	return ports.SCMObserveResult{ProviderName: e.provider, Subjects: req.Subjects}, nil
+}
+
 type fakeLCM struct{ facts []ports.SCMFacts }
 
 func (f *fakeLCM) ApplySCMObservation(_ context.Context, _ domain.SessionID, facts ports.SCMFacts) error {
@@ -74,5 +85,52 @@ func TestFactsFromUnavailableSnapshotIsNotFetched(t *testing.T) {
 	facts := FactsFromSnapshot(domain.SCMSnapshot{Freshness: domain.SCMFreshnessUnavailable})
 	if facts.Fetched {
 		t.Fatal("unavailable snapshot must project to Fetched=false")
+	}
+}
+
+func TestObserverInfersOnlyRegisteredProviderWithoutGitHubDefault(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	provider := &echoProvider{provider: domain.SCMProviderGitLab}
+	o := New(st, nil, provider)
+	if err := o.Refresh(ctx, []domain.SCMSubject{{SessionID: "s1", ProjectID: "p1", Repo: "g/r", Branch: "feat/27"}}); err != nil {
+		t.Fatal(err)
+	}
+	if len(provider.seen) != 1 || provider.seen[0].Provider != domain.SCMProviderGitLab {
+		t.Fatalf("provider inference leaked GitHub default: %+v", provider.seen)
+	}
+}
+
+func TestObserverRequiresProviderWhenMultipleProvidersRegistered(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	o := New(st, nil, &echoProvider{provider: domain.SCMProviderGitLab}, &echoProvider{provider: domain.SCMProviderBitbucket})
+	err := o.Refresh(ctx, []domain.SCMSubject{{SessionID: "s1", ProjectID: "p1", Repo: "g/r", Branch: "feat/27"}})
+	if err == nil {
+		t.Fatal("missing provider should fail when observer has multiple providers")
+	}
+}
+
+func TestSubjectsFromSessionsUsesProviderMetadataWithoutGitHubDefaults(t *testing.T) {
+	sessions := []domain.Session{{
+		SessionRecord: domain.SessionRecord{
+			ID:        "s1",
+			ProjectID: "p1",
+			Metadata: map[string]string{
+				"scm.provider":  "gitlab",
+				"scm.host":      "gitlab.com",
+				"gitlab.repo":   "group/repo",
+				"gitlab.branch": "feat/27",
+				"gitlab.prUrl":  "https://gitlab.com/group/repo/-/merge_requests/12",
+			},
+		},
+	}}
+	subjects := SubjectsFromSessions(sessions, SubjectConfig{})
+	if len(subjects) != 1 {
+		t.Fatalf("subjects=%d", len(subjects))
+	}
+	got := subjects[0]
+	if got.Provider != domain.SCMProviderGitLab || got.Host != "gitlab.com" || got.Repo != "group/repo" || got.Branch != "feat/27" || got.PRNumber != 12 {
+		t.Fatalf("bad subject: %+v", got)
 	}
 }

--- a/backend/internal/scm/observer/scheduler.go
+++ b/backend/internal/scm/observer/scheduler.go
@@ -1,0 +1,250 @@
+package observer
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os/exec"
+	"path"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const DefaultSchedulerInterval = 30 * time.Second
+
+type Scheduler struct {
+	Observer ports.SCMObserver
+	Store    ports.SCMStore
+	Projects ProjectSource
+	Sessions SessionSource
+	PRs      PRBindingSource
+	Interval time.Duration
+	Clock    func() time.Time
+	Logger   *slog.Logger
+}
+
+func (s *Scheduler) Name() string { return "scm" }
+
+type ProjectSource interface {
+	ListSCMProjects(ctx context.Context) ([]ProjectConfig, error)
+}
+
+type SessionSource interface {
+	ListSCMSessions(ctx context.Context) ([]domain.SessionRecord, error)
+}
+
+type PRBindingSource interface {
+	LatestPRBinding(ctx context.Context, sessionID domain.SessionID) (PRBinding, bool, error)
+}
+
+type ProjectConfig struct {
+	ID            domain.ProjectID
+	Path          string
+	RepoOriginURL string
+	DefaultBranch string
+	SCMProvider   domain.SCMProvider
+	SCMHost       string
+	SCMRepo       string
+}
+
+type PRBinding struct {
+	Number int
+	URL    string
+}
+
+func (s *Scheduler) Start(ctx context.Context) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = s.Poll(ctx)
+		interval := s.Interval
+		if interval <= 0 {
+			interval = DefaultSchedulerInterval
+		}
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				if err := s.Poll(ctx); err != nil && s.Logger != nil {
+					s.Logger.Error("scm scheduler: poll failed", "err", err)
+				}
+			}
+		}
+	}()
+	return done
+}
+
+func (s *Scheduler) Poll(ctx context.Context) error {
+	if s.Observer == nil || s.Store == nil || s.Projects == nil || s.Sessions == nil {
+		return nil
+	}
+	now := time.Now()
+	if s.Clock != nil {
+		now = s.Clock()
+	}
+	subjects, err := s.DeriveSubjects(ctx)
+	if err != nil {
+		return err
+	}
+	due := make([]domain.SCMSubject, 0, len(subjects))
+	for _, subj := range subjects {
+		if err := s.Store.UpsertSubject(ctx, subj); err != nil {
+			return err
+		}
+		if s.pollBlocked(ctx, subj, now) {
+			continue
+		}
+		due = append(due, subj)
+	}
+	if len(due) == 0 {
+		return nil
+	}
+	return s.Observer.Refresh(ctx, due)
+}
+
+func (s *Scheduler) DeriveSubjects(ctx context.Context) ([]domain.SCMSubject, error) {
+	projects, err := s.Projects.ListSCMProjects(ctx)
+	if err != nil {
+		return nil, err
+	}
+	byID := map[domain.ProjectID]ProjectConfig{}
+	for _, p := range projects {
+		if p.DefaultBranch == "" {
+			p.DefaultBranch = "main"
+		}
+		if p.SCMProvider == "" || p.SCMHost == "" || p.SCMRepo == "" {
+			resolved, ok := ResolveGitHubProject(p)
+			if !ok {
+				continue
+			}
+			p = resolved
+		}
+		byID[p.ID] = p
+	}
+	sessions, err := s.Sessions.ListSCMSessions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]domain.SCMSubject, 0, len(sessions))
+	for _, rec := range sessions {
+		if isTerminalSession(rec.Lifecycle.Session.State) || strings.TrimSpace(rec.Metadata.Branch) == "" {
+			continue
+		}
+		p, ok := byID[rec.ProjectID]
+		if !ok {
+			continue
+		}
+		subj := domain.SCMSubject{
+			SessionID:  rec.ID,
+			ProjectID:  rec.ProjectID,
+			Provider:   p.SCMProvider,
+			Host:       p.SCMHost,
+			Repo:       p.SCMRepo,
+			Branch:     rec.Metadata.Branch,
+			BaseBranch: p.DefaultBranch,
+		}
+		if existing, ok, err := s.Store.GetSubject(ctx, rec.ID); err != nil {
+			return nil, err
+		} else if ok {
+			subj.CredentialHash = existing.CredentialHash
+			subj.PRNumber = existing.PRNumber
+			subj.PRURL = existing.PRURL
+			subj.CreatedAt = existing.CreatedAt
+		}
+		if subj.PRNumber == 0 && s.PRs != nil {
+			if binding, ok, err := s.PRs.LatestPRBinding(ctx, rec.ID); err != nil {
+				return nil, err
+			} else if ok {
+				subj.PRNumber = binding.Number
+				subj.PRURL = binding.URL
+			}
+		}
+		out = append(out, subj)
+	}
+	return out, nil
+}
+
+func (s *Scheduler) pollBlocked(ctx context.Context, subj domain.SCMSubject, now time.Time) bool {
+	st, ok, err := s.Store.GetPollState(ctx, domain.SCMPollStateKey{Provider: subj.Provider, Host: subj.Host, Repo: subj.Repo})
+	if err != nil || !ok {
+		return false
+	}
+	return (!st.BackoffUntil.IsZero() && now.Before(st.BackoffUntil)) ||
+		(!st.RateLimitUntil.IsZero() && now.Before(st.RateLimitUntil))
+}
+
+func ResolveGitHubProject(p ProjectConfig) (ProjectConfig, bool) {
+	raw := strings.TrimSpace(p.RepoOriginURL)
+	if raw == "" && p.Path != "" {
+		raw = gitRemoteOrigin(p.Path)
+	}
+	host, repo, ok := parseGitHubRemote(raw)
+	if !ok {
+		return ProjectConfig{}, false
+	}
+	p.SCMProvider = domain.SCMProviderGitHub
+	p.SCMHost = host
+	p.SCMRepo = repo
+	if p.DefaultBranch == "" {
+		p.DefaultBranch = "main"
+	}
+	return p, true
+}
+
+func gitRemoteOrigin(repoPath string) string {
+	out, err := exec.Command("git", "-C", repoPath, "remote", "get-url", "origin").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+var scpLikeRemote = regexp.MustCompile(`^(?:[^@]+@)?([^:]+):(.+)$`)
+
+func parseGitHubRemote(raw string) (host, repo string, ok bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", false
+	}
+	if !strings.Contains(raw, "://") {
+		if m := scpLikeRemote.FindStringSubmatch(raw); len(m) == 3 && !strings.Contains(m[1], "/") {
+			host, repo = m[1], strings.TrimSuffix(m[2], ".git")
+			return normalizeSchedulerHost(host), normalizeSchedulerRepo(repo), strings.EqualFold(normalizeSchedulerHost(host), "github.com") && repo != ""
+		}
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return "", "", false
+	}
+	host = u.Host
+	repo = strings.TrimPrefix(path.Clean(u.Path), "/")
+	repo = strings.TrimSuffix(repo, ".git")
+	if strings.Count(repo, "/") < 1 {
+		return "", "", false
+	}
+	host = normalizeSchedulerHost(host)
+	return host, normalizeSchedulerRepo(repo), strings.EqualFold(host, "github.com")
+}
+
+func normalizeSchedulerHost(host string) string {
+	host = strings.TrimSpace(strings.ToLower(host))
+	host = strings.TrimPrefix(host, "https://")
+	host = strings.TrimPrefix(host, "http://")
+	return strings.TrimSuffix(host, "/")
+}
+
+func normalizeSchedulerRepo(repo string) string {
+	return strings.ToLower(strings.Trim(strings.TrimSpace(repo), "/"))
+}
+
+func (s *Scheduler) String() string {
+	return fmt.Sprintf("scm scheduler interval=%s", s.Interval)
+}

--- a/backend/internal/scm/readmodel/readmodel.go
+++ b/backend/internal/scm/readmodel/readmodel.go
@@ -1,0 +1,29 @@
+package readmodel
+
+import (
+	"context"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// AttachLatestSCM enriches the session read-model with the latest normalized
+// SCM snapshot. Dashboard/API code should consume these typed fields rather
+// than legacy metadata blobs such as prEnrichment or prReviewComments.
+func AttachLatestSCM(ctx context.Context, store ports.SCMStore, sessions []domain.Session) ([]domain.Session, error) {
+	out := make([]domain.Session, len(sessions))
+	copy(out, sessions)
+	if store == nil {
+		return out, nil
+	}
+	for i := range out {
+		snap, ok, err := store.GetLatestSnapshot(ctx, out[i].ID)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			out[i].SCM = &snap
+		}
+	}
+	return out, nil
+}

--- a/backend/internal/scm/readmodel/readmodel_test.go
+++ b/backend/internal/scm/readmodel/readmodel_test.go
@@ -1,0 +1,32 @@
+package readmodel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/scm/store"
+)
+
+func TestAttachLatestSCMAddsSnapshotWithoutChangingDerivedStatus(t *testing.T) {
+	ctx := context.Background()
+	st := store.NewMemoryStore()
+	session := domain.Session{
+		SessionRecord: domain.SessionRecord{ID: "s1", ProjectID: "p1"},
+		Status:        domain.StatusWorking,
+	}
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "o/r", Branch: "feat/27", PRNumber: 7}
+	if _, _, err := st.SaveSnapshot(ctx, domain.SCMSnapshot{SessionID: "s1", Subject: subj, PR: &domain.SCMPullRequest{Number: 7, State: domain.PROpen}, CI: domain.SCMCI{Summary: "passing"}}); err != nil {
+		t.Fatal(err)
+	}
+	out, err := AttachLatestSCM(ctx, st, []domain.Session{session})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 || out[0].SCM == nil || out[0].SCM.PR == nil || out[0].SCM.PR.Number != 7 {
+		t.Fatalf("missing SCM snapshot: %+v", out)
+	}
+	if out[0].Status != domain.StatusWorking {
+		t.Fatalf("status changed: %s", out[0].Status)
+	}
+}

--- a/backend/internal/scm/store/store.go
+++ b/backend/internal/scm/store/store.go
@@ -1,0 +1,362 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// Store is a small durable JSON implementation of ports.SCMStore. It is meant
+// to back the first Go daemon milestone before a SQL adapter exists: all writes
+// are serialized, semantic snapshot revisions are assigned atomically, and the
+// file is replaced with rename for crash-safe updates on a single filesystem.
+type Store struct {
+	mu    sync.Mutex
+	path  string
+	clock func() time.Time
+	data  persisted
+}
+
+var _ ports.SCMStore = (*Store)(nil)
+
+type Option func(*Store)
+
+func WithClock(clock func() time.Time) Option {
+	return func(s *Store) {
+		if clock != nil {
+			s.clock = clock
+		}
+	}
+}
+
+func NewMemoryStore(opts ...Option) *Store {
+	s := &Store{clock: time.Now, data: emptyPersisted()}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+func NewFileStore(path string, opts ...Option) (*Store, error) {
+	s := &Store{path: path, clock: time.Now, data: emptyPersisted()}
+	for _, opt := range opts {
+		opt(s)
+	}
+	if err := s.load(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+type persisted struct {
+	Subjects      map[string]domain.SCMSubject            `json:"subjects"`
+	Snapshots     map[string][]domain.SCMSnapshot         `json:"snapshots"`
+	ProviderCache map[string]domain.SCMProviderCacheEntry `json:"providerCache"`
+	PollStates    map[string]domain.SCMPollState          `json:"pollStates"`
+}
+
+func emptyPersisted() persisted {
+	return persisted{
+		Subjects:      map[string]domain.SCMSubject{},
+		Snapshots:     map[string][]domain.SCMSnapshot{},
+		ProviderCache: map[string]domain.SCMProviderCacheEntry{},
+		PollStates:    map[string]domain.SCMPollState{},
+	}
+}
+
+func (s *Store) load() error {
+	if s.path == "" {
+		return nil
+	}
+	b, err := os.ReadFile(s.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("scm store read %s: %w", s.path, err)
+	}
+	if len(b) == 0 {
+		return nil
+	}
+	var data persisted
+	if err := json.Unmarshal(b, &data); err != nil {
+		return fmt.Errorf("scm store parse %s: %w", s.path, err)
+	}
+	s.data = normalize(data)
+	return nil
+}
+
+func normalize(d persisted) persisted {
+	if d.Subjects == nil {
+		d.Subjects = map[string]domain.SCMSubject{}
+	}
+	if d.Snapshots == nil {
+		d.Snapshots = map[string][]domain.SCMSnapshot{}
+	}
+	if d.ProviderCache == nil {
+		d.ProviderCache = map[string]domain.SCMProviderCacheEntry{}
+	}
+	if d.PollStates == nil {
+		d.PollStates = map[string]domain.SCMPollState{}
+	}
+	return d
+}
+
+func (s *Store) persistLocked() error {
+	if s.path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(s.data, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, s.path)
+}
+
+func (s *Store) now() time.Time {
+	if s.clock == nil {
+		return time.Now()
+	}
+	return s.clock()
+}
+
+func (s *Store) UpsertSubject(_ context.Context, subject domain.SCMSubject) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+	if subject.CreatedAt.IsZero() {
+		if existing, ok := s.data.Subjects[subject.SubjectKey()]; ok && !existing.CreatedAt.IsZero() {
+			subject.CreatedAt = existing.CreatedAt
+		} else {
+			subject.CreatedAt = now
+		}
+	}
+	subject.UpdatedAt = now
+	s.data.Subjects[subject.SubjectKey()] = subject
+	return s.persistLocked()
+}
+
+func (s *Store) GetSubject(_ context.Context, sessionID domain.SessionID) (domain.SCMSubject, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	subj, ok := s.data.Subjects[string(sessionID)]
+	return subj, ok, nil
+}
+
+func (s *Store) ListSubjects(_ context.Context, filter domain.SCMSubjectFilter) ([]domain.SCMSubject, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]domain.SCMSubject, 0, len(s.data.Subjects))
+	for _, subj := range s.data.Subjects {
+		if filter.ProjectID != "" && subj.ProjectID != filter.ProjectID {
+			continue
+		}
+		if filter.Provider != "" && subj.Provider != filter.Provider {
+			continue
+		}
+		if filter.Host != "" && normalizeHost(filter.Host) != normalizeHost(subj.Host) {
+			continue
+		}
+		if filter.Repo != "" && lower(filter.Repo) != lower(subj.Repo) {
+			continue
+		}
+		out = append(out, subj)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].SessionID < out[j].SessionID })
+	return out, nil
+}
+
+func (s *Store) DeleteSubject(_ context.Context, sessionID domain.SessionID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data.Subjects, string(sessionID))
+	return s.persistLocked()
+}
+
+func (s *Store) SaveSnapshot(_ context.Context, snapshot domain.SCMSnapshot) (domain.SCMSnapshot, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if snapshot.SessionID == "" {
+		snapshot.SessionID = snapshot.Subject.SessionID
+	}
+	if snapshot.SessionID == "" {
+		return domain.SCMSnapshot{}, false, fmt.Errorf("scm store: snapshot missing session id")
+	}
+	if snapshot.Subject.SessionID == "" {
+		snapshot.Subject.SessionID = snapshot.SessionID
+	}
+	if snapshot.ObservedAt.IsZero() {
+		snapshot.ObservedAt = s.now()
+	}
+	if snapshot.Freshness == "" {
+		snapshot.Freshness = domain.SCMFreshnessFresh
+	}
+	hash, err := domain.ComputeSCMSemanticHash(snapshot)
+	if err != nil {
+		return domain.SCMSnapshot{}, false, err
+	}
+	snapshot.SemanticHash = hash
+
+	key := string(snapshot.SessionID)
+	history := s.data.Snapshots[key]
+	if len(history) > 0 {
+		latest := history[len(history)-1]
+		if latest.SemanticHash == snapshot.SemanticHash {
+			return latest, false, nil
+		}
+		snapshot.Revision = latest.Revision + 1
+	} else {
+		snapshot.Revision = 1
+	}
+	s.data.Snapshots[key] = append(history, cloneSnapshot(snapshot))
+	if snapshot.Subject.SessionID != "" {
+		s.data.Subjects[snapshot.Subject.SubjectKey()] = snapshot.Subject
+	}
+	if err := s.persistLocked(); err != nil {
+		return domain.SCMSnapshot{}, false, err
+	}
+	return snapshot, true, nil
+}
+
+func (s *Store) GetLatestSnapshot(_ context.Context, sessionID domain.SessionID) (domain.SCMSnapshot, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	history := s.data.Snapshots[string(sessionID)]
+	if len(history) == 0 {
+		return domain.SCMSnapshot{}, false, nil
+	}
+	return cloneSnapshot(history[len(history)-1]), true, nil
+}
+
+func (s *Store) ListLatestSnapshots(_ context.Context, project domain.ProjectID) ([]domain.SCMSnapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]domain.SCMSnapshot, 0, len(s.data.Snapshots))
+	for id, history := range s.data.Snapshots {
+		if len(history) == 0 {
+			continue
+		}
+		latest := history[len(history)-1]
+		if project != "" {
+			if subj, ok := s.data.Subjects[id]; ok && subj.ProjectID != project {
+				continue
+			}
+			if latest.Subject.ProjectID != "" && latest.Subject.ProjectID != project {
+				continue
+			}
+		}
+		out = append(out, cloneSnapshot(latest))
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].SessionID < out[j].SessionID })
+	return out, nil
+}
+
+func (s *Store) GetProviderCache(_ context.Context, key domain.SCMProviderCacheKey) (domain.SCMProviderCacheEntry, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.data.ProviderCache[key.String()]
+	if !ok {
+		return domain.SCMProviderCacheEntry{}, false, nil
+	}
+	if entry.Expired(s.now()) {
+		delete(s.data.ProviderCache, key.String())
+		_ = s.persistLocked()
+		return domain.SCMProviderCacheEntry{}, false, nil
+	}
+	return cloneCacheEntry(entry), true, nil
+}
+
+func (s *Store) PutProviderCache(_ context.Context, entry domain.SCMProviderCacheEntry) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if entry.UpdatedAt.IsZero() {
+		entry.UpdatedAt = s.now()
+	}
+	s.data.ProviderCache[entry.Key.String()] = cloneCacheEntry(entry)
+	return s.persistLocked()
+}
+
+func (s *Store) DeleteProviderCache(_ context.Context, prefix domain.SCMProviderCachePrefix) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, entry := range s.data.ProviderCache {
+		if prefix.Matches(entry.Key) {
+			delete(s.data.ProviderCache, entry.Key.String())
+		}
+	}
+	return s.persistLocked()
+}
+
+func (s *Store) GetPollState(_ context.Context, key domain.SCMPollStateKey) (domain.SCMPollState, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	st, ok := s.data.PollStates[key.String()]
+	return st, ok, nil
+}
+
+func (s *Store) PutPollState(_ context.Context, state domain.SCMPollState) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data.PollStates[state.Key.String()] = state
+	return s.persistLocked()
+}
+
+func cloneSnapshot(in domain.SCMSnapshot) domain.SCMSnapshot {
+	out := in
+	if in.PR != nil {
+		pr := *in.PR
+		out.PR = &pr
+	}
+	out.CI.Checks = append([]domain.SCMCheck(nil), in.CI.Checks...)
+	out.Review.UnresolvedThreads = cloneThreads(in.Review.UnresolvedThreads)
+	out.Review.BotComments = cloneThreads(in.Review.BotComments)
+	out.Review.HumanComments = cloneThreads(in.Review.HumanComments)
+	out.Mergeability.Blockers = append([]string(nil), in.Mergeability.Blockers...)
+	if in.RateLimit != nil {
+		rl := *in.RateLimit
+		out.RateLimit = &rl
+	}
+	out.Diagnostics = append([]domain.SCMDiagnostic(nil), in.Diagnostics...)
+	return out
+}
+
+func cloneThreads(in []domain.SCMReviewThread) []domain.SCMReviewThread {
+	out := make([]domain.SCMReviewThread, len(in))
+	for i, th := range in {
+		out[i] = th
+		out[i].Comments = append([]domain.SCMReviewComment(nil), th.Comments...)
+	}
+	return out
+}
+
+func cloneCacheEntry(in domain.SCMProviderCacheEntry) domain.SCMProviderCacheEntry {
+	out := in
+	out.Value = append([]byte(nil), in.Value...)
+	return out
+}
+
+func lower(s string) string { return strings.ToLower(strings.TrimSpace(s)) }
+
+func normalizeHost(h string) string {
+	h = strings.TrimSpace(strings.ToLower(h))
+	h = strings.TrimPrefix(h, "https://")
+	h = strings.TrimPrefix(h, "http://")
+	return strings.TrimSuffix(h, "/")
+}

--- a/backend/internal/scm/store/store.go
+++ b/backend/internal/scm/store/store.go
@@ -140,6 +140,11 @@ func (s *Store) now() time.Time {
 func (s *Store) UpsertSubject(_ context.Context, subject domain.SCMSubject) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.upsertSubjectLocked(subject)
+	return s.persistLocked()
+}
+
+func (s *Store) upsertSubjectLocked(subject domain.SCMSubject) domain.SCMSubject {
 	now := s.now()
 	if subject.CreatedAt.IsZero() {
 		if existing, ok := s.data.Subjects[subject.SubjectKey()]; ok && !existing.CreatedAt.IsZero() {
@@ -150,7 +155,7 @@ func (s *Store) UpsertSubject(_ context.Context, subject domain.SCMSubject) erro
 	}
 	subject.UpdatedAt = now
 	s.data.Subjects[subject.SubjectKey()] = subject
-	return s.persistLocked()
+	return subject
 }
 
 func (s *Store) GetSubject(_ context.Context, sessionID domain.SessionID) (domain.SCMSubject, bool, error) {
@@ -219,20 +224,30 @@ func (s *Store) SaveSnapshot(_ context.Context, snapshot domain.SCMSnapshot) (do
 	if len(history) > 0 {
 		latest := history[len(history)-1]
 		if latest.SemanticHash == snapshot.SemanticHash {
+			if snapshot.Subject.SessionID != "" && subjectNeedsTimestampRepair(s.data.Subjects[snapshot.Subject.SubjectKey()]) {
+				s.upsertSubjectLocked(snapshot.Subject)
+				if err := s.persistLocked(); err != nil {
+					return domain.SCMSnapshot{}, false, err
+				}
+			}
 			return latest, false, nil
 		}
 		snapshot.Revision = latest.Revision + 1
 	} else {
 		snapshot.Revision = 1
 	}
-	s.data.Snapshots[key] = append(history, cloneSnapshot(snapshot))
 	if snapshot.Subject.SessionID != "" {
-		s.data.Subjects[snapshot.Subject.SubjectKey()] = snapshot.Subject
+		snapshot.Subject = s.upsertSubjectLocked(snapshot.Subject)
 	}
+	s.data.Snapshots[key] = append(history, cloneSnapshot(snapshot))
 	if err := s.persistLocked(); err != nil {
 		return domain.SCMSnapshot{}, false, err
 	}
 	return snapshot, true, nil
+}
+
+func subjectNeedsTimestampRepair(subject domain.SCMSubject) bool {
+	return subject.SessionID == "" || subject.CreatedAt.IsZero() || subject.UpdatedAt.IsZero()
 }
 
 func (s *Store) GetLatestSnapshot(_ context.Context, sessionID domain.SessionID) (domain.SCMSnapshot, bool, error) {

--- a/backend/internal/scm/store/store.go
+++ b/backend/internal/scm/store/store.go
@@ -224,7 +224,7 @@ func (s *Store) SaveSnapshot(_ context.Context, snapshot domain.SCMSnapshot) (do
 	if len(history) > 0 {
 		latest := history[len(history)-1]
 		if latest.SemanticHash == snapshot.SemanticHash {
-			if snapshot.Subject.SessionID != "" && subjectNeedsTimestampRepair(s.data.Subjects[snapshot.Subject.SubjectKey()]) {
+			if subjectNeedsTimestampRepair(s.data.Subjects[snapshot.Subject.SubjectKey()]) {
 				s.upsertSubjectLocked(snapshot.Subject)
 				if err := s.persistLocked(); err != nil {
 					return domain.SCMSnapshot{}, false, err
@@ -236,9 +236,7 @@ func (s *Store) SaveSnapshot(_ context.Context, snapshot domain.SCMSnapshot) (do
 	} else {
 		snapshot.Revision = 1
 	}
-	if snapshot.Subject.SessionID != "" {
-		snapshot.Subject = s.upsertSubjectLocked(snapshot.Subject)
-	}
+	snapshot.Subject = s.upsertSubjectLocked(snapshot.Subject)
 	s.data.Snapshots[key] = append(history, cloneSnapshot(snapshot))
 	if err := s.persistLocked(); err != nil {
 		return domain.SCMSnapshot{}, false, err

--- a/backend/internal/scm/store/store.go
+++ b/backend/internal/scm/store/store.go
@@ -31,6 +31,14 @@ var _ ports.SCMStore = (*Store)(nil)
 
 type Option func(*Store)
 
+var defaultProviderCacheCaps = map[string]int{
+	"pr-list":      100,
+	"checks":       500,
+	"checks-guard": 500,
+	"reviews":      500,
+	"branch-map":   1000,
+}
+
 func WithClock(clock func() time.Time) Option {
 	return func(s *Store) {
 		if clock != nil {
@@ -290,7 +298,34 @@ func (s *Store) PutProviderCache(_ context.Context, entry domain.SCMProviderCach
 		entry.UpdatedAt = s.now()
 	}
 	s.data.ProviderCache[entry.Key.String()] = cloneCacheEntry(entry)
+	s.pruneProviderCacheLocked(entry.Key.Namespace)
 	return s.persistLocked()
+}
+
+func (s *Store) pruneProviderCacheLocked(namespace string) {
+	capN := defaultProviderCacheCaps[namespace]
+	if capN <= 0 {
+		return
+	}
+	type keyedEntry struct {
+		key   string
+		entry domain.SCMProviderCacheEntry
+	}
+	entries := make([]keyedEntry, 0)
+	for key, entry := range s.data.ProviderCache {
+		if entry.Key.Namespace == namespace {
+			entries = append(entries, keyedEntry{key: key, entry: entry})
+		}
+	}
+	if len(entries) <= capN {
+		return
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].entry.UpdatedAt.Before(entries[j].entry.UpdatedAt)
+	})
+	for _, old := range entries[:len(entries)-capN] {
+		delete(s.data.ProviderCache, old.key)
+	}
 }
 
 func (s *Store) DeleteProviderCache(_ context.Context, prefix domain.SCMProviderCachePrefix) error {

--- a/backend/internal/scm/store/store.go
+++ b/backend/internal/scm/store/store.go
@@ -31,14 +31,6 @@ var _ ports.SCMStore = (*Store)(nil)
 
 type Option func(*Store)
 
-var defaultProviderCacheCaps = map[string]int{
-	"pr-list":      100,
-	"checks":       500,
-	"checks-guard": 500,
-	"reviews":      500,
-	"branch-map":   1000,
-}
-
 func WithClock(clock func() time.Time) Option {
 	return func(s *Store) {
 		if clock != nil {
@@ -298,12 +290,13 @@ func (s *Store) PutProviderCache(_ context.Context, entry domain.SCMProviderCach
 		entry.UpdatedAt = s.now()
 	}
 	s.data.ProviderCache[entry.Key.String()] = cloneCacheEntry(entry)
-	s.pruneProviderCacheLocked(entry.Key.Namespace)
+	if entry.MaxEntries > 0 {
+		s.pruneProviderCacheLocked(entry.Key.SCMProviderCacheScope, entry.Key.Namespace, entry.MaxEntries)
+	}
 	return s.persistLocked()
 }
 
-func (s *Store) pruneProviderCacheLocked(namespace string) {
-	capN := defaultProviderCacheCaps[namespace]
+func (s *Store) pruneProviderCacheLocked(scope domain.SCMProviderCacheScope, namespace string, capN int) {
 	if capN <= 0 {
 		return
 	}
@@ -312,8 +305,9 @@ func (s *Store) pruneProviderCacheLocked(namespace string) {
 		entry domain.SCMProviderCacheEntry
 	}
 	entries := make([]keyedEntry, 0)
+	prefix := domain.SCMProviderCachePrefix{SCMProviderCacheScope: scope, Namespace: namespace}
 	for key, entry := range s.data.ProviderCache {
-		if entry.Key.Namespace == namespace {
+		if prefix.Matches(entry.Key) {
 			entries = append(entries, keyedEntry{key: key, entry: entry})
 		}
 	}

--- a/backend/internal/scm/store/store_test.go
+++ b/backend/internal/scm/store/store_test.go
@@ -1,0 +1,86 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestSaveSnapshotRevisionAndSemanticHash(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	s := NewMemoryStore(WithClock(func() time.Time { return now }))
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "ao/test", Branch: "feat/27", PRNumber: 7}
+	snap := domain.SCMSnapshot{SessionID: "s1", Subject: subj, ObservedAt: now, PR: &domain.SCMPullRequest{Number: 7, URL: "https://github.com/ao/test/pull/7", State: domain.PROpen}, CI: domain.SCMCI{Summary: "passing"}}
+
+	saved, changed, err := s.SaveSnapshot(ctx, snap)
+	if err != nil || !changed {
+		t.Fatalf("SaveSnapshot first changed=%v err=%v", changed, err)
+	}
+	if saved.Revision != 1 || saved.SemanticHash == "" {
+		t.Fatalf("revision/hash = %d/%q", saved.Revision, saved.SemanticHash)
+	}
+
+	snap.ObservedAt = now.Add(time.Hour)
+	saved2, changed, err := s.SaveSnapshot(ctx, snap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatalf("ObservedAt-only change should not create a revision")
+	}
+	if saved2.Revision != 1 {
+		t.Fatalf("unchanged revision = %d", saved2.Revision)
+	}
+
+	snap.CI.Summary = "failing"
+	saved3, changed, err := s.SaveSnapshot(ctx, snap)
+	if err != nil || !changed {
+		t.Fatalf("semantic change changed=%v err=%v", changed, err)
+	}
+	if saved3.Revision != 2 {
+		t.Fatalf("revision after semantic change = %d", saved3.Revision)
+	}
+}
+
+func TestFileStorePersistsSubjectsSnapshotsAndScopedCache(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "scm.json")
+	s, err := NewFileStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	subj := domain.SCMSubject{SessionID: "s1", ProjectID: "p1", Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "ao/test", Branch: "feat/27", CredentialHash: "cred-a"}
+	if err := s.UpsertSubject(ctx, subj); err != nil {
+		t.Fatal(err)
+	}
+	keyA := domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: "checks", Key: "sha"}
+	if err := s.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: keyA, ETag: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	keyB := keyA
+	keyB.CredentialHash = "cred-b"
+	if err := s.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: keyB, ETag: "b"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DeleteProviderCache(ctx, domain.SCMProviderCachePrefix{SCMProviderCacheScope: subj.CacheScope(), Namespace: "checks"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := s.GetProviderCache(ctx, keyA); ok {
+		t.Fatalf("credential scoped cache A was not deleted")
+	}
+	if got, ok, _ := s.GetProviderCache(ctx, keyB); !ok || got.ETag != "b" {
+		t.Fatalf("credential scoped cache B got=%+v ok=%v", got, ok)
+	}
+
+	reopened, err := NewFileStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, ok, _ := reopened.GetSubject(ctx, "s1"); !ok || got.Repo != subj.Repo {
+		t.Fatalf("reopened subject got=%+v ok=%v", got, ok)
+	}
+}

--- a/backend/internal/scm/store/store_test.go
+++ b/backend/internal/scm/store/store_test.go
@@ -84,3 +84,24 @@ func TestFileStorePersistsSubjectsSnapshotsAndScopedCache(t *testing.T) {
 		t.Fatalf("reopened subject got=%+v ok=%v", got, ok)
 	}
 }
+
+func TestProviderCachePrunesOldestEntriesByNamespace(t *testing.T) {
+	ctx := context.Background()
+	base := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	s := NewMemoryStore()
+	scope := domain.SCMProviderCacheScope{Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "ao/test", CredentialHash: "cred"}
+	for i := 0; i < defaultProviderCacheCaps["pr-list"]+5; i++ {
+		key := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: "pr-list", Key: string(rune('a' + i))}
+		if err := s.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: key.Key, UpdatedAt: base.Add(time.Duration(i) * time.Second)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldKey := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: "pr-list", Key: string(rune('a'))}
+	if _, ok, _ := s.GetProviderCache(ctx, oldKey); ok {
+		t.Fatal("oldest pr-list cache entry should have been pruned")
+	}
+	newKey := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: "pr-list", Key: string(rune('a' + defaultProviderCacheCaps["pr-list"] + 4))}
+	if _, ok, _ := s.GetProviderCache(ctx, newKey); !ok {
+		t.Fatal("newest pr-list cache entry should remain")
+	}
+}

--- a/backend/internal/scm/store/store_test.go
+++ b/backend/internal/scm/store/store_test.go
@@ -23,6 +23,13 @@ func TestSaveSnapshotRevisionAndSemanticHash(t *testing.T) {
 	if saved.Revision != 1 || saved.SemanticHash == "" {
 		t.Fatalf("revision/hash = %d/%q", saved.Revision, saved.SemanticHash)
 	}
+	gotSubject, ok, err := s.GetSubject(ctx, "s1")
+	if err != nil || !ok {
+		t.Fatalf("subject from snapshot ok=%v err=%v", ok, err)
+	}
+	if gotSubject.CreatedAt.IsZero() || gotSubject.UpdatedAt.IsZero() {
+		t.Fatalf("snapshot subject timestamps were not initialized: %+v", gotSubject)
+	}
 
 	snap.ObservedAt = now.Add(time.Hour)
 	saved2, changed, err := s.SaveSnapshot(ctx, snap)

--- a/backend/internal/scm/store/store_test.go
+++ b/backend/internal/scm/store/store_test.go
@@ -57,7 +57,7 @@ func TestFileStorePersistsSubjectsSnapshotsAndScopedCache(t *testing.T) {
 	if err := s.UpsertSubject(ctx, subj); err != nil {
 		t.Fatal(err)
 	}
-	keyA := domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: "checks", Key: "sha"}
+	keyA := domain.SCMProviderCacheKey{SCMProviderCacheScope: subj.CacheScope(), Namespace: "provider-cache", Key: "sha"}
 	if err := s.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: keyA, ETag: "a"}); err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestFileStorePersistsSubjectsSnapshotsAndScopedCache(t *testing.T) {
 	if err := s.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: keyB, ETag: "b"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.DeleteProviderCache(ctx, domain.SCMProviderCachePrefix{SCMProviderCacheScope: subj.CacheScope(), Namespace: "checks"}); err != nil {
+	if err := s.DeleteProviderCache(ctx, domain.SCMProviderCachePrefix{SCMProviderCacheScope: subj.CacheScope(), Namespace: "provider-cache"}); err != nil {
 		t.Fatal(err)
 	}
 	if _, ok, _ := s.GetProviderCache(ctx, keyA); ok {
@@ -90,18 +90,27 @@ func TestProviderCachePrunesOldestEntriesByNamespace(t *testing.T) {
 	base := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
 	s := NewMemoryStore()
 	scope := domain.SCMProviderCacheScope{Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "ao/test", CredentialHash: "cred"}
-	for i := 0; i < defaultProviderCacheCaps["pr-list"]+5; i++ {
-		key := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: "pr-list", Key: string(rune('a' + i))}
-		if err := s.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: key.Key, UpdatedAt: base.Add(time.Duration(i) * time.Second)}); err != nil {
+	otherScope := domain.SCMProviderCacheScope{Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "ao/other", CredentialHash: "cred"}
+	capN := 3
+	for i := 0; i < capN+2; i++ {
+		key := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: "provider-owned", Key: string(rune('a' + i))}
+		if err := s.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: key, ETag: key.Key, UpdatedAt: base.Add(time.Duration(i) * time.Second), MaxEntries: capN}); err != nil {
 			t.Fatal(err)
 		}
 	}
-	oldKey := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: "pr-list", Key: string(rune('a'))}
-	if _, ok, _ := s.GetProviderCache(ctx, oldKey); ok {
-		t.Fatal("oldest pr-list cache entry should have been pruned")
+	otherKey := domain.SCMProviderCacheKey{SCMProviderCacheScope: otherScope, Namespace: "provider-owned", Key: "a"}
+	if err := s.PutProviderCache(ctx, domain.SCMProviderCacheEntry{Key: otherKey, ETag: "other", UpdatedAt: base, MaxEntries: capN}); err != nil {
+		t.Fatal(err)
 	}
-	newKey := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: "pr-list", Key: string(rune('a' + defaultProviderCacheCaps["pr-list"] + 4))}
+	oldKey := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: "provider-owned", Key: string(rune('a'))}
+	if _, ok, _ := s.GetProviderCache(ctx, oldKey); ok {
+		t.Fatal("oldest scoped cache entry should have been pruned")
+	}
+	newKey := domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: "provider-owned", Key: string(rune('a' + capN + 1))}
 	if _, ok, _ := s.GetProviderCache(ctx, newKey); !ok {
-		t.Fatal("newest pr-list cache entry should remain")
+		t.Fatal("newest scoped cache entry should remain")
+	}
+	if _, ok, _ := s.GetProviderCache(ctx, otherKey); !ok {
+		t.Fatal("cache cap should not prune another scope")
 	}
 }

--- a/backend/internal/session/manager_test.go
+++ b/backend/internal/session/manager_test.go
@@ -94,6 +94,9 @@ func (l *fakeLCM) ApplyRuntimeObservation(context.Context, domain.SessionID, por
 func (l *fakeLCM) ApplyActivitySignal(context.Context, domain.SessionID, ports.ActivitySignal) error {
 	return nil
 }
+func (l *fakeLCM) ApplySCMObservation(context.Context, domain.SessionID, ports.SCMFacts) error {
+	return nil
+}
 func (l *fakeLCM) ApplyPRObservation(context.Context, domain.SessionID, ports.PRObservation) error {
 	return nil
 }

--- a/backend/internal/storage/sqlite/gen/models.go
+++ b/backend/internal/storage/sqlite/gen/models.go
@@ -68,6 +68,9 @@ type PrComment struct {
 	Body      string
 	Resolved  int64
 	CreatedAt time.Time
+	ThreadID  string
+	Url       string
+	IsBot     int64
 }
 
 type Project struct {

--- a/backend/internal/storage/sqlite/gen/pr_comment.sql.go
+++ b/backend/internal/storage/sqlite/gen/pr_comment.sql.go
@@ -20,7 +20,8 @@ func (q *Queries) DeletePRComments(ctx context.Context, prUrl string) error {
 }
 
 const listPRComments = `-- name: ListPRComments :many
-SELECT pr_url, comment_id, author, file, line, body, resolved, created_at FROM pr_comment WHERE pr_url = ? ORDER BY created_at, comment_id
+SELECT pr_url, comment_id, author, file, line, body, resolved, created_at, thread_id, url, is_bot
+FROM pr_comment WHERE pr_url = ? ORDER BY created_at, comment_id
 `
 
 func (q *Queries) ListPRComments(ctx context.Context, prUrl string) ([]PrComment, error) {
@@ -41,6 +42,9 @@ func (q *Queries) ListPRComments(ctx context.Context, prUrl string) ([]PrComment
 			&i.Body,
 			&i.Resolved,
 			&i.CreatedAt,
+			&i.ThreadID,
+			&i.Url,
+			&i.IsBot,
 		); err != nil {
 			return nil, err
 		}
@@ -56,11 +60,12 @@ func (q *Queries) ListPRComments(ctx context.Context, prUrl string) ([]PrComment
 }
 
 const upsertPRComment = `-- name: UpsertPRComment :exec
-INSERT INTO pr_comment (pr_url, comment_id, author, file, line, body, resolved, created_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO pr_comment (pr_url, comment_id, author, file, line, body, resolved, created_at, thread_id, url, is_bot)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (pr_url, comment_id) DO UPDATE SET
     author = excluded.author, file = excluded.file, line = excluded.line,
-    body = excluded.body, resolved = excluded.resolved
+    body = excluded.body, resolved = excluded.resolved,
+    thread_id = excluded.thread_id, url = excluded.url, is_bot = excluded.is_bot
 `
 
 type UpsertPRCommentParams struct {
@@ -72,6 +77,9 @@ type UpsertPRCommentParams struct {
 	Body      string
 	Resolved  int64
 	CreatedAt time.Time
+	ThreadID  string
+	Url       string
+	IsBot     int64
 }
 
 func (q *Queries) UpsertPRComment(ctx context.Context, arg UpsertPRCommentParams) error {
@@ -84,6 +92,9 @@ func (q *Queries) UpsertPRComment(ctx context.Context, arg UpsertPRCommentParams
 		arg.Body,
 		arg.Resolved,
 		arg.CreatedAt,
+		arg.ThreadID,
+		arg.Url,
+		arg.IsBot,
 	)
 	return err
 }

--- a/backend/internal/storage/sqlite/migrations/0003_scm.sql
+++ b/backend/internal/storage/sqlite/migrations/0003_scm.sql
@@ -1,0 +1,158 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- scm_subjects is the durable binding from an AO session to the provider/repo
+-- branch and, once discovered, the concrete change request. Provider cache
+-- scoping deliberately includes credential_hash; PR identity never does.
+CREATE TABLE scm_subjects (
+    session_id      TEXT PRIMARY KEY REFERENCES sessions (id) ON DELETE CASCADE,
+    project_id      TEXT NOT NULL REFERENCES projects (id),
+    provider        TEXT NOT NULL,
+    host            TEXT NOT NULL,
+    repo            TEXT NOT NULL,
+    branch          TEXT NOT NULL,
+    base_branch     TEXT NOT NULL DEFAULT '',
+    credential_hash TEXT NOT NULL DEFAULT '',
+    pr_number       INTEGER NOT NULL DEFAULT 0,
+    pr_url          TEXT NOT NULL DEFAULT '',
+    created_at      TIMESTAMP NOT NULL,
+    updated_at      TIMESTAMP NOT NULL
+);
+CREATE INDEX idx_scm_subjects_project ON scm_subjects (project_id);
+CREATE INDEX idx_scm_subjects_repo ON scm_subjects (provider, host, repo, project_id);
+
+-- scm_snapshots is the raw normalized SCM truth. The LCM consumes these through
+-- the SCM snapshot event path; the derived pr/pr_checks/pr_comment tables remain
+-- the display/reaction read model written by the LCM.
+CREATE TABLE scm_snapshots (
+    session_id    TEXT NOT NULL REFERENCES sessions (id) ON DELETE CASCADE,
+    revision      INTEGER NOT NULL,
+    project_id    TEXT NOT NULL REFERENCES projects (id),
+    provider      TEXT NOT NULL,
+    host          TEXT NOT NULL,
+    repo          TEXT NOT NULL,
+    pr_number     INTEGER NOT NULL DEFAULT 0,
+    pr_url        TEXT NOT NULL DEFAULT '',
+    freshness     TEXT NOT NULL,
+    semantic_hash TEXT NOT NULL,
+    observed_at   TIMESTAMP NOT NULL,
+    snapshot_json TEXT NOT NULL,
+    PRIMARY KEY (session_id, revision)
+);
+CREATE INDEX idx_scm_snapshots_latest ON scm_snapshots (session_id, revision DESC);
+CREATE INDEX idx_scm_snapshots_project ON scm_snapshots (project_id, session_id, revision DESC);
+
+-- scm_provider_cache stores provider-owned ETags, positive branch mappings, and
+-- opaque provider hints. Generic storage only scopes, expires, and prunes it.
+CREATE TABLE scm_provider_cache (
+    provider        TEXT NOT NULL,
+    host            TEXT NOT NULL,
+    repo            TEXT NOT NULL,
+    credential_hash TEXT NOT NULL DEFAULT '',
+    namespace       TEXT NOT NULL,
+    cache_key       TEXT NOT NULL,
+    etag            TEXT NOT NULL DEFAULT '',
+    value_json      BLOB NOT NULL DEFAULT x'',
+    updated_at      TIMESTAMP NOT NULL,
+    expires_at      TIMESTAMP,
+    PRIMARY KEY (provider, host, repo, credential_hash, namespace, cache_key)
+);
+CREATE INDEX idx_scm_provider_cache_scope ON scm_provider_cache (
+    provider, host, repo, credential_hash, namespace, updated_at
+);
+
+-- scm_poll_state is provider/repo scheduler memory: failures, backoff, and
+-- rate-limit gates. It is intentionally separate from provider cache because it
+-- affects scheduling even when no semantic snapshot changes.
+CREATE TABLE scm_poll_state (
+    provider             TEXT NOT NULL,
+    host                 TEXT NOT NULL,
+    repo                 TEXT NOT NULL,
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+    last_success_at      TIMESTAMP,
+    last_failure_at      TIMESTAMP,
+    backoff_until        TIMESTAMP,
+    rate_limit_until     TIMESTAMP,
+    last_error_json      TEXT NOT NULL DEFAULT '',
+    updated_at           TIMESTAMP NOT NULL,
+    PRIMARY KEY (provider, host, repo)
+);
+
+-- Preserve SCM review-thread metadata in the derived PR comment read model.
+ALTER TABLE pr_comment ADD COLUMN thread_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE pr_comment ADD COLUMN url TEXT NOT NULL DEFAULT '';
+ALTER TABLE pr_comment ADD COLUMN is_bot INTEGER NOT NULL DEFAULT 0;
+
+-- +goose StatementEnd
+
+-- Snapshot inserts are meaningful semantic changes only: SaveSnapshot suppresses
+-- unchanged semantic hashes before writing this table. The trigger turns each
+-- inserted revision into the event the SCM consumer uses to feed the LCM.
+-- +goose StatementBegin
+CREATE TRIGGER scm_snapshots_cdc_insert
+AFTER INSERT ON scm_snapshots
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (NEW.project_id, NEW.session_id, 'scm_snapshot_created',
+        json_object('sessionId', NEW.session_id, 'revision', NEW.revision,
+                    'semanticHash', NEW.semantic_hash, 'provider', NEW.provider,
+                    'host', NEW.host, 'repo', NEW.repo, 'prNumber', NEW.pr_number,
+                    'prUrl', NEW.pr_url, 'freshness', NEW.freshness),
+        NEW.observed_at);
+END;
+-- +goose StatementEnd
+
+-- Review comments change without necessarily changing scalar PR fields. Emit a
+-- small event so API/dashboard live subscribers can refresh the comment read
+-- model. The LCM is not driven by these events; it is driven by SCM snapshots.
+-- +goose StatementBegin
+CREATE TRIGGER pr_comment_cdc_insert
+AFTER INSERT ON pr_comment
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT s.project_id FROM pr p JOIN sessions s ON s.id = p.session_id WHERE p.url = NEW.pr_url),
+        (SELECT session_id FROM pr WHERE url = NEW.pr_url),
+        'pr_comment_recorded',
+        json_object('pr', NEW.pr_url, 'commentId', NEW.comment_id,
+                    'threadId', NEW.thread_id, 'author', NEW.author,
+                    'isBot', NEW.is_bot, 'resolved', NEW.resolved),
+        NEW.created_at);
+END;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER pr_comment_cdc_update
+AFTER UPDATE ON pr_comment
+WHEN OLD.author <> NEW.author
+    OR OLD.file <> NEW.file
+    OR OLD.line <> NEW.line
+    OR OLD.body <> NEW.body
+    OR OLD.resolved <> NEW.resolved
+    OR OLD.thread_id <> NEW.thread_id
+    OR OLD.url <> NEW.url
+    OR OLD.is_bot <> NEW.is_bot
+BEGIN
+    INSERT INTO change_log (project_id, session_id, event_type, payload, created_at)
+    VALUES (
+        (SELECT s.project_id FROM pr p JOIN sessions s ON s.id = p.session_id WHERE p.url = NEW.pr_url),
+        (SELECT session_id FROM pr WHERE url = NEW.pr_url),
+        'pr_comment_recorded',
+        json_object('pr', NEW.pr_url, 'commentId', NEW.comment_id,
+                    'threadId', NEW.thread_id, 'author', NEW.author,
+                    'isBot', NEW.is_bot, 'resolved', NEW.resolved),
+        NEW.created_at);
+END;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS pr_comment_cdc_update;
+DROP TRIGGER IF EXISTS pr_comment_cdc_insert;
+DROP TRIGGER IF EXISTS scm_snapshots_cdc_insert;
+DROP TABLE IF EXISTS scm_poll_state;
+DROP TABLE IF EXISTS scm_provider_cache;
+DROP TABLE IF EXISTS scm_snapshots;
+DROP TABLE IF EXISTS scm_subjects;
+-- SQLite cannot drop columns from pr_comment portably in a down migration here.
+-- +goose StatementEnd

--- a/backend/internal/storage/sqlite/pr_store.go
+++ b/backend/internal/storage/sqlite/pr_store.go
@@ -77,6 +77,7 @@ func (s *Store) WritePRObservation(ctx context.Context, pr PRRow, checks []PRChe
 			if err := q.UpsertPRComment(ctx, gen.UpsertPRCommentParams{
 				PrUrl: pr.URL, CommentID: cm.CommentID, Author: cm.Author, File: cm.File,
 				Line: cm.Line, Body: cm.Body, Resolved: boolToInt(cm.Resolved), CreatedAt: cm.CreatedAt,
+				ThreadID: cm.ThreadID, Url: cm.URL, IsBot: boolToInt(cm.IsBot),
 			}); err != nil {
 				return fmt.Errorf("comment %q: %w", cm.CommentID, err)
 			}
@@ -224,6 +225,9 @@ type PRCommentRow struct {
 	Body      string
 	Resolved  bool
 	CreatedAt time.Time
+	ThreadID  string
+	URL       string
+	IsBot     bool
 }
 
 // ReplacePRComments atomically replaces the full comment set for a PR (each SCM
@@ -245,6 +249,9 @@ func (s *Store) ReplacePRComments(ctx context.Context, prURL string, comments []
 				Body:      c.Body,
 				Resolved:  boolToInt(c.Resolved),
 				CreatedAt: c.CreatedAt,
+				ThreadID:  c.ThreadID,
+				Url:       c.URL,
+				IsBot:     boolToInt(c.IsBot),
 			}); err != nil {
 				return fmt.Errorf("comment %q: %w", c.CommentID, err)
 			}
@@ -264,6 +271,7 @@ func (s *Store) ListPRComments(ctx context.Context, prURL string) ([]PRCommentRo
 		out = append(out, PRCommentRow{
 			PRURL: c.PrUrl, CommentID: c.CommentID, Author: c.Author, File: c.File,
 			Line: c.Line, Body: c.Body, Resolved: c.Resolved != 0, CreatedAt: c.CreatedAt,
+			ThreadID: c.ThreadID, URL: c.Url, IsBot: c.IsBot != 0,
 		})
 	}
 	return out, nil

--- a/backend/internal/storage/sqlite/queries/pr_comment.sql
+++ b/backend/internal/storage/sqlite/queries/pr_comment.sql
@@ -1,12 +1,14 @@
 -- name: UpsertPRComment :exec
-INSERT INTO pr_comment (pr_url, comment_id, author, file, line, body, resolved, created_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO pr_comment (pr_url, comment_id, author, file, line, body, resolved, created_at, thread_id, url, is_bot)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (pr_url, comment_id) DO UPDATE SET
     author = excluded.author, file = excluded.file, line = excluded.line,
-    body = excluded.body, resolved = excluded.resolved;
+    body = excluded.body, resolved = excluded.resolved,
+    thread_id = excluded.thread_id, url = excluded.url, is_bot = excluded.is_bot;
 
 -- name: DeletePRComments :exec
 DELETE FROM pr_comment WHERE pr_url = ?;
 
 -- name: ListPRComments :many
-SELECT * FROM pr_comment WHERE pr_url = ? ORDER BY created_at, comment_id;
+SELECT pr_url, comment_id, author, file, line, body, resolved, created_at, thread_id, url, is_bot
+FROM pr_comment WHERE pr_url = ? ORDER BY created_at, comment_id;

--- a/backend/internal/storage/sqlite/scm_store.go
+++ b/backend/internal/storage/sqlite/scm_store.go
@@ -1,0 +1,594 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+var _ ports.SCMStore = (*Store)(nil)
+
+func (s *Store) UpsertSubject(ctx context.Context, subject domain.SCMSubject) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	_, err := s.upsertSCMSubject(ctx, s.writeDB, subject, s.now())
+	return err
+}
+
+func (s *Store) GetSubject(ctx context.Context, sessionID domain.SessionID) (domain.SCMSubject, bool, error) {
+	row := s.readDB.QueryRowContext(ctx, `
+SELECT session_id, project_id, provider, host, repo, branch, base_branch, credential_hash,
+       pr_number, pr_url, created_at, updated_at
+FROM scm_subjects WHERE session_id = ?`, string(sessionID))
+	subj, err := scanSCMSubject(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return domain.SCMSubject{}, false, nil
+	}
+	if err != nil {
+		return domain.SCMSubject{}, false, fmt.Errorf("get scm subject %s: %w", sessionID, err)
+	}
+	return subj, true, nil
+}
+
+func (s *Store) ListSubjects(ctx context.Context, filter domain.SCMSubjectFilter) ([]domain.SCMSubject, error) {
+	where := []string{"1=1"}
+	args := []any{}
+	if filter.ProjectID != "" {
+		where = append(where, "project_id = ?")
+		args = append(args, string(filter.ProjectID))
+	}
+	if filter.Provider != "" {
+		where = append(where, "provider = ?")
+		args = append(args, string(filter.Provider))
+	}
+	if strings.TrimSpace(filter.Host) != "" {
+		where = append(where, "host = ?")
+		args = append(args, normalizeSCMHost(filter.Host))
+	}
+	if strings.TrimSpace(filter.Repo) != "" {
+		where = append(where, "repo = ?")
+		args = append(args, normalizeSCMRepo(filter.Repo))
+	}
+	rows, err := s.readDB.QueryContext(ctx, `
+SELECT session_id, project_id, provider, host, repo, branch, base_branch, credential_hash,
+       pr_number, pr_url, created_at, updated_at
+FROM scm_subjects WHERE `+strings.Join(where, " AND ")+` ORDER BY session_id`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list scm subjects: %w", err)
+	}
+	defer rows.Close()
+	out := []domain.SCMSubject{}
+	for rows.Next() {
+		subj, err := scanSCMSubject(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, subj)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (s *Store) DeleteSubject(ctx context.Context, sessionID domain.SessionID) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	_, err := s.writeDB.ExecContext(ctx, `DELETE FROM scm_subjects WHERE session_id = ?`, string(sessionID))
+	return err
+}
+
+func (s *Store) SaveSnapshot(ctx context.Context, snapshot domain.SCMSnapshot) (domain.SCMSnapshot, bool, error) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	if snapshot.SessionID == "" {
+		snapshot.SessionID = snapshot.Subject.SessionID
+	}
+	if snapshot.SessionID == "" {
+		return domain.SCMSnapshot{}, false, fmt.Errorf("scm store: snapshot missing session id")
+	}
+	if snapshot.Subject.SessionID == "" {
+		snapshot.Subject.SessionID = snapshot.SessionID
+	}
+	if snapshot.ObservedAt.IsZero() {
+		snapshot.ObservedAt = s.now()
+	}
+	if snapshot.Freshness == "" {
+		snapshot.Freshness = domain.SCMFreshnessFresh
+	}
+	if snapshot.PR != nil {
+		if snapshot.Subject.PRNumber == 0 {
+			snapshot.Subject.PRNumber = snapshot.PR.Number
+		}
+		if snapshot.Subject.PRURL == "" {
+			snapshot.Subject.PRURL = snapshot.PR.URL
+		}
+	}
+	if snapshot.Subject.ProjectID == "" {
+		if existing, ok, err := s.getSCMSubjectForWrite(ctx, snapshot.SessionID); err != nil {
+			return domain.SCMSnapshot{}, false, err
+		} else if ok {
+			if snapshot.Subject.ProjectID == "" {
+				snapshot.Subject.ProjectID = existing.ProjectID
+			}
+			if snapshot.Subject.Provider == "" {
+				snapshot.Subject.Provider = existing.Provider
+			}
+			if snapshot.Subject.Host == "" {
+				snapshot.Subject.Host = existing.Host
+			}
+			if snapshot.Subject.Repo == "" {
+				snapshot.Subject.Repo = existing.Repo
+			}
+			if snapshot.Subject.Branch == "" {
+				snapshot.Subject.Branch = existing.Branch
+			}
+		}
+	}
+	hash, err := domain.ComputeSCMSemanticHash(snapshot)
+	if err != nil {
+		return domain.SCMSnapshot{}, false, err
+	}
+	snapshot.SemanticHash = hash
+
+	latest, ok, err := s.latestSCMSnapshotForWrite(ctx, snapshot.SessionID)
+	if err != nil {
+		return domain.SCMSnapshot{}, false, err
+	}
+	if ok && latest.SemanticHash == snapshot.SemanticHash {
+		return latest, false, nil
+	}
+	if ok {
+		snapshot.Revision = latest.Revision + 1
+	} else {
+		snapshot.Revision = 1
+	}
+	if snapshot.Subject.CreatedAt.IsZero() {
+		if existing, ok, err := s.getSCMSubjectForWrite(ctx, snapshot.SessionID); err != nil {
+			return domain.SCMSnapshot{}, false, err
+		} else if ok && !existing.CreatedAt.IsZero() {
+			snapshot.Subject.CreatedAt = existing.CreatedAt
+		} else {
+			snapshot.Subject.CreatedAt = snapshot.ObservedAt
+		}
+	}
+	snapshot.Subject.UpdatedAt = snapshot.ObservedAt
+
+	tx, err := s.writeDB.BeginTx(ctx, nil)
+	if err != nil {
+		return domain.SCMSnapshot{}, false, fmt.Errorf("begin save scm snapshot: %w", err)
+	}
+	defer tx.Rollback()
+
+	subj, err := s.upsertSCMSubject(ctx, tx, snapshot.Subject, snapshot.ObservedAt)
+	if err != nil {
+		return domain.SCMSnapshot{}, false, err
+	}
+	snapshot.Subject = subj
+	if snapshot.Subject.ProjectID == "" {
+		return domain.SCMSnapshot{}, false, fmt.Errorf("scm store: snapshot %s missing project id", snapshot.SessionID)
+	}
+	if snapshot.Subject.Provider == "" || snapshot.Subject.Host == "" || snapshot.Subject.Repo == "" {
+		return domain.SCMSnapshot{}, false, fmt.Errorf("scm store: snapshot %s missing provider/repo identity", snapshot.SessionID)
+	}
+	b, err := json.Marshal(snapshot)
+	if err != nil {
+		return domain.SCMSnapshot{}, false, err
+	}
+	prNumber, prURL := snapshot.Subject.PRNumber, snapshot.Subject.PRURL
+	if snapshot.PR != nil {
+		prNumber = snapshot.PR.Number
+		prURL = snapshot.PR.URL
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO scm_snapshots (
+    session_id, revision, project_id, provider, host, repo, pr_number, pr_url,
+    freshness, semantic_hash, observed_at, snapshot_json
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		string(snapshot.SessionID), snapshot.Revision, string(snapshot.Subject.ProjectID),
+		string(snapshot.Subject.Provider), normalizeSCMHost(snapshot.Subject.Host), normalizeSCMRepo(snapshot.Subject.Repo),
+		int64(prNumber), prURL, string(snapshot.Freshness), snapshot.SemanticHash, snapshot.ObservedAt, string(b),
+	); err != nil {
+		return domain.SCMSnapshot{}, false, fmt.Errorf("insert scm snapshot: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return domain.SCMSnapshot{}, false, fmt.Errorf("commit save scm snapshot: %w", err)
+	}
+	return snapshot, true, nil
+}
+
+func (s *Store) GetLatestSnapshot(ctx context.Context, sessionID domain.SessionID) (domain.SCMSnapshot, bool, error) {
+	row := s.readDB.QueryRowContext(ctx, `
+SELECT snapshot_json FROM scm_snapshots
+WHERE session_id = ?
+ORDER BY revision DESC LIMIT 1`, string(sessionID))
+	var raw string
+	if err := row.Scan(&raw); errors.Is(err, sql.ErrNoRows) {
+		return domain.SCMSnapshot{}, false, nil
+	} else if err != nil {
+		return domain.SCMSnapshot{}, false, fmt.Errorf("get latest scm snapshot %s: %w", sessionID, err)
+	}
+	snap, err := decodeSCMSnapshot(raw)
+	if err != nil {
+		return domain.SCMSnapshot{}, false, err
+	}
+	return snap, true, nil
+}
+
+func (s *Store) ListLatestSnapshots(ctx context.Context, project domain.ProjectID) ([]domain.SCMSnapshot, error) {
+	args := []any{}
+	projectWhere := ""
+	if project != "" {
+		projectWhere = "WHERE ss.project_id = ?"
+		args = append(args, string(project))
+	}
+	rows, err := s.readDB.QueryContext(ctx, `
+SELECT ss.snapshot_json
+FROM scm_snapshots ss
+JOIN (
+    SELECT session_id, MAX(revision) AS revision
+    FROM scm_snapshots
+    GROUP BY session_id
+) latest ON latest.session_id = ss.session_id AND latest.revision = ss.revision
+`+projectWhere+`
+ORDER BY ss.session_id`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list latest scm snapshots: %w", err)
+	}
+	defer rows.Close()
+	out := []domain.SCMSnapshot{}
+	for rows.Next() {
+		var raw string
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		snap, err := decodeSCMSnapshot(raw)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, snap)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (s *Store) GetProviderCache(ctx context.Context, key domain.SCMProviderCacheKey) (domain.SCMProviderCacheEntry, bool, error) {
+	key = normalizeCacheKey(key)
+	row := s.readDB.QueryRowContext(ctx, `
+SELECT etag, value_json, updated_at, expires_at
+FROM scm_provider_cache
+WHERE provider = ? AND host = ? AND repo = ? AND credential_hash = ? AND namespace = ? AND cache_key = ?`,
+		string(key.Provider), normalizeSCMHost(key.Host), normalizeSCMRepo(key.Repo), key.CredentialHash, key.Namespace, key.Key)
+	var entry domain.SCMProviderCacheEntry
+	var expires sql.NullTime
+	entry.Key = key
+	if err := row.Scan(&entry.ETag, &entry.Value, &entry.UpdatedAt, &expires); errors.Is(err, sql.ErrNoRows) {
+		return domain.SCMProviderCacheEntry{}, false, nil
+	} else if err != nil {
+		return domain.SCMProviderCacheEntry{}, false, fmt.Errorf("get scm provider cache %s: %w", key.String(), err)
+	}
+	if expires.Valid {
+		entry.ExpiresAt = expires.Time
+	}
+	if entry.Expired(s.now()) {
+		_ = s.DeleteProviderCache(ctx, domain.SCMProviderCachePrefix{SCMProviderCacheScope: key.SCMProviderCacheScope, Namespace: key.Namespace, KeyPrefix: key.Key})
+		return domain.SCMProviderCacheEntry{}, false, nil
+	}
+	return entry, true, nil
+}
+
+func (s *Store) PutProviderCache(ctx context.Context, entry domain.SCMProviderCacheEntry) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	entry.Key = normalizeCacheKey(entry.Key)
+	if entry.UpdatedAt.IsZero() {
+		entry.UpdatedAt = s.now()
+	}
+	if _, err := s.writeDB.ExecContext(ctx, `
+INSERT INTO scm_provider_cache (
+    provider, host, repo, credential_hash, namespace, cache_key, etag, value_json, updated_at, expires_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT (provider, host, repo, credential_hash, namespace, cache_key) DO UPDATE SET
+    etag = excluded.etag,
+    value_json = excluded.value_json,
+    updated_at = excluded.updated_at,
+    expires_at = excluded.expires_at`,
+		string(entry.Key.Provider), normalizeSCMHost(entry.Key.Host), normalizeSCMRepo(entry.Key.Repo),
+		entry.Key.CredentialHash, entry.Key.Namespace, entry.Key.Key, entry.ETag, []byte(entry.Value),
+		entry.UpdatedAt, nullTime(entry.ExpiresAt),
+	); err != nil {
+		return fmt.Errorf("put scm provider cache %s: %w", entry.Key.String(), err)
+	}
+	if entry.MaxEntries > 0 {
+		if _, err := s.writeDB.ExecContext(ctx, `
+DELETE FROM scm_provider_cache
+WHERE rowid IN (
+    SELECT rowid FROM scm_provider_cache
+    WHERE provider = ? AND host = ? AND repo = ? AND credential_hash = ? AND namespace = ?
+    ORDER BY updated_at DESC
+    LIMIT -1 OFFSET ?
+)`,
+			string(entry.Key.Provider), normalizeSCMHost(entry.Key.Host), normalizeSCMRepo(entry.Key.Repo),
+			entry.Key.CredentialHash, entry.Key.Namespace, entry.MaxEntries,
+		); err != nil {
+			return fmt.Errorf("prune scm provider cache %s: %w", entry.Key.String(), err)
+		}
+	}
+	return nil
+}
+
+func (s *Store) DeleteProviderCache(ctx context.Context, prefix domain.SCMProviderCachePrefix) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	where, args := providerCachePrefixWhere(prefix)
+	_, err := s.writeDB.ExecContext(ctx, `DELETE FROM scm_provider_cache WHERE `+where, args...)
+	if err != nil {
+		return fmt.Errorf("delete scm provider cache: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetPollState(ctx context.Context, key domain.SCMPollStateKey) (domain.SCMPollState, bool, error) {
+	key = normalizePollStateKey(key)
+	row := s.readDB.QueryRowContext(ctx, `
+SELECT consecutive_failures, last_success_at, last_failure_at, backoff_until, rate_limit_until, last_error_json
+FROM scm_poll_state
+WHERE provider = ? AND host = ? AND repo = ?`, string(key.Provider), normalizeSCMHost(key.Host), normalizeSCMRepo(key.Repo))
+	st := domain.SCMPollState{Key: key}
+	var lastSuccess, lastFailure, backoff, rateLimit sql.NullTime
+	var lastErr string
+	if err := row.Scan(&st.ConsecutiveFail, &lastSuccess, &lastFailure, &backoff, &rateLimit, &lastErr); errors.Is(err, sql.ErrNoRows) {
+		return domain.SCMPollState{}, false, nil
+	} else if err != nil {
+		return domain.SCMPollState{}, false, fmt.Errorf("get scm poll state %s: %w", key.String(), err)
+	}
+	if lastSuccess.Valid {
+		st.LastSuccessAt = lastSuccess.Time
+	}
+	if lastFailure.Valid {
+		st.LastFailureAt = lastFailure.Time
+	}
+	if backoff.Valid {
+		st.BackoffUntil = backoff.Time
+	}
+	if rateLimit.Valid {
+		st.RateLimitUntil = rateLimit.Time
+	}
+	if strings.TrimSpace(lastErr) != "" {
+		var se domain.SCMError
+		if err := json.Unmarshal([]byte(lastErr), &se); err != nil {
+			return domain.SCMPollState{}, false, fmt.Errorf("decode scm poll state error %s: %w", key.String(), err)
+		}
+		st.LastError = &se
+	}
+	return st, true, nil
+}
+
+func (s *Store) PutPollState(ctx context.Context, state domain.SCMPollState) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	state.Key = normalizePollStateKey(state.Key)
+	var lastErr string
+	if state.LastError != nil {
+		b, err := json.Marshal(state.LastError)
+		if err != nil {
+			return err
+		}
+		lastErr = string(b)
+	}
+	_, err := s.writeDB.ExecContext(ctx, `
+INSERT INTO scm_poll_state (
+    provider, host, repo, consecutive_failures, last_success_at, last_failure_at,
+    backoff_until, rate_limit_until, last_error_json, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT (provider, host, repo) DO UPDATE SET
+    consecutive_failures = excluded.consecutive_failures,
+    last_success_at = excluded.last_success_at,
+    last_failure_at = excluded.last_failure_at,
+    backoff_until = excluded.backoff_until,
+    rate_limit_until = excluded.rate_limit_until,
+    last_error_json = excluded.last_error_json,
+    updated_at = excluded.updated_at`,
+		string(state.Key.Provider), normalizeSCMHost(state.Key.Host), normalizeSCMRepo(state.Key.Repo),
+		int64(state.ConsecutiveFail), nullTime(state.LastSuccessAt), nullTime(state.LastFailureAt),
+		nullTime(state.BackoffUntil), nullTime(state.RateLimitUntil), lastErr, s.now(),
+	)
+	if err != nil {
+		return fmt.Errorf("put scm poll state %s: %w", state.Key.String(), err)
+	}
+	return nil
+}
+
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+type execer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+func (s *Store) upsertSCMSubject(ctx context.Context, db execer, subject domain.SCMSubject, now time.Time) (domain.SCMSubject, error) {
+	if subject.SessionID == "" {
+		return domain.SCMSubject{}, fmt.Errorf("scm subject missing session id")
+	}
+	if subject.ProjectID == "" {
+		return domain.SCMSubject{}, fmt.Errorf("scm subject %s missing project id", subject.SessionID)
+	}
+	if subject.Provider == "" || subject.Host == "" || subject.Repo == "" || subject.Branch == "" {
+		return domain.SCMSubject{}, fmt.Errorf("scm subject %s missing provider/repo/branch", subject.SessionID)
+	}
+	if subject.CreatedAt.IsZero() {
+		if existing, ok, err := s.getSCMSubjectForWrite(ctx, subject.SessionID); err != nil {
+			return domain.SCMSubject{}, err
+		} else if ok && !existing.CreatedAt.IsZero() {
+			subject.CreatedAt = existing.CreatedAt
+		} else {
+			subject.CreatedAt = now
+		}
+	}
+	subject.UpdatedAt = now
+	subject.Host = normalizeSCMHost(subject.Host)
+	subject.Repo = normalizeSCMRepo(subject.Repo)
+	_, err := db.ExecContext(ctx, `
+INSERT INTO scm_subjects (
+    session_id, project_id, provider, host, repo, branch, base_branch, credential_hash,
+    pr_number, pr_url, created_at, updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT (session_id) DO UPDATE SET
+    project_id = excluded.project_id,
+    provider = excluded.provider,
+    host = excluded.host,
+    repo = excluded.repo,
+    branch = excluded.branch,
+    base_branch = excluded.base_branch,
+    credential_hash = excluded.credential_hash,
+    pr_number = excluded.pr_number,
+    pr_url = excluded.pr_url,
+    updated_at = excluded.updated_at`,
+		string(subject.SessionID), string(subject.ProjectID), string(subject.Provider), subject.Host, subject.Repo,
+		subject.Branch, subject.BaseBranch, subject.CredentialHash, int64(subject.PRNumber), subject.PRURL,
+		subject.CreatedAt, subject.UpdatedAt,
+	)
+	if err != nil {
+		return domain.SCMSubject{}, fmt.Errorf("upsert scm subject %s: %w", subject.SessionID, err)
+	}
+	return subject, nil
+}
+
+func (s *Store) getSCMSubjectForWrite(ctx context.Context, sessionID domain.SessionID) (domain.SCMSubject, bool, error) {
+	row := s.writeDB.QueryRowContext(ctx, `
+SELECT session_id, project_id, provider, host, repo, branch, base_branch, credential_hash,
+       pr_number, pr_url, created_at, updated_at
+FROM scm_subjects WHERE session_id = ?`, string(sessionID))
+	subj, err := scanSCMSubject(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return domain.SCMSubject{}, false, nil
+	}
+	if err != nil {
+		return domain.SCMSubject{}, false, fmt.Errorf("get scm subject for write %s: %w", sessionID, err)
+	}
+	return subj, true, nil
+}
+
+func (s *Store) latestSCMSnapshotForWrite(ctx context.Context, sessionID domain.SessionID) (domain.SCMSnapshot, bool, error) {
+	row := s.writeDB.QueryRowContext(ctx, `
+SELECT snapshot_json FROM scm_snapshots
+WHERE session_id = ?
+ORDER BY revision DESC LIMIT 1`, string(sessionID))
+	var raw string
+	if err := row.Scan(&raw); errors.Is(err, sql.ErrNoRows) {
+		return domain.SCMSnapshot{}, false, nil
+	} else if err != nil {
+		return domain.SCMSnapshot{}, false, fmt.Errorf("get latest scm snapshot for write %s: %w", sessionID, err)
+	}
+	snap, err := decodeSCMSnapshot(raw)
+	if err != nil {
+		return domain.SCMSnapshot{}, false, err
+	}
+	return snap, true, nil
+}
+
+func scanSCMSubject(row scanner) (domain.SCMSubject, error) {
+	var subj domain.SCMSubject
+	var provider string
+	var prNumber int64
+	if err := row.Scan(
+		&subj.SessionID,
+		&subj.ProjectID,
+		&provider,
+		&subj.Host,
+		&subj.Repo,
+		&subj.Branch,
+		&subj.BaseBranch,
+		&subj.CredentialHash,
+		&prNumber,
+		&subj.PRURL,
+		&subj.CreatedAt,
+		&subj.UpdatedAt,
+	); err != nil {
+		return domain.SCMSubject{}, err
+	}
+	subj.Provider = domain.SCMProvider(provider)
+	subj.PRNumber = int(prNumber)
+	return subj, nil
+}
+
+func decodeSCMSnapshot(raw string) (domain.SCMSnapshot, error) {
+	var snap domain.SCMSnapshot
+	if err := json.Unmarshal([]byte(raw), &snap); err != nil {
+		return domain.SCMSnapshot{}, fmt.Errorf("decode scm snapshot: %w", err)
+	}
+	return snap, nil
+}
+
+func providerCachePrefixWhere(prefix domain.SCMProviderCachePrefix) (string, []any) {
+	where := []string{"1=1"}
+	args := []any{}
+	if prefix.Provider != "" {
+		where = append(where, "provider = ?")
+		args = append(args, string(prefix.Provider))
+	}
+	if strings.TrimSpace(prefix.Host) != "" {
+		where = append(where, "host = ?")
+		args = append(args, normalizeSCMHost(prefix.Host))
+	}
+	if strings.TrimSpace(prefix.Repo) != "" {
+		where = append(where, "repo = ?")
+		args = append(args, normalizeSCMRepo(prefix.Repo))
+	}
+	if prefix.CredentialHash != "" {
+		where = append(where, "credential_hash = ?")
+		args = append(args, prefix.CredentialHash)
+	}
+	if prefix.Namespace != "" {
+		where = append(where, "namespace = ?")
+		args = append(args, prefix.Namespace)
+	}
+	if prefix.KeyPrefix != "" {
+		where = append(where, "cache_key LIKE ? ESCAPE '\\'")
+		args = append(args, escapeLike(prefix.KeyPrefix)+"%")
+	}
+	return strings.Join(where, " AND "), args
+}
+
+func normalizeCacheKey(key domain.SCMProviderCacheKey) domain.SCMProviderCacheKey {
+	key.Host = normalizeSCMHost(key.Host)
+	key.Repo = normalizeSCMRepo(key.Repo)
+	return key
+}
+
+func normalizePollStateKey(key domain.SCMPollStateKey) domain.SCMPollStateKey {
+	key.Host = normalizeSCMHost(key.Host)
+	key.Repo = normalizeSCMRepo(key.Repo)
+	return key
+}
+
+func normalizeSCMHost(host string) string {
+	host = strings.TrimSpace(strings.ToLower(host))
+	host = strings.TrimPrefix(host, "https://")
+	host = strings.TrimPrefix(host, "http://")
+	return strings.TrimSuffix(host, "/")
+}
+
+func normalizeSCMRepo(repo string) string {
+	return strings.ToLower(strings.Trim(strings.TrimSpace(repo), "/"))
+}
+
+func escapeLike(s string) string {
+	// Existing cache keys only use exact prefixes from providers, but keep a
+	// conservative escape for SQL LIKE wildcards.
+	repl := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return repl.Replace(s)
+}
+
+func (s *Store) now() time.Time { return time.Now() }

--- a/backend/internal/storage/sqlite/scm_store_test.go
+++ b/backend/internal/storage/sqlite/scm_store_test.go
@@ -1,0 +1,222 @@
+package sqlite
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func seedSCMSession(t *testing.T, s *Store) domain.SessionRecord {
+	t.Helper()
+	seedProject(t, s, "mer")
+	rec, err := s.CreateSession(context.Background(), sampleRecord("mer"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rec
+}
+
+func sampleSCMSubject(sessionID domain.SessionID) domain.SCMSubject {
+	return domain.SCMSubject{
+		SessionID:      sessionID,
+		ProjectID:      "mer",
+		Provider:       domain.SCMProviderGitHub,
+		Host:           "github.com",
+		Repo:           "aoagents/agent-orchestrator",
+		Branch:         "feat/27",
+		BaseBranch:     "main",
+		CredentialHash: "cred",
+		PRNumber:       28,
+		PRURL:          "https://github.com/aoagents/agent-orchestrator/pull/28",
+	}
+}
+
+func sampleSCMSnapshot(subject domain.SCMSubject, observedAt time.Time) domain.SCMSnapshot {
+	return domain.SCMSnapshot{
+		SessionID:  subject.SessionID,
+		Subject:    subject,
+		Freshness:  domain.SCMFreshnessFresh,
+		ObservedAt: observedAt,
+		PR: &domain.SCMPullRequest{
+			ID:           subject.ChangeRequestID(),
+			Number:       subject.PRNumber,
+			URL:          subject.PRURL,
+			Title:        "SCM",
+			State:        domain.PROpen,
+			SourceBranch: subject.Branch,
+			TargetBranch: subject.BaseBranch,
+			HeadSHA:      "abc123",
+		},
+		CI: domain.SCMCI{Summary: "passing", Checks: []domain.SCMCheck{{Name: "build", Status: "completed", Conclusion: "success"}}},
+		Review: domain.SCMReview{
+			Decision: "approved",
+			UnresolvedThreads: []domain.SCMReviewThread{{
+				ID:   "thread-1",
+				Path: "main.go",
+				Line: 10,
+				URL:  "https://github.com/review/thread-1",
+				Comments: []domain.SCMReviewComment{{
+					ID: "c1", Author: "reviewer", Body: "nit", URL: "https://github.com/comment/c1", ThreadID: "thread-1",
+				}},
+			}},
+		},
+		Mergeability: domain.SCMMergeability{Mergeable: true, CIPassing: true, Approved: true, NoConflicts: true, RawState: "MERGEABLE"},
+	}
+}
+
+func TestSCMStoreSaveSnapshotRevisionAndSemanticHash(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	rec := seedSCMSession(t, s)
+	now := time.Now().UTC().Truncate(time.Second)
+	subj := sampleSCMSubject(rec.ID)
+
+	first, changed, err := s.SaveSnapshot(ctx, sampleSCMSnapshot(subj, now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed || first.Revision != 1 || first.SemanticHash == "" {
+		t.Fatalf("first save changed=%v rev=%d hash=%q", changed, first.Revision, first.SemanticHash)
+	}
+	secondSnap := sampleSCMSnapshot(subj, now.Add(time.Minute))
+	second, changed, err := s.SaveSnapshot(ctx, secondSnap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed || second.Revision != 1 || second.SemanticHash != first.SemanticHash {
+		t.Fatalf("observed-at only save should reuse rev/hash, changed=%v second=%+v first=%+v", changed, second, first)
+	}
+	modified := sampleSCMSnapshot(subj, now.Add(2*time.Minute))
+	modified.CI.Summary = "failing"
+	modified.CI.Checks[0].Conclusion = "failure"
+	third, changed, err := s.SaveSnapshot(ctx, modified)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed || third.Revision != 2 || third.SemanticHash == first.SemanticHash {
+		t.Fatalf("semantic change should increment revision: changed=%v third=%+v firstHash=%s", changed, third, first.SemanticHash)
+	}
+	latest, ok, err := s.GetLatestSnapshot(ctx, rec.ID)
+	if err != nil || !ok || latest.Revision != 2 || latest.CI.Summary != "failing" {
+		t.Fatalf("latest = %+v ok=%v err=%v", latest, ok, err)
+	}
+}
+
+func TestSCMStoreProviderCacheScopedAndPruned(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	scope := domain.SCMProviderCacheScope{Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "AOAgents/Agent-Orchestrator", CredentialHash: "a"}
+	for i, key := range []string{"branch/a", "branch/b", "branch/c"} {
+		entry := domain.SCMProviderCacheEntry{
+			Key:        domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: "branch-map", Key: key},
+			Value:      json.RawMessage(`{"ok":true}`),
+			UpdatedAt:  time.Now().Add(time.Duration(i) * time.Second),
+			MaxEntries: 2,
+		}
+		if err := s.PutProviderCache(ctx, entry); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, ok, err := s.GetProviderCache(ctx, domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: "branch-map", Key: "branch/a"}); err != nil {
+		t.Fatal(err)
+	} else if ok {
+		t.Fatal("oldest branch-map entry should be pruned")
+	}
+	if _, ok, _ := s.GetProviderCache(ctx, domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: "branch-map", Key: "branch/c"}); !ok {
+		t.Fatal("newest branch-map entry should remain")
+	}
+	otherCred := scope
+	otherCred.CredentialHash = "b"
+	if err := s.PutProviderCache(ctx, domain.SCMProviderCacheEntry{
+		Key:   domain.SCMProviderCacheKey{SCMProviderCacheScope: otherCred, Namespace: "branch-map", Key: "branch/c"},
+		Value: json.RawMessage(`{"other":true}`),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DeleteProviderCache(ctx, domain.SCMProviderCachePrefix{SCMProviderCacheScope: scope, Namespace: "branch-map"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := s.GetProviderCache(ctx, domain.SCMProviderCacheKey{SCMProviderCacheScope: scope, Namespace: "branch-map", Key: "branch/c"}); ok {
+		t.Fatal("delete prefix should remove only matching credential scope")
+	}
+	if _, ok, _ := s.GetProviderCache(ctx, domain.SCMProviderCacheKey{SCMProviderCacheScope: otherCred, Namespace: "branch-map", Key: "branch/c"}); !ok {
+		t.Fatal("different credential scope should remain")
+	}
+}
+
+func TestSCMStorePollStateAndSnapshotCDC(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	rec := seedSCMSession(t, s)
+	key := domain.SCMPollStateKey{Provider: domain.SCMProviderGitHub, Host: "github.com", Repo: "aoagents/agent-orchestrator"}
+	state := domain.SCMPollState{
+		Key:             key,
+		ConsecutiveFail: 2,
+		BackoffUntil:    time.Now().UTC().Add(time.Minute).Truncate(time.Second),
+		LastError:       &domain.SCMError{Kind: domain.SCMErrorRateLimited, Operation: "observe", Message: "slow down"},
+	}
+	if err := s.PutPollState(ctx, state); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := s.GetPollState(ctx, key)
+	if err != nil || !ok || got.ConsecutiveFail != 2 || got.LastError == nil || got.LastError.Kind != domain.SCMErrorRateLimited {
+		t.Fatalf("poll state = %+v ok=%v err=%v", got, ok, err)
+	}
+	if _, changed, err := s.SaveSnapshot(ctx, sampleSCMSnapshot(sampleSCMSubject(rec.ID), time.Now().UTC())); err != nil || !changed {
+		t.Fatalf("save snapshot changed=%v err=%v", changed, err)
+	}
+	rows, err := s.ReadChangeLogAfter(ctx, 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, row := range rows {
+		if row.EventType == "scm_snapshot_created" && row.SessionID == string(rec.ID) {
+			found = true
+			if !stringsContainsAll(row.Payload, `"revision":1`, `"semanticHash"`) {
+				t.Fatalf("snapshot event payload missing fields: %s", row.Payload)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("missing scm_snapshot_created event in %+v", rows)
+	}
+}
+
+func TestPRCommentsPreserveSCMThreadMetadata(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	rec := seedSCMSession(t, s)
+	now := time.Now().UTC().Truncate(time.Second)
+	url := "https://github.com/o/r/pull/1"
+	if err := s.WritePRObservation(ctx,
+		PRRow{URL: url, SessionID: string(rec.ID), Number: 1, State: "open", UpdatedAt: now},
+		nil,
+		[]PRCommentRow{{
+			PRURL: url, CommentID: "c1", Author: "renovate[bot]", File: "go.mod", Line: 7,
+			Body: "pin this", ThreadID: "thread-1", URL: "https://github.com/comment/c1", IsBot: true, CreatedAt: now,
+		}},
+	); err != nil {
+		t.Fatal(err)
+	}
+	comments, err := s.ListPRComments(ctx, url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(comments) != 1 || comments[0].ThreadID != "thread-1" || comments[0].URL == "" || !comments[0].IsBot {
+		t.Fatalf("comment metadata not preserved: %+v", comments)
+	}
+}
+
+func stringsContainsAll(s string, parts ...string) bool {
+	for _, p := range parts {
+		if !strings.Contains(s, p) {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/internal/storage/sqlite/wiring/adapter.go
+++ b/backend/internal/storage/sqlite/wiring/adapter.go
@@ -87,6 +87,7 @@ func (a Adapter) WritePR(ctx context.Context, pr ports.PRRow, checks []ports.PRC
 		commentRows[i] = sqlite.PRCommentRow{
 			PRURL: pr.URL, CommentID: c.ID, Author: c.Author, File: c.File,
 			Line: int64(c.Line), Body: c.Body, Resolved: c.Resolved, CreatedAt: c.CreatedAt,
+			ThreadID: c.ThreadID, URL: c.URL, IsBot: c.IsBot,
 		}
 	}
 	return a.Store.WritePRObservation(ctx, row, checkRows, commentRows)

--- a/backend/main.go
+++ b/backend/main.go
@@ -80,11 +80,24 @@ func run() error {
 		return err
 	}
 
-	// Bring up the Lifecycle Manager (sole store writer) and the reaper (OBSERVE
-	// timer). This makes the write path live end-to-end: LCM write -> store -> DB
-	// trigger -> change_log -> poller -> broadcaster.
+	// Bring up the Lifecycle Manager (sole canonical writer), the runtime reaper,
+	// and the SCM observer. This makes both write paths live end-to-end:
+	//   LCM write -> store -> DB trigger -> change_log -> poller -> broadcaster
+	//   SCM poll -> scm_snapshots -> change_log -> SCM consumer -> LCM
+	// Collaborators that don't yet have production implementations (Notifier,
+	// AgentMessenger, runtime registry) are stubbed in lifecycle_wiring.go with
+	// TODO markers.
 	lcStack, err := startLifecycle(ctx, store, log)
 	if err != nil {
+		return err
+	}
+	scmStack, err := startSCM(ctx, store, lcStack.LCM, cdcPipe, log)
+	if err != nil {
+		stop()
+		lcStack.Stop()
+		if cdcErr := cdcPipe.Stop(); cdcErr != nil {
+			log.Error("cdc pipeline shutdown", "err", cdcErr)
+		}
 		return err
 	}
 
@@ -103,6 +116,7 @@ func run() error {
 		// drained before the deferred store.Close() fires. Defers would hit
 		// the LIFO trap (see comment after srv.Run), hence explicit.
 		stop()
+		scmStack.Stop()
 		lcStack.Stop()
 		if cdcErr := cdcPipe.Stop(); cdcErr != nil {
 			log.Error("cdc pipeline shutdown", "err", cdcErr)
@@ -118,6 +132,7 @@ func run() error {
 	// via defer) avoids the LIFO trap where a Stop() that blocks on ctx-cancel
 	// runs before the cancel — which would hang any non-signal exit path.
 	stop()
+	scmStack.Stop()
 	lcStack.Stop()
 	if err := cdcPipe.Stop(); err != nil {
 		log.Error("cdc pipeline shutdown", "err", err)

--- a/backend/scm_wiring.go
+++ b/backend/scm_wiring.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+
+	ghscm "github.com/aoagents/agent-orchestrator/backend/internal/adapters/scm/github"
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/observe/poller"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/aoagents/agent-orchestrator/backend/internal/scm/command"
+	scmevents "github.com/aoagents/agent-orchestrator/backend/internal/scm/events"
+	"github.com/aoagents/agent-orchestrator/backend/internal/scm/observer"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+)
+
+type scmStack struct {
+	Observer ports.SCMObserver
+	Commands *command.Service
+	registry *poller.Registry
+	unsub    func()
+}
+
+func startSCM(ctx context.Context, store *sqlite.Store, lcm ports.LifecycleManager, cdcPipe *cdcPipeline, logger *slog.Logger) (*scmStack, error) {
+	provider := ghscm.NewProvider(ghscm.ProviderOptions{Logger: logger})
+	obs := observer.New(store, nil, provider)
+	obs.Logger = logger
+
+	consumer := scmevents.NewConsumer(store, lcm, logger)
+	unsub := func() {}
+	if cdcPipe != nil && cdcPipe.Broadcaster != nil {
+		unsub = cdcPipe.Broadcaster.Subscribe(func(e cdc.Event) {
+			if e.Type != cdc.EventSCMSnapshotCreated {
+				return
+			}
+			go func() {
+				if err := consumer.Handle(ctx, e); err != nil && logger != nil {
+					logger.Error("scm event consumer: apply failed", "seq", e.Seq, "session", e.SessionID, "err", err)
+				}
+			}()
+		})
+	}
+
+	sched := &observer.Scheduler{
+		Observer: obs,
+		Store:    store,
+		Projects: scmProjectSource{store: store},
+		Sessions: scmSessionSource{store: store},
+		PRs:      scmPRSource{store: store},
+		Logger:   logger,
+	}
+	reg := poller.NewRegistry(logger)
+	if err := reg.Register(sched); err != nil {
+		unsub()
+		return nil, err
+	}
+	reg.Start(ctx)
+
+	cmds := command.New(store, obs, provider)
+	cmds.Logger = logger
+
+	return &scmStack{Observer: obs, Commands: cmds, registry: reg, unsub: unsub}, nil
+}
+
+func (s *scmStack) Stop() {
+	if s == nil {
+		return
+	}
+	if s.unsub != nil {
+		s.unsub()
+	}
+	if s.registry != nil {
+		s.registry.Stop()
+	}
+}
+
+type scmProjectSource struct{ store *sqlite.Store }
+
+func (s scmProjectSource) ListSCMProjects(ctx context.Context) ([]observer.ProjectConfig, error) {
+	rows, err := s.store.ListProjects(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]observer.ProjectConfig, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, observer.ProjectConfig{
+			ID:            domain.ProjectID(r.ID),
+			Path:          r.Path,
+			RepoOriginURL: r.RepoOriginURL,
+			DefaultBranch: "main",
+		})
+	}
+	return out, nil
+}
+
+type scmSessionSource struct{ store *sqlite.Store }
+
+func (s scmSessionSource) ListSCMSessions(ctx context.Context) ([]domain.SessionRecord, error) {
+	return s.store.ListAllSessions(ctx)
+}
+
+type scmPRSource struct{ store *sqlite.Store }
+
+func (s scmPRSource) LatestPRBinding(ctx context.Context, sessionID domain.SessionID) (observer.PRBinding, bool, error) {
+	rows, err := s.store.ListPRsBySession(ctx, string(sessionID))
+	if err != nil {
+		return observer.PRBinding{}, false, err
+	}
+	if len(rows) == 0 {
+		return observer.PRBinding{}, false, nil
+	}
+	pick := rows[0]
+	for _, r := range rows {
+		if r.State == "draft" || r.State == "open" {
+			pick = r
+			break
+		}
+	}
+	return observer.PRBinding{Number: int(pick.Number), URL: pick.URL}, true, nil
+}


### PR DESCRIPTION
## Summary
- add SCM domain/contracts, durable JSON store, observer projection, and session read-model enrichment
- implement GitHub auth/client/provider with REST ETags, GraphQL PR batching, branch discovery, CI/review/mergeability normalization, and commands
- wire SCM reaction detail fingerprints for deduping/re-arming CI/review/merge blockers

## Tests
- npm run typecheck
- cd backend && go test ./...

Closes #27