### PR TITLE
feat(notifier): macOS desktop notifier adapter + test CLI

### DIFF
--- a/backend/cmd/notifier-test/main.go
+++ b/backend/cmd/notifier-test/main.go
@@ -1,0 +1,37 @@
+// notifier-test fires one macOS desktop notification via the desktop
+// Notifier adapter. Intended for local smoke-testing only.
+//
+// Usage: notifier-test "title" "body"
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/notifier/desktop"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintf(os.Stderr, "usage: %s <title> <body>\n", os.Args[0])
+		os.Exit(1)
+	}
+	n, err := desktop.New()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "init: %v\n", err)
+		os.Exit(1)
+	}
+	if err := n.Notify(context.Background(), ports.OrchestratorEvent{
+		// The desktop adapter maps Type→title, Message→body. We reuse those
+		// fields here purely as a smoke-test plumbing convenience; real callers
+		// (LCM reactions) populate Type with the canonical event kind.
+		Type:    os.Args[1],
+		Message: os.Args[2],
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "notify: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("OK")
+}

--- a/backend/internal/adapters/notifier/desktop/desktop.go
+++ b/backend/internal/adapters/notifier/desktop/desktop.go
@@ -1,0 +1,72 @@
+// Package desktop is a macOS-only Notifier port adapter that fires native
+// notification-center notifications via osascript. Intended for local-dev /
+// testing workflows; Slack/webhook adapters live in sibling packages.
+//
+// Safety: the AppleScript program defines an `on run argv` handler and reads
+// the title and body from argv (passed after `--`). The user payload is never
+// composed into the AppleScript source, so AppleScript string-literal
+// escaping (\, ", newline) is unnecessary by construction. Go's exec.Command
+// does not invoke a shell, so backticks and $() in argv are also inert.
+package desktop
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// execer is the seam the adapter uses to invoke osascript. Tests inject a
+// programmable fake; production uses realExecer.
+type execer interface {
+	LookPath(name string) (string, error)
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+type realExecer struct{}
+
+func (realExecer) LookPath(name string) (string, error) { return exec.LookPath(name) }
+
+func (realExecer) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+// Notifier implements ports.Notifier by shelling out to /usr/bin/osascript.
+type Notifier struct {
+	exec execer
+}
+
+// New returns a Notifier and verifies that osascript is on PATH.
+func New() (*Notifier, error) {
+	return newWithExecer(realExecer{})
+}
+
+func newWithExecer(e execer) (*Notifier, error) {
+	if _, err := e.LookPath("osascript"); err != nil {
+		return nil, fmt.Errorf("desktop notifier: osascript not on PATH: %w", err)
+	}
+	return &Notifier{exec: e}, nil
+}
+
+// Notify fires a macOS notification using event.Type as the title and
+// event.Message as the body.
+func (n *Notifier) Notify(ctx context.Context, event ports.OrchestratorEvent) error {
+	out, err := n.exec.Run(ctx, "osascript",
+		"-e", "on run argv",
+		"-e", "display notification (item 2 of argv) with title (item 1 of argv)",
+		"-e", "end run",
+		"--", event.Type, event.Message,
+	)
+	if err != nil {
+		trimmed := strings.TrimSpace(string(out))
+		if trimmed != "" {
+			return fmt.Errorf("desktop notifier: osascript: %w (output: %s)", err, trimmed)
+		}
+		return fmt.Errorf("desktop notifier: osascript: %w", err)
+	}
+	return nil
+}
+
+var _ ports.Notifier = (*Notifier)(nil)

--- a/backend/internal/adapters/notifier/desktop/desktop_test.go
+++ b/backend/internal/adapters/notifier/desktop/desktop_test.go
@@ -1,0 +1,169 @@
+package desktop
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+type runCall struct {
+	name string
+	args []string
+}
+
+type fakeExecer struct {
+	lookPathArg string
+	lookPathErr error
+	runOutput   []byte
+	runErr      error
+	runCalls    []runCall
+}
+
+func (f *fakeExecer) LookPath(name string) (string, error) {
+	f.lookPathArg = name
+	if f.lookPathErr != nil {
+		return "", f.lookPathErr
+	}
+	return "/usr/bin/" + name, nil
+}
+
+func (f *fakeExecer) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	f.runCalls = append(f.runCalls, runCall{name: name, args: append([]string(nil), args...)})
+	return f.runOutput, f.runErr
+}
+
+func TestNew_RequiresOsascriptOnPath(t *testing.T) {
+	f := &fakeExecer{lookPathErr: errors.New("not found")}
+	if _, err := newWithExecer(f); err == nil {
+		t.Fatal("expected error when osascript missing, got nil")
+	}
+	if f.lookPathArg != "osascript" {
+		t.Errorf("LookPath called with %q, want %q", f.lookPathArg, "osascript")
+	}
+}
+
+func TestNew_OK(t *testing.T) {
+	f := &fakeExecer{}
+	n, err := newWithExecer(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n == nil {
+		t.Fatal("nil notifier")
+	}
+}
+
+func TestNotify_InvokesOsascriptWithPayloadAfterSeparator(t *testing.T) {
+	f := &fakeExecer{}
+	n, _ := newWithExecer(f)
+	err := n.Notify(context.Background(), ports.OrchestratorEvent{
+		Type:    "AO",
+		Message: "hello",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(f.runCalls) != 1 {
+		t.Fatalf("expected 1 run call, got %d", len(f.runCalls))
+	}
+	rc := f.runCalls[0]
+	if rc.name != "osascript" {
+		t.Errorf("ran %q, want osascript", rc.name)
+	}
+	sepIdx := indexOf(rc.args, "--")
+	if sepIdx < 0 {
+		t.Fatalf("no -- separator in args: %v", rc.args)
+	}
+	if len(rc.args)-sepIdx-1 != 2 {
+		t.Fatalf("expected exactly 2 args after --, got %d (args=%v)", len(rc.args)-sepIdx-1, rc.args)
+	}
+	if rc.args[sepIdx+1] != "AO" || rc.args[sepIdx+2] != "hello" {
+		t.Errorf("payload after --: got %q %q, want AO hello", rc.args[sepIdx+1], rc.args[sepIdx+2])
+	}
+}
+
+func TestNotify_PayloadPassesVerbatim_NoEscapingNeeded(t *testing.T) {
+	cases := []struct {
+		name  string
+		title string
+		body  string
+	}{
+		{"quotes", `He said "hi"`, `back"to"you`},
+		{"backslashes", `path\to\file`, `C:\Windows\System32`},
+		{"newlines", "line1\nline2", "alpha\nbeta\ngamma"},
+		{"backticks_and_dollar", "back`tick`", "$(rm -rf /)"},
+		{"mixed_nasties", "\"\\$(`x`)\n", "foo\n\\\"bar"},
+		{"empty", "", ""},
+		{"double_dash", "--", "--"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeExecer{}
+			n, _ := newWithExecer(f)
+			if err := n.Notify(context.Background(), ports.OrchestratorEvent{Type: tc.title, Message: tc.body}); err != nil {
+				t.Fatalf("notify: %v", err)
+			}
+			if len(f.runCalls) != 1 {
+				t.Fatalf("expected 1 call, got %d", len(f.runCalls))
+			}
+			args := f.runCalls[0].args
+			sepIdx := indexOf(args, "--")
+			if sepIdx < 0 {
+				t.Fatalf("no -- separator in args: %v", args)
+			}
+
+			if args[sepIdx+1] != tc.title {
+				t.Errorf("title not verbatim: got %q want %q", args[sepIdx+1], tc.title)
+			}
+			if args[sepIdx+2] != tc.body {
+				t.Errorf("body not verbatim: got %q want %q", args[sepIdx+2], tc.body)
+			}
+
+			for i := 0; i < sepIdx; i++ {
+				if tc.title != "" && strings.Contains(args[i], tc.title) {
+					t.Errorf("title leaked into script line [%d]: %q", i, args[i])
+				}
+				if tc.body != "" && strings.Contains(args[i], tc.body) {
+					t.Errorf("body leaked into script line [%d]: %q", i, args[i])
+				}
+			}
+		})
+	}
+}
+
+func TestNotify_SurfacesOsascriptError(t *testing.T) {
+	cases := []struct {
+		name   string
+		output []byte
+	}{
+		{"with_output", []byte("syntax error: bad thing")},
+		{"no_output", nil},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeExecer{runErr: errors.New("exit status 1"), runOutput: tc.output}
+			n, _ := newWithExecer(f)
+			err := n.Notify(context.Background(), ports.OrchestratorEvent{Type: "T", Message: "M"})
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "exit status 1") {
+				t.Errorf("error %q does not contain underlying cause", err.Error())
+			}
+		})
+	}
+}
+
+func indexOf(s []string, v string) int {
+	for i, x := range s {
+		if x == v {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## Summary
- New `backend/internal/adapters/notifier/desktop/` package — implements `ports.Notifier` for macOS via `osascript`. `New()` verifies osascript is on PATH; an injected `execer` interface keeps it testable.
- New `backend/cmd/notifier-test/` smoke-test CLI — `notifier-test "<title>" "<body>"`, prints `OK` or error, exits 0/1.

## Design note — payload safety
The AppleScript runs `on run argv` and reads title + body from `argv` (after `--`). The user payload never appears in the script source, so AppleScript string-literal escaping (`\`, `"`, newline) is unnecessary by construction. `exec.Command` does not invoke a shell, so backticks and `$()` in argv are also inert. This is option (a)'s spirit (payload not in script source) without the stdin pipe — equally safe, simpler.

Verified end-to-end on this Mac with `notifier-test 'quote"and\back' '$(echo pwn)\`also\` end'` — exit 0, notification fires, no shell interpretation.

## Tests (14 passing, none fire osascript)
- `TestNew_RequiresOsascriptOnPath`
- `TestNew_OK`
- `TestNotify_InvokesOsascriptWithPayloadAfterSeparator`
- `TestNotify_PayloadPassesVerbatim_NoEscapingNeeded` — quotes / backslashes / newlines / backticks+`$()` / mixed / empty / `--`
- `TestNotify_SurfacesOsascriptError` — with-output and no-output branches

## Out of scope (per task)
Slack/webhook adapters, rate limiting, dedup, batching, daemon wiring (aditi's #10), routing logic, Linux/Windows.

## Test plan
- [x] \`go test ./...\` from \`backend/\` — 261+ passing
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] Real-Mac smoke test: \`go run ./cmd/notifier-test "AO" "session aa-22 idle 10m"\` fires a notification and prints OK

Refs aa-23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)