### PR TITLE
feat(frontend): typed API client generated from the OpenAPI spec + gen-verify CI

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "agent-orchestrator-frontend",
       "version": "0.0.0",
+      "dependencies": {
+        "openapi-fetch": "^0.17.0"
+      },
       "devDependencies": {
         "electron": "^33.0.0",
         "typescript": "^5.6.0"
@@ -672,6 +675,21 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/openapi-fetch": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.17.0.tgz",
+      "integrity": "sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.1.0"
+      }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.1.0.tgz",
+      "integrity": "sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==",
+      "license": "MIT"
     },
     "node_modules/p-cancelable": {
       "version": "2.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,9 @@
     "typecheck": "tsc --noEmit",
     "start": "npm run build && electron ."
   },
+  "dependencies": {
+    "openapi-fetch": "^0.17.0"
+  },
   "devDependencies": {
     "electron": "^33.0.0",
     "typescript": "^5.6.0"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,11 @@
+import createClient from "openapi-fetch";
+import type { paths } from "./schema";
+
+// Typed client for the daemon's loopback /api/v1 surface. Request and response
+// types come from ./schema.ts, which is generated from the backend OpenAPI
+// document (`npm run api` at the repo root) — never hand-maintained.
+export const api = createClient<paths>({ baseUrl: "http://127.0.0.1:3001" });
+
+// Re-export the generated component schemas for convenient use in the renderer,
+// e.g. components["schemas"]["Project"], "Session", "APIError".
+export type { components, paths } from "./schema";

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,10 +1,25 @@
 import createClient from "openapi-fetch";
 import type { paths } from "./schema";
 
-// Typed client for the daemon's loopback /api/v1 surface. Request and response
-// types come from ./schema.ts, which is generated from the backend OpenAPI
-// document (`npm run api` at the repo root) — never hand-maintained.
-export const api = createClient<paths>({ baseUrl: "http://127.0.0.1:3001" });
+// The daemon binds DEFAULT_PORT unless AO_PORT overrides it (see config.go),
+// and writes the port it actually bound to running.json (runfile.File.Port).
+// DEFAULT_PORT only mirrors config.DefaultPort as a last-resort fallback for
+// when the runfile hasn't been read yet — clients must NOT assume it.
+export const DEFAULT_PORT = 3001;
+
+// baseURLForPort builds the loopback base URL for a known daemon port. Pass the
+// port read from running.json; default only as a fallback.
+export const baseURLForPort = (port: number = DEFAULT_PORT): string =>
+  `http://127.0.0.1:${port}`;
+
+// createApiClient builds a typed openapi-fetch client for the daemon's
+// /api/v1 surface. The renderer cannot read running.json directly, so the
+// wiring layer must read it (via IPC to the main process) and pass the resolved
+// base URL here — hardcoding DEFAULT_PORT would silently break any user who
+// overrides AO_PORT. Request/response types come from ./schema.ts, generated
+// from the backend OpenAPI document (`npm run api` at the repo root).
+export const createApiClient = (baseUrl: string) =>
+  createClient<paths>({ baseUrl });
 
 // Re-export the generated component schemas for convenient use in the renderer,
 // e.g. components["schemas"]["Project"], "Session", "APIError".


### PR DESCRIPTION
## Why (scope change)

This PR originally added the code-first OpenAPI generator + a frontend client. The **backend generator has since landed on `main`** (via #68/#65) and now covers projects **and** sessions — superseding this branch's backend work. Rather than duplicate it, this PR is repurposed to the parts `main` still lacks.

## What's here

- **`frontend/src/api/schema.d.ts`** — generated from `backend/internal/httpd/apispec/openapi.yaml` via `openapi-typescript` (`npm run gen:api`). Covers projects, sessions, and orchestrators.
- **`frontend/src/api/client.ts`** — a small `openapi-fetch` client typed by that schema, so the renderer's request/response types come from the daemon contract instead of being hand-maintained.
- **`gen-verify` CI job** — regenerates the spec from Go *and* the TS client from the spec, failing if either committed artifact is stale. Backend drift is already covered by the `apispec` tests; this additionally guards the **frontend** artifact, which nothing else checks.

## Verification

```
frontend: npm run gen:api ✓   npm run typecheck ✓
pipeline: go generate ./... + npm run gen:api reproduce the committed files with no drift
```

Rebased on current `main`; no overlap with the backend codegen or the recent CLI PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)