### PR TITLE
feat: add notification APIs and SSE clients

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -5,6 +5,8 @@ package daemon
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"log/slog"
 	"os"
@@ -71,7 +73,21 @@ func Run() error {
 	termMgr := terminal.NewManager(runtimeAdapter, cdcPipe.Broadcaster, log)
 	defer termMgr.Close()
 
-	srv, err := httpd.New(cfg, log, termMgr)
+	actionToken, err := newActionToken()
+	if err != nil {
+		stop()
+		notifier.Stop()
+		if cdcErr := cdcPipe.Stop(); cdcErr != nil {
+			log.Error("cdc pipeline shutdown", "err", cdcErr)
+		}
+		return fmt.Errorf("generate action token: %w", err)
+	}
+	srv, err := httpd.NewWithAPI(cfg, log, termMgr, httpd.APIDeps{
+		Notifications: store,
+		ActionToken:   actionToken,
+		EventSource:   cdcSource{store},
+		Broadcaster:   cdcPipe.Broadcaster,
+	})
 	if err != nil {
 		stop()
 		notifier.Stop()
@@ -137,4 +153,15 @@ func Run() error {
 // can capture it separately from any structured stdout protocol added later.
 func newLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func newActionToken() (string, error) {
+	if token := os.Getenv("AO_ACTION_TOKEN"); token != "" {
+		return token, nil
+	}
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b[:]), nil
 }

--- a/backend/internal/domain/notification.go
+++ b/backend/internal/domain/notification.go
@@ -32,9 +32,11 @@ type Notification struct {
 	UpdatedAt    time.Time
 }
 
-// NotificationAction is a provider-neutral action descriptor. Renderers may use
-// Route for app-local navigation, URL for external navigation, or Method for a
-// future command/action endpoint.
+// NotificationAction is a provider-neutral, allowlisted action descriptor.
+// Kind is the public action kind (open-session, open-pr, mark-read, ...).
+// Renderers may use Route for app-local navigation or URL for trusted external
+// navigation. Method is kept for backward-compatible decoding but action
+// execution rejects arbitrary callback/method payloads.
 type NotificationAction struct {
 	ID     string `json:"id"`
 	Kind   string `json:"kind"`

--- a/backend/internal/httpd/api.go
+++ b/backend/internal/httpd/api.go
@@ -6,9 +6,11 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/apispec"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/controllers"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/sse"
 	"github.com/aoagents/agent-orchestrator/backend/internal/project"
 )
 
@@ -23,7 +25,11 @@ import (
 // apispec.NotImplemented and don't dereference them yet. The handler-impl PR
 // wires real Managers and flips stubs to real logic one route at a time.
 type APIDeps struct {
-	Projects project.Manager
+	Projects      project.Manager
+	Notifications controllers.NotificationStore
+	ActionToken   string
+	EventSource   cdc.Source
+	Broadcaster   *cdc.Broadcaster
 }
 
 // API owns one controller per resource and is the single Register call the
@@ -31,8 +37,11 @@ type APIDeps struct {
 // later PRs can land a controller's real handlers without touching the
 // surrounding wiring.
 type API struct {
-	cfg      config.Config
-	projects *controllers.ProjectsController
+	cfg           config.Config
+	projects      *controllers.ProjectsController
+	notifications *controllers.NotificationsController
+	eventSource   cdc.Source
+	broadcaster   *cdc.Broadcaster
 }
 
 // NewAPI constructs the API surface from its dependencies. cfg carries the
@@ -44,6 +53,12 @@ func NewAPI(cfg config.Config, deps APIDeps) *API {
 		projects: &controllers.ProjectsController{
 			Mgr: deps.Projects,
 		},
+		notifications: &controllers.NotificationsController{
+			Store:       deps.Notifications,
+			ActionToken: deps.ActionToken,
+		},
+		eventSource: deps.EventSource,
+		broadcaster: deps.Broadcaster,
 	}
 }
 
@@ -70,12 +85,13 @@ func (a *API) Register(root chi.Router) {
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.Timeout(timeout))
 			a.projects.Register(r)
+			a.notifications.Register(r)
 			// Sibling controllers (sessions, issues, prs, ...) plug in here in
 			// follow-up PRs #21 / #22 without touching the timeout group.
 		})
 		// Surfaces that intentionally bypass the REST timeout (SSE, future WS)
-		// register at this level — none exist in the route-shell PR.
 	})
+	root.Get("/events", sse.Handler{Source: a.eventSource, Broadcaster: a.broadcaster}.ServeHTTP)
 }
 
 // notFoundJSON returns the locked envelope for unmatched routes. Chi's default

--- a/backend/internal/httpd/apispec/apispec_test.go
+++ b/backend/internal/httpd/apispec/apispec_test.go
@@ -21,6 +21,30 @@ func TestDefaultLoadsEmbeddedSpec(t *testing.T) {
 	}
 }
 
+func TestDefaultIncludesNotificationsAndEvents(t *testing.T) {
+	cases := []struct {
+		method string
+		path   string
+		opID   string
+	}{
+		{"GET", "/api/v1/notifications", "listNotifications"},
+		{"GET", "/api/v1/notifications/{id}", "getNotification"},
+		{"PATCH", "/api/v1/notifications/{id}", "updateNotification"},
+		{"POST", "/api/v1/notifications/read-all", "markAllNotificationsRead"},
+		{"POST", "/api/v1/notifications/{id}/actions/{actionId}", "invokeNotificationAction"},
+		{"GET", "/events", "streamEvents"},
+	}
+	for _, tc := range cases {
+		op := apispec.Default().Operation(tc.method, tc.path)
+		if op == nil {
+			t.Fatalf("missing %s %s", tc.method, tc.path)
+		}
+		if got, _ := op["operationId"].(string); got != tc.opID {
+			t.Fatalf("%s %s operationId=%q want %q", tc.method, tc.path, got, tc.opID)
+		}
+	}
+}
+
 // TestOperation_MissingPath returns nil for unknown paths — that's how the
 // controller-side test catches "route registered without spec coverage".
 func TestOperation_MissingPath(t *testing.T) {

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -16,6 +16,10 @@ servers:
 tags:
   - name: projects
     description: Project registry, configuration, and lifecycle administration
+  - name: notifications
+    description: Durable notification snapshot, state, and safe actions
+  - name: events
+    description: Durable CDC replay and live Server-Sent Events
 
 paths:
   /api/v1/projects:
@@ -246,6 +250,160 @@ paths:
         "404": { $ref: "#/components/responses/ProjectNotFound" }
         "501": { $ref: "#/components/responses/NotImplemented" }
 
+  /api/v1/notifications:
+    get:
+      operationId: listNotifications
+      tags: [notifications]
+      summary: List durable notifications with unread badge count
+      parameters:
+        - { name: projectId, in: query, schema: { type: string } }
+        - { name: sessionId, in: query, schema: { type: string } }
+        - { name: unreadOnly, in: query, schema: { type: boolean, default: false } }
+        - { name: includeArchived, in: query, schema: { type: boolean, default: false } }
+        - { name: limit, in: query, schema: { type: integer, minimum: 1, maximum: 500, default: 50 } }
+        - { name: beforeSeq, in: query, schema: { type: integer, format: int64, minimum: 0 } }
+      responses:
+        "200":
+          description: Notifications listed
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [notifications, unreadCount, limit, nextBeforeSeq]
+                properties:
+                  notifications:
+                    type: array
+                    items: { $ref: "#/components/schemas/NotificationRecord" }
+                  unreadCount: { type: integer }
+                  limit: { type: integer }
+                  nextBeforeSeq:
+                    oneOf:
+                      - { type: integer, format: int64 }
+                      - { type: "null" }
+        "400": { $ref: "#/components/responses/APIErrorResponse" }
+        "500": { $ref: "#/components/responses/APIErrorResponse" }
+
+  /api/v1/notifications/read-all:
+    post:
+      operationId: markAllNotificationsRead
+      tags: [notifications]
+      summary: Mark visible notifications read, optionally scoped
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/NotificationsReadAllRequest" }
+      responses:
+        "200":
+          description: Notifications updated
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [updated]
+                properties:
+                  updated: { type: integer }
+        "400": { $ref: "#/components/responses/APIErrorResponse" }
+        "500": { $ref: "#/components/responses/APIErrorResponse" }
+
+  /api/v1/notifications/{id}:
+    parameters:
+      - $ref: "#/components/parameters/NotificationIDPath"
+    get:
+      operationId: getNotification
+      tags: [notifications]
+      summary: Fetch one notification
+      responses:
+        "200":
+          description: Notification found
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [notification]
+                properties:
+                  notification: { $ref: "#/components/schemas/NotificationRecord" }
+        "404": { $ref: "#/components/responses/NotificationNotFound" }
+        "500": { $ref: "#/components/responses/APIErrorResponse" }
+    patch:
+      operationId: updateNotification
+      tags: [notifications]
+      summary: Update server-side read/archive state
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/NotificationPatchRequest" }
+      responses:
+        "200":
+          description: Notification updated
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [notification]
+                properties:
+                  notification: { $ref: "#/components/schemas/NotificationRecord" }
+        "400": { $ref: "#/components/responses/APIErrorResponse" }
+        "404": { $ref: "#/components/responses/NotificationNotFound" }
+        "500": { $ref: "#/components/responses/APIErrorResponse" }
+
+  /api/v1/notifications/{id}/actions/{actionId}:
+    parameters:
+      - $ref: "#/components/parameters/NotificationIDPath"
+      - $ref: "#/components/parameters/NotificationActionIDPath"
+    post:
+      operationId: invokeNotificationAction
+      tags: [notifications]
+      summary: Invoke an allowlisted notification action
+      parameters:
+        - name: X-AO-Action-Token
+          in: header
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+      responses:
+        "200":
+          description: Action accepted
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/NotificationActionResult" }
+        "403": { $ref: "#/components/responses/APIErrorResponse" }
+        "404": { $ref: "#/components/responses/APIErrorResponse" }
+        "409": { $ref: "#/components/responses/APIErrorResponse" }
+        "422": { $ref: "#/components/responses/APIErrorResponse" }
+
+  /events:
+    get:
+      operationId: streamEvents
+      tags: [events]
+      summary: Replay durable CDC events and continue with live Server-Sent Events
+      parameters:
+        - { name: after, in: query, schema: { type: integer, format: int64, minimum: 0 } }
+        - { name: Last-Event-ID, in: header, schema: { type: integer, format: int64, minimum: 0 } }
+        - { name: projectId, in: query, schema: { type: string } }
+        - name: topics
+          in: query
+          schema:
+            type: string
+            enum: [sessions, prs, notifications]
+          description: Comma-separated list of topics.
+      responses:
+        "200":
+          description: Event stream
+          content:
+            text/event-stream:
+              schema:
+                type: string
+        "400": { $ref: "#/components/responses/APIErrorResponse" }
+        "503": { $ref: "#/components/responses/APIErrorResponse" }
+
 components:
   parameters:
     ProjectIDPath:
@@ -254,6 +412,16 @@ components:
       required: true
       schema: { type: string, minLength: 1 }
       description: Project identifier (registry key).
+    NotificationIDPath:
+      name: id
+      in: path
+      required: true
+      schema: { type: string, minLength: 1 }
+    NotificationActionIDPath:
+      name: actionId
+      in: path
+      required: true
+      schema: { type: string, minLength: 1 }
 
   responses:
     NotImplemented:
@@ -272,6 +440,17 @@ components:
         application/json:
           schema: { $ref: "#/components/schemas/APIError" }
           example: { error: not_found, code: PROJECT_NOT_FOUND, message: "Unknown project" }
+    NotificationNotFound:
+      description: Notification not found
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/APIError" }
+          example: { error: not_found, code: NOTIFICATION_NOT_FOUND, message: "Notification not found" }
+    APIErrorResponse:
+      description: API error
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/APIError" }
 
   schemas:
     APIError:
@@ -394,6 +573,79 @@ components:
         reloaded: { type: boolean }
         projectCount: { type: integer }
         degradedCount: { type: integer }
+
+    NotificationRecord:
+      type: object
+      required: [seq, id, receivedAt, readAt, archivedAt, event, actions]
+      properties:
+        seq: { type: integer, format: int64 }
+        id: { type: string }
+        receivedAt: { type: string, format: date-time }
+        readAt:
+          oneOf:
+            - { type: string, format: date-time }
+            - { type: "null" }
+        archivedAt:
+          oneOf:
+            - { type: string, format: date-time }
+            - { type: "null" }
+        event: { $ref: "#/components/schemas/NotificationEvent" }
+        actions:
+          type: array
+          items: { $ref: "#/components/schemas/NotificationAction" }
+
+    NotificationEvent:
+      type: object
+      required: [id, type, priority, sessionId, projectId, timestamp, message, data]
+      properties:
+        id: { type: string }
+        type: { type: string }
+        priority:
+          type: string
+          enum: [urgent, action, warning, info]
+        sessionId: { type: string }
+        projectId: { type: string }
+        timestamp: { type: string, format: date-time }
+        message: { type: string }
+        data:
+          type: object
+          additionalProperties: true
+
+    NotificationAction:
+      type: object
+      required: [id, kind, label]
+      properties:
+        id: { type: string }
+        kind:
+          type: string
+          enum: [open-session, open-pr, open-review, open-ci, restore-session, send-message, merge-pr, mark-read, dismiss]
+        label: { type: string }
+        route: { type: string }
+        url: { type: string, format: uri }
+
+    NotificationPatchRequest:
+      type: object
+      properties:
+        read: { type: boolean }
+        archived: { type: boolean }
+      minProperties: 1
+
+    NotificationsReadAllRequest:
+      type: object
+      properties:
+        projectId: { type: string }
+        sessionId: { type: string }
+
+    NotificationActionResult:
+      type: object
+      required: [ok, actionId, kind]
+      properties:
+        ok: { type: boolean }
+        actionId: { type: string }
+        kind: { type: string }
+        result:
+          type: object
+          additionalProperties: true
 
     # ---- Behaviour config blobs (ported from the TS Zod schemas) ----
     # These are the known config shapes only. The current Go handler does not

--- a/backend/internal/httpd/controllers/notifications.go
+++ b/backend/internal/httpd/controllers/notifications.go
@@ -1,0 +1,349 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
+	"github.com/aoagents/agent-orchestrator/backend/internal/notification"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+)
+
+const (
+	defaultNotificationAPILimit = 50
+	maxNotificationAPILimit     = 500
+)
+
+// NotificationStore is the HTTP API's durable notification dependency.
+// *sqlite.Store satisfies it.
+type NotificationStore interface {
+	ListNotifications(ctx context.Context, filter sqlite.NotificationFilter) ([]domain.Notification, error)
+	CountUnreadNotifications(ctx context.Context, filter sqlite.NotificationFilter) (int, error)
+	GetNotification(ctx context.Context, id string) (domain.Notification, bool, error)
+	MarkNotificationRead(ctx context.Context, id string, at time.Time) (domain.Notification, bool, error)
+	MarkNotificationUnread(ctx context.Context, id string) (domain.Notification, bool, error)
+	ArchiveNotification(ctx context.Context, id string, at time.Time) (domain.Notification, bool, error)
+	MarkAllNotificationsRead(ctx context.Context, filter sqlite.NotificationFilter, at time.Time) (int, error)
+}
+
+type NotificationsController struct {
+	Store       NotificationStore
+	ActionToken string
+	Clock       func() time.Time
+}
+
+func (c *NotificationsController) Register(r chi.Router) {
+	r.Get("/notifications", c.list)
+	r.Post("/notifications/read-all", c.readAll)
+	r.Get("/notifications/{id}", c.get)
+	r.Patch("/notifications/{id}", c.patch)
+	r.Post("/notifications/{id}/actions/{actionId}", c.action)
+}
+
+func (c *NotificationsController) now() time.Time {
+	if c.Clock != nil {
+		return c.Clock().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (c *NotificationsController) list(w http.ResponseWriter, r *http.Request) {
+	if c.Store == nil {
+		unavailable(w, r)
+		return
+	}
+	filter, ok := notificationFilterFromQuery(w, r)
+	if !ok {
+		return
+	}
+	rows, err := c.Store.ListNotifications(r.Context(), filter)
+	if err != nil {
+		envelope.WriteAPIError(w, r, http.StatusInternalServerError, "internal", "NOTIFICATIONS_LIST_FAILED", "Failed to list notifications", nil)
+		return
+	}
+	unread, err := c.Store.CountUnreadNotifications(r.Context(), filter)
+	if err != nil {
+		envelope.WriteAPIError(w, r, http.StatusInternalServerError, "internal", "NOTIFICATIONS_COUNT_FAILED", "Failed to count unread notifications", nil)
+		return
+	}
+	records := make([]notificationRecord, 0, len(rows))
+	for _, row := range rows {
+		records = append(records, notificationRecordFromDomain(row))
+	}
+	var nextBeforeSeq any
+	if len(records) == filter.Limit {
+		nextBeforeSeq = records[len(records)-1].Seq
+	}
+	envelope.WriteJSON(w, http.StatusOK, map[string]any{
+		"notifications": records,
+		"unreadCount":   unread,
+		"limit":         filter.Limit,
+		"nextBeforeSeq": nextBeforeSeq,
+	})
+}
+
+func (c *NotificationsController) get(w http.ResponseWriter, r *http.Request) {
+	if c.Store == nil {
+		unavailable(w, r)
+		return
+	}
+	row, ok, err := c.Store.GetNotification(r.Context(), chi.URLParam(r, "id"))
+	if err != nil {
+		envelope.WriteAPIError(w, r, http.StatusInternalServerError, "internal", "NOTIFICATION_GET_FAILED", "Failed to get notification", nil)
+		return
+	}
+	if !ok {
+		notificationNotFound(w, r)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusOK, map[string]any{"notification": notificationRecordFromDomain(row)})
+}
+
+func (c *NotificationsController) patch(w http.ResponseWriter, r *http.Request) {
+	if c.Store == nil {
+		unavailable(w, r)
+		return
+	}
+	id := chi.URLParam(r, "id")
+	var body struct {
+		Read     *bool `json:"read"`
+		Archived *bool `json:"archived"`
+	}
+	if err := decodeJSON(r, &body); err != nil {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_JSON", "Invalid JSON body", nil)
+		return
+	}
+	if body.Read == nil && body.Archived == nil {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_NOTIFICATION_UPDATE", "Patch must include read or archived", nil)
+		return
+	}
+
+	row, ok, err := c.Store.GetNotification(r.Context(), id)
+	if err != nil {
+		envelope.WriteAPIError(w, r, http.StatusInternalServerError, "internal", "NOTIFICATION_GET_FAILED", "Failed to get notification", nil)
+		return
+	}
+	if !ok {
+		notificationNotFound(w, r)
+		return
+	}
+	if body.Archived != nil && !*body.Archived && !row.ArchivedAt.IsZero() {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_NOTIFICATION_UPDATE", "Unarchive is not supported by this API", nil)
+		return
+	}
+	now := c.now()
+	if body.Read != nil {
+		if *body.Read {
+			row, _, err = c.Store.MarkNotificationRead(r.Context(), id, now)
+		} else {
+			row, _, err = c.Store.MarkNotificationUnread(r.Context(), id)
+		}
+		if err != nil {
+			envelope.WriteAPIError(w, r, http.StatusInternalServerError, "internal", "NOTIFICATION_UPDATE_FAILED", "Failed to update notification", nil)
+			return
+		}
+	}
+	if body.Archived != nil {
+		if *body.Archived {
+			row, _, err = c.Store.ArchiveNotification(r.Context(), id, now)
+		}
+		if err != nil {
+			envelope.WriteAPIError(w, r, http.StatusInternalServerError, "internal", "NOTIFICATION_UPDATE_FAILED", "Failed to update notification", nil)
+			return
+		}
+	}
+	envelope.WriteJSON(w, http.StatusOK, map[string]any{"notification": notificationRecordFromDomain(row)})
+}
+
+func (c *NotificationsController) readAll(w http.ResponseWriter, r *http.Request) {
+	if c.Store == nil {
+		unavailable(w, r)
+		return
+	}
+	var body struct {
+		ProjectID string `json:"projectId"`
+		SessionID string `json:"sessionId"`
+	}
+	if r.Body != nil {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+			envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_JSON", "Invalid JSON body", nil)
+			return
+		}
+	}
+	updated, err := c.Store.MarkAllNotificationsRead(r.Context(), sqlite.NotificationFilter{ProjectID: body.ProjectID, SessionID: body.SessionID}, c.now())
+	if err != nil {
+		envelope.WriteAPIError(w, r, http.StatusInternalServerError, "internal", "NOTIFICATIONS_READ_ALL_FAILED", "Failed to mark notifications read", nil)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusOK, map[string]any{"updated": updated})
+}
+
+func (c *NotificationsController) action(w http.ResponseWriter, r *http.Request) {
+	if c.Store == nil {
+		unavailable(w, r)
+		return
+	}
+	if c.ActionToken == "" || r.Header.Get("X-AO-Action-Token") != c.ActionToken {
+		envelope.WriteAPIError(w, r, http.StatusForbidden, "forbidden", "ACTION_NOT_ALLOWED", "Notification action token is invalid", nil)
+		return
+	}
+	if r.Body != nil {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+			envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_JSON", "Invalid JSON body", nil)
+			return
+		}
+	}
+	result, err := notification.ExecuteAction(r.Context(), c.Store, chi.URLParam(r, "id"), chi.URLParam(r, "actionId"), c.now())
+	if err != nil {
+		if ae, ok := notification.IsActionError(err); ok {
+			kind := "bad_request"
+			switch ae.StatusCode {
+			case http.StatusForbidden:
+				kind = "forbidden"
+			case http.StatusNotFound:
+				kind = "not_found"
+			case http.StatusConflict:
+				kind = "conflict"
+			case http.StatusUnprocessableEntity:
+				kind = "unprocessable_entity"
+			case http.StatusInternalServerError:
+				kind = "internal"
+			}
+			envelope.WriteAPIError(w, r, ae.StatusCode, kind, ae.Code, ae.Message, nil)
+			return
+		}
+		envelope.WriteAPIError(w, r, http.StatusInternalServerError, "internal", "ACTION_FAILED", "Notification action failed", nil)
+		return
+	}
+	envelope.WriteJSON(w, http.StatusOK, result)
+}
+
+func notificationFilterFromQuery(w http.ResponseWriter, r *http.Request) (sqlite.NotificationFilter, bool) {
+	q := r.URL.Query()
+	limit := defaultNotificationAPILimit
+	if raw := q.Get("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_NOTIFICATION_QUERY", "limit must be a number", nil)
+			return sqlite.NotificationFilter{}, false
+		}
+		limit = n
+	}
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > maxNotificationAPILimit {
+		limit = maxNotificationAPILimit
+	}
+	beforeSeq := int64(0)
+	if raw := q.Get("beforeSeq"); raw != "" {
+		n, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil || n < 0 {
+			envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_NOTIFICATION_QUERY", "beforeSeq must be a non-negative integer", nil)
+			return sqlite.NotificationFilter{}, false
+		}
+		beforeSeq = n
+	}
+	unreadOnly, ok := parseBoolQuery(w, r, "unreadOnly")
+	if !ok {
+		return sqlite.NotificationFilter{}, false
+	}
+	includeArchived, ok := parseBoolQuery(w, r, "includeArchived")
+	if !ok {
+		return sqlite.NotificationFilter{}, false
+	}
+	return sqlite.NotificationFilter{
+		ProjectID:       q.Get("projectId"),
+		SessionID:       q.Get("sessionId"),
+		UnreadOnly:      unreadOnly,
+		IncludeArchived: includeArchived,
+		Limit:           limit,
+		BeforeSeq:       beforeSeq,
+	}, true
+}
+
+func parseBoolQuery(w http.ResponseWriter, r *http.Request, key string) (bool, bool) {
+	raw := r.URL.Query().Get(key)
+	if raw == "" {
+		return false, true
+	}
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_NOTIFICATION_QUERY", key+" must be a boolean", nil)
+		return false, false
+	}
+	return v, true
+}
+
+func unavailable(w http.ResponseWriter, r *http.Request) {
+	envelope.WriteAPIError(w, r, http.StatusServiceUnavailable, "unavailable", "NOTIFICATIONS_UNAVAILABLE", "Notifications are not available", nil)
+}
+
+func notificationNotFound(w http.ResponseWriter, r *http.Request) {
+	envelope.WriteAPIError(w, r, http.StatusNotFound, "not_found", "NOTIFICATION_NOT_FOUND", "Notification not found", nil)
+}
+
+type notificationRecord struct {
+	Seq        int64                       `json:"seq"`
+	ID         string                      `json:"id"`
+	ReceivedAt time.Time                   `json:"receivedAt"`
+	ReadAt     any                         `json:"readAt"`
+	ArchivedAt any                         `json:"archivedAt"`
+	Event      notificationEvent           `json:"event"`
+	Actions    []domain.NotificationAction `json:"actions"`
+}
+
+type notificationEvent struct {
+	ID        string          `json:"id"`
+	Type      string          `json:"type"`
+	Priority  string          `json:"priority"`
+	SessionID string          `json:"sessionId"`
+	ProjectID string          `json:"projectId"`
+	Timestamp time.Time       `json:"timestamp"`
+	Message   string          `json:"message"`
+	Data      json.RawMessage `json:"data"`
+}
+
+func notificationRecordFromDomain(row domain.Notification) notificationRecord {
+	actions := make([]domain.NotificationAction, 0, len(row.Actions))
+	for _, action := range row.Actions {
+		action = notification.NormalizeActionKind(action)
+		if err := notification.ValidateAction(row, action); err == nil {
+			actions = append(actions, action)
+		}
+	}
+	return notificationRecord{
+		Seq:        row.Seq,
+		ID:         string(row.ID),
+		ReceivedAt: row.CreatedAt.UTC(),
+		ReadAt:     nullableTime(row.ReadAt),
+		ArchivedAt: nullableTime(row.ArchivedAt),
+		Event: notificationEvent{
+			ID:        string(row.ID),
+			Type:      row.SemanticType,
+			Priority:  row.Priority,
+			SessionID: string(row.SessionID),
+			ProjectID: string(row.ProjectID),
+			Timestamp: row.CreatedAt.UTC(),
+			Message:   row.Message,
+			Data:      row.Payload,
+		},
+		Actions: actions,
+	}
+}
+
+func nullableTime(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t.UTC()
+}

--- a/backend/internal/httpd/controllers/notifications_test.go
+++ b/backend/internal/httpd/controllers/notifications_test.go
@@ -1,0 +1,285 @@
+package controllers_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/config"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+)
+
+func TestNotificationsAPIListGetFiltersPaginationAndUnreadCount(t *testing.T) {
+	srv, store := newNotificationAPIServer(t)
+	ctx := context.Background()
+	ao1 := seedNotificationSession(t, store, "ao")
+	ao2 := seedNotificationSession(t, store, "ao")
+	mer := seedNotificationSession(t, store, "mer")
+
+	n1 := enqueueAPINotification(t, store, ao1, "n1", "urgent")
+	n2 := enqueueAPINotification(t, store, ao2, "n2", "info")
+	n3 := enqueueAPINotification(t, store, mer, "n3", "warning")
+	if _, _, err := store.MarkNotificationRead(ctx, string(n2.ID), time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.ArchiveNotification(ctx, string(n3.ID), time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+
+	body, status, headers := doRequest(t, srv, "GET", "/api/v1/notifications?limit=1", "")
+	if status != http.StatusOK {
+		t.Fatalf("list status=%d body=%s", status, body)
+	}
+	assertJSON(t, headers)
+	var list notificationListResponse
+	mustJSON(t, body, &list)
+	if list.Limit != 1 || len(list.Notifications) != 1 || list.UnreadCount != 1 || list.NextBeforeSeq == nil {
+		t.Fatalf("list response = %#v", list)
+	}
+
+	body, status, _ = doRequest(t, srv, "GET", "/api/v1/notifications?unreadOnly=true", "")
+	if status != http.StatusOK {
+		t.Fatalf("unread status=%d body=%s", status, body)
+	}
+	mustJSON(t, body, &list)
+	if len(list.Notifications) != 1 || list.Notifications[0].ID != string(n1.ID) {
+		t.Fatalf("unread = %#v, want only %s", list.Notifications, n1.ID)
+	}
+
+	body, status, _ = doRequest(t, srv, "GET", "/api/v1/notifications?projectId=ao&beforeSeq="+jsonNumber(n2.Seq), "")
+	if status != http.StatusOK {
+		t.Fatalf("before/project status=%d body=%s", status, body)
+	}
+	mustJSON(t, body, &list)
+	if len(list.Notifications) != 1 || list.Notifications[0].ID != string(n1.ID) {
+		t.Fatalf("before/project = %#v", list.Notifications)
+	}
+
+	body, status, _ = doRequest(t, srv, "GET", "/api/v1/notifications?includeArchived=true", "")
+	if status != http.StatusOK {
+		t.Fatalf("includeArchived status=%d body=%s", status, body)
+	}
+	mustJSON(t, body, &list)
+	if len(list.Notifications) != 3 {
+		t.Fatalf("includeArchived len=%d want 3; n3=%s", len(list.Notifications), n3.ID)
+	}
+
+	body, status, _ = doRequest(t, srv, "GET", "/api/v1/notifications/"+string(n1.ID), "")
+	if status != http.StatusOK {
+		t.Fatalf("get status=%d body=%s", status, body)
+	}
+	var got struct {
+		Notification notificationRecordBody `json:"notification"`
+	}
+	mustJSON(t, body, &got)
+	if got.Notification.Event.Type != "session.needs_input" || got.Notification.Actions[0].Kind != "open-session" {
+		t.Fatalf("notification record = %#v", got.Notification)
+	}
+}
+
+func TestNotificationsAPIPatchReadArchiveAndReadAll(t *testing.T) {
+	srv, store := newNotificationAPIServer(t)
+	rec := seedNotificationSession(t, store, "ao")
+	n1 := enqueueAPINotification(t, store, rec, "patch-1", "urgent")
+	n2 := enqueueAPINotification(t, store, rec, "patch-2", "urgent")
+
+	body, status, _ := doRequest(t, srv, "PATCH", "/api/v1/notifications/"+string(n1.ID), `{"read":true,"archived":false}`)
+	if status != http.StatusOK {
+		t.Fatalf("patch read status=%d body=%s", status, body)
+	}
+	var patched struct {
+		Notification notificationRecordBody `json:"notification"`
+	}
+	mustJSON(t, body, &patched)
+	if patched.Notification.ReadAt == nil || patched.Notification.ArchivedAt != nil {
+		t.Fatalf("patched = %#v", patched.Notification)
+	}
+
+	body, status, _ = doRequest(t, srv, "PATCH", "/api/v1/notifications/"+string(n1.ID), `{"read":false}`)
+	if status != http.StatusOK {
+		t.Fatalf("patch unread status=%d body=%s", status, body)
+	}
+	mustJSON(t, body, &patched)
+	if patched.Notification.ReadAt != nil {
+		t.Fatalf("unread patch = %#v", patched.Notification)
+	}
+
+	body, status, _ = doRequest(t, srv, "PATCH", "/api/v1/notifications/"+string(n1.ID), `{"archived":true}`)
+	if status != http.StatusOK {
+		t.Fatalf("archive status=%d body=%s", status, body)
+	}
+	mustJSON(t, body, &patched)
+	if patched.Notification.ArchivedAt == nil {
+		t.Fatalf("archive patch = %#v", patched.Notification)
+	}
+
+	body, status, _ = doRequest(t, srv, "POST", "/api/v1/notifications/read-all", `{"projectId":"ao","sessionId":"`+string(rec.ID)+`"}`)
+	if status != http.StatusOK {
+		t.Fatalf("read-all status=%d body=%s", status, body)
+	}
+	var readAll struct {
+		Updated int `json:"updated"`
+	}
+	mustJSON(t, body, &readAll)
+	if readAll.Updated != 1 {
+		t.Fatalf("read-all updated=%d want 1 (n2=%s)", readAll.Updated, n2.ID)
+	}
+}
+
+func TestNotificationsAPIActionTokenAllowlistAndTargets(t *testing.T) {
+	srv, store := newNotificationAPIServer(t)
+	rec := seedNotificationSession(t, store, "ao")
+	row := enqueueAPINotification(t, store, rec, "action-1", "urgent")
+
+	body, status, _ := doRequest(t, srv, "POST", "/api/v1/notifications/"+string(row.ID)+"/actions/open-session", `{}`)
+	assertErrorCode(t, body, status, http.StatusForbidden, "ACTION_NOT_ALLOWED")
+
+	body, status, _ = doActionRequest(t, srv, string(row.ID), "open-session", "test-token")
+	if status != http.StatusOK {
+		t.Fatalf("action status=%d body=%s", status, body)
+	}
+	var result struct {
+		OK     bool `json:"ok"`
+		Result struct {
+			Route string `json:"route"`
+		} `json:"result"`
+	}
+	mustJSON(t, body, &result)
+	if !result.OK || result.Result.Route != "/projects/ao/sessions/"+string(rec.ID) {
+		t.Fatalf("action result = %#v", result)
+	}
+
+	body, status, _ = doActionRequest(t, srv, string(row.ID), "merge-pr", "test-token")
+	assertErrorCode(t, body, status, http.StatusConflict, "ACTION_PRECONDITION_FAILED")
+}
+
+func newNotificationAPIServer(t *testing.T) (*httptest.Server, *sqlite.Store) {
+	t.Helper()
+	store, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv := httptest.NewServer(httpd.NewRouterWithAPI(config.Config{}, log, nil, httpd.APIDeps{
+		Notifications: store,
+		ActionToken:   "test-token",
+	}))
+	t.Cleanup(srv.Close)
+	return srv, store
+}
+
+func seedNotificationSession(t *testing.T, store *sqlite.Store, project string) domain.SessionRecord {
+	t.Helper()
+	ctx := context.Background()
+	if _, ok, err := store.GetProject(ctx, project); err != nil {
+		t.Fatal(err)
+	} else if !ok {
+		if err := store.UpsertProject(ctx, sqlite.ProjectRow{ID: project, Path: "/tmp/" + project, RegisteredAt: time.Now().UTC()}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rec, err := store.CreateSession(ctx, domain.SessionRecord{
+		ProjectID: domain.ProjectID(project),
+		Kind:      domain.KindWorker,
+		Lifecycle: domain.CanonicalSessionLifecycle{
+			Version: domain.LifecycleVersion,
+			IsAlive: true,
+			Session: domain.SessionSubstate{State: domain.SessionWorking},
+			Activity: domain.ActivitySubstate{
+				State: domain.ActivityActive, LastActivityAt: time.Now().UTC(), Source: domain.SourceNative,
+			},
+		},
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rec
+}
+
+func enqueueAPINotification(t *testing.T, store *sqlite.Store, rec domain.SessionRecord, dedupe string, priority string) domain.Notification {
+	t.Helper()
+	now := time.Now().UTC().Truncate(time.Second)
+	row, _, err := store.EnqueueNotification(context.Background(), domain.Notification{
+		ProjectID:    rec.ProjectID,
+		SessionID:    rec.ID,
+		Source:       "lifecycle",
+		EventType:    "reaction.agent-needs-input",
+		SemanticType: "session.needs_input",
+		Priority:     priority,
+		Message:      "Agent needs input to continue.",
+		Payload:      json.RawMessage(`{"schemaVersion":3,"semanticType":"session.needs_input","subject":{"session":{"id":"` + string(rec.ID) + `","projectId":"` + string(rec.ProjectID) + `"}}}`),
+		Actions: []domain.NotificationAction{
+			{ID: "open-session", Kind: "open-session", Label: "Open session", Route: "/projects/" + string(rec.ProjectID) + "/sessions/" + string(rec.ID)},
+			{ID: "merge-pr", Kind: "merge-pr", Label: "Merge PR"},
+		},
+		DedupeKey: dedupe,
+		CauseKey:  "agent-needs-input",
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return row
+}
+
+func doActionRequest(t *testing.T, srv *httptest.Server, notificationID string, actionID string, token string) ([]byte, int, http.Header) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/notifications/"+notificationID+"/actions/"+actionID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-AO-Action-Token", token)
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body, resp.StatusCode, resp.Header
+}
+
+type notificationListResponse struct {
+	Notifications []notificationRecordBody `json:"notifications"`
+	UnreadCount   int                      `json:"unreadCount"`
+	Limit         int                      `json:"limit"`
+	NextBeforeSeq *int64                   `json:"nextBeforeSeq"`
+}
+
+type notificationRecordBody struct {
+	Seq        int64        `json:"seq"`
+	ID         string       `json:"id"`
+	ReadAt     any          `json:"readAt"`
+	ArchivedAt any          `json:"archivedAt"`
+	Event      eventBody    `json:"event"`
+	Actions    []actionBody `json:"actions"`
+}
+
+type eventBody struct {
+	Type string `json:"type"`
+}
+
+type actionBody struct {
+	ID    string `json:"id"`
+	Kind  string `json:"kind"`
+	Route string `json:"route"`
+	URL   string `json:"url"`
+}
+
+func jsonNumber(n int64) string {
+	b, _ := json.Marshal(n)
+	return string(b)
+}

--- a/backend/internal/httpd/server.go
+++ b/backend/internal/httpd/server.go
@@ -34,6 +34,10 @@ type Server struct {
 // the returned Server's lifecycle via Run. termMgr may be nil, in which case
 // the /mux terminal surface is not mounted.
 func New(cfg config.Config, log *slog.Logger, termMgr *terminal.Manager) (*Server, error) {
+	return NewWithAPI(cfg, log, termMgr, APIDeps{})
+}
+
+func NewWithAPI(cfg config.Config, log *slog.Logger, termMgr *terminal.Manager, deps APIDeps) (*Server, error) {
 	ln, err := net.Listen("tcp", cfg.Addr())
 	if err != nil {
 		return nil, fmt.Errorf("bind %s (is a daemon already running?): %w", cfg.Addr(), err)
@@ -46,7 +50,7 @@ func New(cfg config.Config, log *slog.Logger, termMgr *terminal.Manager) (*Serve
 		shutdownRequested: make(chan struct{}),
 	}
 	srv.http = &http.Server{
-		Handler: NewRouterWithControl(cfg, log, termMgr, APIDeps{}, ControlDeps{
+		Handler: NewRouterWithControl(cfg, log, termMgr, deps, ControlDeps{
 			RequestShutdown: srv.requestShutdown,
 		}),
 		// ReadHeaderTimeout guards against slow-loris even on loopback;

--- a/backend/internal/httpd/sse/events.go
+++ b/backend/internal/httpd/sse/events.go
@@ -1,0 +1,250 @@
+package sse
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd/envelope"
+)
+
+const (
+	defaultReplayBatchSize = 512
+	defaultLiveBufferSize  = 256
+	defaultHeartbeat       = 15 * time.Second
+)
+
+type Handler struct {
+	Source            cdc.Source
+	Broadcaster       *cdc.Broadcaster
+	ReplayBatchSize   int
+	LiveBufferSize    int
+	HeartbeatInterval time.Duration
+}
+
+func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.Source == nil {
+		envelope.WriteAPIError(w, r, http.StatusServiceUnavailable, "unavailable", "EVENTS_UNAVAILABLE", "Event stream is not available", nil)
+		return
+	}
+	filter, err := parseFilter(r)
+	if err != nil {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_EVENT_STREAM_FILTER", err.Error(), nil)
+		return
+	}
+	explicitAfter, hasExplicitAfter, err := explicitOffset(r)
+	if err != nil {
+		envelope.WriteAPIError(w, r, http.StatusBadRequest, "bad_request", "INVALID_EVENT_STREAM_OFFSET", err.Error(), nil)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		envelope.WriteAPIError(w, r, http.StatusInternalServerError, "internal", "EVENT_STREAM_UNSUPPORTED", "Response writer does not support streaming", nil)
+		return
+	}
+
+	batch := h.ReplayBatchSize
+	if batch <= 0 {
+		batch = defaultReplayBatchSize
+	}
+	bufferSize := h.LiveBufferSize
+	if bufferSize <= 0 {
+		bufferSize = defaultLiveBufferSize
+	}
+	heartbeat := h.HeartbeatInterval
+	if heartbeat <= 0 {
+		heartbeat = defaultHeartbeat
+	}
+
+	live := make(chan cdc.Event, bufferSize)
+	slow := make(chan struct{})
+	var slowOnce sync.Once
+	if h.Broadcaster != nil {
+		unsubscribe := h.Broadcaster.Subscribe(func(e cdc.Event) {
+			if !filter.matches(e) {
+				return
+			}
+			select {
+			case live <- e:
+			default:
+				slowOnce.Do(func() { close(slow) })
+			}
+		})
+		defer unsubscribe()
+	}
+
+	after := explicitAfter
+	if !hasExplicitAfter {
+		after, err = h.Source.LatestSeq(r.Context())
+		if err != nil {
+			envelope.WriteAPIError(w, r, http.StatusInternalServerError, "internal", "EVENT_STREAM_HEAD_FAILED", "Failed to determine event stream offset", nil)
+			return
+		}
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	_, _ = fmt.Fprint(w, "retry: 2000\n\n")
+	flusher.Flush()
+
+	lastSent := after
+	cursor := after
+	for {
+		rows, err := h.Source.EventsAfter(r.Context(), cursor, batch)
+		if err != nil {
+			writeStreamError(w, flusher, "REPLAY_FAILED", "Failed to replay event stream")
+			return
+		}
+		if len(rows) == 0 {
+			break
+		}
+		cursor = rows[len(rows)-1].Seq
+		for _, event := range rows {
+			if !filter.matches(event) || event.Seq <= lastSent {
+				continue
+			}
+			if err := writeEvent(w, flusher, event); err != nil {
+				return
+			}
+			lastSent = event.Seq
+		}
+		if len(rows) < batch {
+			break
+		}
+	}
+
+drain:
+	for {
+		select {
+		case event := <-live:
+			if event.Seq > lastSent {
+				if err := writeEvent(w, flusher, event); err != nil {
+					return
+				}
+				lastSent = event.Seq
+			}
+		default:
+			break drain
+		}
+	}
+
+	ticker := time.NewTicker(heartbeat)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-slow:
+			writeStreamError(w, flusher, "CLIENT_TOO_SLOW", "SSE client could not keep up")
+			return
+		case event := <-live:
+			if event.Seq <= lastSent {
+				continue
+			}
+			if err := writeEvent(w, flusher, event); err != nil {
+				return
+			}
+			lastSent = event.Seq
+		case <-ticker.C:
+			_, _ = fmt.Fprint(w, ": heartbeat\n\n")
+			flusher.Flush()
+		}
+	}
+}
+
+func explicitOffset(r *http.Request) (int64, bool, error) {
+	if raw := r.URL.Query().Get("after"); raw != "" {
+		seq, err := parseOffset(raw, "after")
+		return seq, true, err
+	}
+	if raw := r.Header.Get("Last-Event-ID"); raw != "" {
+		seq, err := parseOffset(raw, "Last-Event-ID")
+		return seq, true, err
+	}
+	return 0, false, nil
+}
+
+func parseOffset(raw, name string) (int64, error) {
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("%s must be a non-negative integer", name)
+	}
+	return n, nil
+}
+
+type streamFilter struct {
+	projectID string
+	topics    map[string]struct{}
+}
+
+func parseFilter(r *http.Request) (streamFilter, error) {
+	filter := streamFilter{projectID: r.URL.Query().Get("projectId")}
+	rawTopics := strings.TrimSpace(r.URL.Query().Get("topics"))
+	if rawTopics == "" {
+		return filter, nil
+	}
+	filter.topics = map[string]struct{}{}
+	for _, part := range strings.Split(rawTopics, ",") {
+		topic := strings.TrimSpace(part)
+		switch topic {
+		case "sessions", "prs", "notifications":
+			filter.topics[topic] = struct{}{}
+		case "":
+			continue
+		default:
+			return streamFilter{}, fmt.Errorf("topics contains unsupported topic %q", topic)
+		}
+	}
+	return filter, nil
+}
+
+func (f streamFilter) matches(event cdc.Event) bool {
+	if f.projectID != "" && event.ProjectID != f.projectID {
+		return false
+	}
+	if len(f.topics) == 0 {
+		return true
+	}
+	_, ok := f.topics[eventTopic(event)]
+	return ok
+}
+
+func eventTopic(event cdc.Event) string {
+	t := string(event.Type)
+	switch {
+	case strings.HasPrefix(t, "session_"):
+		return "sessions"
+	case strings.HasPrefix(t, "pr_"):
+		return "prs"
+	case strings.HasPrefix(t, "notification_"):
+		return "notifications"
+	default:
+		return ""
+	}
+}
+
+func writeEvent(w http.ResponseWriter, flusher http.Flusher, event cdc.Event) error {
+	data, err := json.Marshal(event)
+	if err != nil {
+		writeStreamError(w, flusher, "ENCODE_FAILED", "Failed to encode event")
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "id: %d\nevent: %s\ndata: %s\n\n", event.Seq, event.Type, data); err != nil {
+		return err
+	}
+	flusher.Flush()
+	return nil
+}
+
+func writeStreamError(w http.ResponseWriter, flusher http.Flusher, code, message string) {
+	data, _ := json.Marshal(map[string]string{"code": code, "message": message})
+	_, _ = fmt.Fprintf(w, "event: stream_error\ndata: %s\n\n", data)
+	flusher.Flush()
+}

--- a/backend/internal/httpd/sse/events_test.go
+++ b/backend/internal/httpd/sse/events_test.go
@@ -1,0 +1,240 @@
+package sse
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+)
+
+func TestEventsReplayAfterHeaderPrecedenceAndFiltering(t *testing.T) {
+	src := &memorySource{events: []cdc.Event{
+		testEvent(1, "ao", cdc.EventSessionCreated),
+		testEvent(2, "ao", cdc.EventNotificationCreated),
+		testEvent(3, "mer", cdc.EventNotificationCreated),
+		testEvent(4, "ao", cdc.EventNotificationUpdated),
+	}}
+	srv := httptest.NewServer(Handler{Source: src, Broadcaster: cdc.NewBroadcaster(), HeartbeatInterval: time.Hour})
+	t.Cleanup(srv.Close)
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/events?after=1&projectId=ao&topics=notifications", nil)
+	req.Header.Set("Last-Event-ID", "3")
+	body := readStreamUntil(t, srv.Client(), req, "id: 4")
+	if strings.Contains(body, "id: 1") || strings.Contains(body, "id: 3") || !strings.Contains(body, "id: 2") || !strings.Contains(body, "id: 4") {
+		t.Fatalf("filtered replay body:\n%s", body)
+	}
+}
+
+func TestEventsReplayFromLastEventID(t *testing.T) {
+	src := &memorySource{events: []cdc.Event{
+		testEvent(1, "ao", cdc.EventNotificationCreated),
+		testEvent(2, "ao", cdc.EventNotificationUpdated),
+	}}
+	srv := httptest.NewServer(Handler{Source: src, Broadcaster: cdc.NewBroadcaster(), HeartbeatInterval: time.Hour})
+	t.Cleanup(srv.Close)
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/events?topics=notifications", nil)
+	req.Header.Set("Last-Event-ID", "1")
+	body := readStreamUntil(t, srv.Client(), req, "id: 2")
+	if strings.Contains(body, "id: 1") || !strings.Contains(body, "id: 2") {
+		t.Fatalf("Last-Event-ID replay body:\n%s", body)
+	}
+}
+
+func TestEventsReplayBatches(t *testing.T) {
+	src := &memorySource{events: []cdc.Event{
+		testEvent(1, "ao", cdc.EventNotificationCreated),
+		testEvent(2, "ao", cdc.EventNotificationUpdated),
+		testEvent(3, "ao", cdc.EventNotificationUpdated),
+	}}
+	srv := httptest.NewServer(Handler{Source: src, Broadcaster: cdc.NewBroadcaster(), ReplayBatchSize: 1, HeartbeatInterval: time.Hour})
+	t.Cleanup(srv.Close)
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/events?after=0&topics=notifications", nil)
+	body := readStreamUntil(t, srv.Client(), req, "id: 3")
+	if !strings.Contains(body, "id: 1") || !strings.Contains(body, "id: 2") || !strings.Contains(body, "id: 3") {
+		t.Fatalf("batched replay body:\n%s", body)
+	}
+}
+
+func TestEventsFreshLiveOnlyStream(t *testing.T) {
+	src := &memorySource{events: []cdc.Event{testEvent(1, "ao", cdc.EventNotificationCreated)}}
+	bc := cdc.NewBroadcaster()
+	srv := httptest.NewServer(Handler{Source: src, Broadcaster: bc, HeartbeatInterval: time.Hour})
+	t.Cleanup(srv.Close)
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/events?topics=notifications", nil)
+	done := make(chan string, 1)
+	go func() {
+		done <- readStreamUntil(t, srv.Client(), req, "id: 2")
+	}()
+	time.Sleep(20 * time.Millisecond)
+	bc.Publish(testEvent(2, "ao", cdc.EventNotificationUpdated))
+	body := <-done
+	if strings.Contains(body, "id: 1") || !strings.Contains(body, "id: 2") {
+		t.Fatalf("fresh stream body:\n%s", body)
+	}
+}
+
+func TestEventsNoDuplicateAcrossReplayLiveBoundary(t *testing.T) {
+	bc := cdc.NewBroadcaster()
+	src := &memorySource{events: []cdc.Event{
+		testEvent(1, "ao", cdc.EventNotificationCreated),
+		testEvent(2, "ao", cdc.EventNotificationUpdated),
+	}}
+	src.onRead = func() {
+		bc.Publish(testEvent(2, "ao", cdc.EventNotificationUpdated))
+		bc.Publish(testEvent(3, "ao", cdc.EventNotificationUpdated))
+	}
+	srv := httptest.NewServer(Handler{Source: src, Broadcaster: bc, HeartbeatInterval: time.Hour})
+	t.Cleanup(srv.Close)
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/events?after=0&topics=notifications", nil)
+	body := readStreamUntil(t, srv.Client(), req, "id: 3")
+	if strings.Count(body, "id: 2") != 1 || !strings.Contains(body, "id: 3") {
+		t.Fatalf("dedupe body:\n%s", body)
+	}
+}
+
+func TestEventsHeartbeatAndInvalidOffset(t *testing.T) {
+	src := &memorySource{}
+	srv := httptest.NewServer(Handler{Source: src, Broadcaster: cdc.NewBroadcaster(), HeartbeatInterval: time.Millisecond})
+	t.Cleanup(srv.Close)
+
+	resp, err := srv.Client().Get(srv.URL + "/events?after=wat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("invalid offset status=%d body=%s", resp.StatusCode, body)
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/events?after=0", nil)
+	body := readStreamUntil(t, srv.Client(), req, ": heartbeat")
+	if !strings.Contains(body, ": heartbeat") {
+		t.Fatalf("heartbeat body:\n%s", body)
+	}
+}
+
+func TestEventsSlowClientGetsStreamError(t *testing.T) {
+	bc := cdc.NewBroadcaster()
+	release := make(chan struct{})
+	src := &memorySource{}
+	src.blockRead = release
+	srv := httptest.NewServer(Handler{Source: src, Broadcaster: bc, LiveBufferSize: 1, HeartbeatInterval: time.Hour})
+	t.Cleanup(srv.Close)
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/events?after=0&topics=notifications", nil)
+	done := make(chan string, 1)
+	go func() {
+		done <- readStreamUntil(t, srv.Client(), req, "CLIENT_TOO_SLOW")
+	}()
+	time.Sleep(20 * time.Millisecond)
+	bc.Publish(testEvent(1, "ao", cdc.EventNotificationCreated))
+	bc.Publish(testEvent(2, "ao", cdc.EventNotificationUpdated))
+	close(release)
+
+	select {
+	case body := <-done:
+		if !strings.Contains(body, "event: stream_error") || !strings.Contains(body, "CLIENT_TOO_SLOW") {
+			t.Fatalf("slow body:\n%s", body)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for slow-client stream_error")
+	}
+}
+
+type memorySource struct {
+	mu        sync.Mutex
+	events    []cdc.Event
+	onRead    func()
+	blockRead <-chan struct{}
+	readOnce  sync.Once
+}
+
+func (s *memorySource) EventsAfter(ctx context.Context, after int64, limit int) ([]cdc.Event, error) {
+	s.readOnce.Do(func() {
+		if s.onRead != nil {
+			s.onRead()
+		}
+	})
+	if s.blockRead != nil {
+		select {
+		case <-s.blockRead:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []cdc.Event
+	for _, e := range s.events {
+		if e.Seq > after {
+			out = append(out, e)
+			if len(out) == limit {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func (s *memorySource) LatestSeq(context.Context) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.events) == 0 {
+		return 0, nil
+	}
+	return s.events[len(s.events)-1].Seq, nil
+}
+
+func testEvent(seq int64, project string, eventType cdc.EventType) cdc.Event {
+	payload, _ := json.Marshal(map[string]any{"id": seq})
+	return cdc.Event{
+		Seq:       seq,
+		ProjectID: project,
+		SessionID: project + "-1",
+		Type:      eventType,
+		Payload:   payload,
+		CreatedAt: time.Date(2026, 5, 31, 10, 30, int(seq), 0, time.UTC),
+	}
+}
+
+func readStreamUntil(t *testing.T, client *http.Client, req *http.Request, want string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(req.Context(), 2*time.Second)
+	defer cancel()
+	req = req.WithContext(ctx)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	var b strings.Builder
+	buf := make([]byte, 256)
+	for {
+		n, err := resp.Body.Read(buf)
+		if n > 0 {
+			b.Write(buf[:n])
+			if strings.Contains(b.String(), want) {
+				return b.String()
+			}
+		}
+		if err != nil {
+			t.Fatalf("read stream before %q: %v body=%s", want, err, b.String())
+		}
+	}
+}

--- a/backend/internal/notification/actions.go
+++ b/backend/internal/notification/actions.go
@@ -1,0 +1,236 @@
+package notification
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+const (
+	ActionOpenSession    = "open-session"
+	ActionOpenPR         = "open-pr"
+	ActionOpenReview     = "open-review"
+	ActionOpenCI         = "open-ci"
+	ActionRestoreSession = "restore-session"
+	ActionSendMessage    = "send-message"
+	ActionMergePR        = "merge-pr"
+	ActionMarkRead       = "mark-read"
+	ActionDismiss        = "dismiss"
+)
+
+var allowedActionKinds = map[string]struct{}{
+	ActionOpenSession:    {},
+	ActionOpenPR:         {},
+	ActionOpenReview:     {},
+	ActionOpenCI:         {},
+	ActionRestoreSession: {},
+	ActionSendMessage:    {},
+	ActionMergePR:        {},
+	ActionMarkRead:       {},
+	ActionDismiss:        {},
+}
+
+var allowedExternalHosts = []string{"github.com", "gitlab.com", "linear.app"}
+
+// ActionStore is the minimal durable surface needed by notification actions.
+type ActionStore interface {
+	GetNotification(ctx context.Context, id string) (domain.Notification, bool, error)
+	MarkNotificationRead(ctx context.Context, id string, at time.Time) (domain.Notification, bool, error)
+	ArchiveNotification(ctx context.Context, id string, at time.Time) (domain.Notification, bool, error)
+}
+
+type ActionError struct {
+	StatusCode int
+	Code       string
+	Message    string
+}
+
+func (e *ActionError) Error() string { return e.Message }
+
+type ActionResult struct {
+	OK       bool           `json:"ok"`
+	ActionID string         `json:"actionId"`
+	Kind     string         `json:"kind"`
+	Result   map[string]any `json:"result,omitempty"`
+}
+
+// ExecuteAction validates and executes a user-visible notification action. It
+// deliberately supports only an allowlist of local/navigation actions; payloads
+// never supply arbitrary callback endpoints or HTTP methods.
+func ExecuteAction(ctx context.Context, store ActionStore, notificationID, actionID string, now time.Time) (ActionResult, error) {
+	if store == nil {
+		return ActionResult{}, &ActionError{StatusCode: 500, Code: "NOTIFICATION_STORE_UNAVAILABLE", Message: "Notification store unavailable"}
+	}
+	row, ok, err := store.GetNotification(ctx, notificationID)
+	if err != nil {
+		return ActionResult{}, err
+	}
+	if !ok {
+		return ActionResult{}, &ActionError{StatusCode: 404, Code: "NOTIFICATION_NOT_FOUND", Message: "Notification not found"}
+	}
+	action, ok := FindAction(row, actionID)
+	if !ok {
+		return ActionResult{}, &ActionError{StatusCode: 404, Code: "ACTION_NOT_FOUND", Message: "Notification action not found"}
+	}
+	action = NormalizeActionKind(action)
+	if err := ValidateAction(row, action); err != nil {
+		return ActionResult{}, err
+	}
+	kind := action.Kind
+	switch kind {
+	case ActionOpenSession, ActionRestoreSession, ActionSendMessage:
+		route := action.Route
+		if route == "" {
+			route = SessionRoute(row)
+		}
+		return ActionResult{OK: true, ActionID: action.ID, Kind: kind, Result: map[string]any{"route": route}}, nil
+	case ActionOpenPR, ActionOpenReview, ActionOpenCI:
+		target := action.URL
+		if target == "" {
+			target = URLFromPayload(row.Payload)
+		}
+		if err := ValidateExternalURL(target); err != nil {
+			return ActionResult{}, err
+		}
+		return ActionResult{OK: true, ActionID: action.ID, Kind: kind, Result: map[string]any{"url": target}}, nil
+	case ActionMarkRead:
+		updated, _, err := store.MarkNotificationRead(ctx, string(row.ID), now)
+		if err != nil {
+			return ActionResult{}, err
+		}
+		return ActionResult{OK: true, ActionID: action.ID, Kind: kind, Result: map[string]any{"readAt": timeOrNil(updated.ReadAt)}}, nil
+	case ActionDismiss:
+		updated, _, err := store.ArchiveNotification(ctx, string(row.ID), now)
+		if err != nil {
+			return ActionResult{}, err
+		}
+		return ActionResult{OK: true, ActionID: action.ID, Kind: kind, Result: map[string]any{"archivedAt": timeOrNil(updated.ArchivedAt)}}, nil
+	case ActionMergePR:
+		return ActionResult{}, &ActionError{StatusCode: 409, Code: "ACTION_PRECONDITION_FAILED", Message: "PR merge preconditions are not currently satisfied"}
+	default:
+		return ActionResult{}, &ActionError{StatusCode: 403, Code: "ACTION_NOT_ALLOWED", Message: "Notification action is not allowed"}
+	}
+}
+
+func FindAction(row domain.Notification, actionID string) (domain.NotificationAction, bool) {
+	for _, action := range row.Actions {
+		if action.ID == actionID {
+			return action, true
+		}
+	}
+	return domain.NotificationAction{}, false
+}
+
+// NormalizeActionKind accepts the legacy route/url storage kind for old rows
+// but maps it through the action id before validation. New rows should persist
+// one of the public allowlisted kinds directly.
+func NormalizeActionKind(action domain.NotificationAction) domain.NotificationAction {
+	switch action.Kind {
+	case "", "route", "url":
+		action.Kind = action.ID
+	}
+	return action
+}
+
+func ValidateAction(row domain.Notification, action domain.NotificationAction) error {
+	action = NormalizeActionKind(action)
+	if _, ok := allowedActionKinds[action.Kind]; !ok {
+		return &ActionError{StatusCode: 403, Code: "ACTION_NOT_ALLOWED", Message: "Notification action is not allowed"}
+	}
+	if strings.TrimSpace(action.Method) != "" {
+		return &ActionError{StatusCode: 403, Code: "ACTION_NOT_ALLOWED", Message: "Notification actions cannot define arbitrary methods or callbacks"}
+	}
+	if action.Route != "" {
+		if err := ValidateInternalRoute(action.Route); err != nil {
+			return err
+		}
+	}
+	if action.URL != "" {
+		if err := ValidateExternalURL(action.URL); err != nil {
+			return err
+		}
+	}
+	if action.Kind == ActionOpenSession && action.Route == "" && (row.ProjectID == "" || row.SessionID == "") {
+		return &ActionError{StatusCode: 422, Code: "ACTION_TARGET_INVALID", Message: "Open session action is missing a target"}
+	}
+	return nil
+}
+
+func ValidateInternalRoute(route string) error {
+	if route == "" || !strings.HasPrefix(route, "/") || strings.HasPrefix(route, "//") || strings.Contains(route, "\\") {
+		return &ActionError{StatusCode: 422, Code: "ACTION_TARGET_INVALID", Message: "Notification action route is invalid"}
+	}
+	if strings.ContainsAny(route, "\x00\r\n\t") {
+		return &ActionError{StatusCode: 422, Code: "ACTION_TARGET_INVALID", Message: "Notification action route is invalid"}
+	}
+	u, err := url.Parse(route)
+	if err != nil || u.IsAbs() || u.Host != "" {
+		return &ActionError{StatusCode: 422, Code: "ACTION_TARGET_INVALID", Message: "Notification action route is invalid"}
+	}
+	return nil
+}
+
+func ValidateExternalURL(raw string) error {
+	if raw == "" {
+		return &ActionError{StatusCode: 422, Code: "ACTION_TARGET_INVALID", Message: "Notification action URL is missing"}
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "https" || u.Hostname() == "" {
+		return &ActionError{StatusCode: 422, Code: "ACTION_TARGET_INVALID", Message: "Notification action URL must be HTTPS"}
+	}
+	host := strings.ToLower(u.Hostname())
+	for _, allowed := range allowedExternalHosts {
+		if host == allowed || strings.HasSuffix(host, "."+allowed) {
+			return nil
+		}
+	}
+	return &ActionError{StatusCode: 403, Code: "ACTION_NOT_ALLOWED", Message: "Notification action URL host is not allowed"}
+}
+
+func SessionRoute(row domain.Notification) string {
+	return fmt.Sprintf("/projects/%s/sessions/%s", row.ProjectID, row.SessionID)
+}
+
+func URLFromPayload(raw json.RawMessage) string {
+	var p struct {
+		Subject struct {
+			PR struct {
+				URL string `json:"url"`
+			} `json:"pr"`
+		} `json:"subject"`
+		PR struct {
+			URL string `json:"url"`
+		} `json:"pr"`
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return ""
+	}
+	switch {
+	case p.Subject.PR.URL != "":
+		return p.Subject.PR.URL
+	case p.PR.URL != "":
+		return p.PR.URL
+	default:
+		return p.URL
+	}
+}
+
+func timeOrNil(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t.UTC()
+}
+
+func IsActionError(err error) (*ActionError, bool) {
+	var ae *ActionError
+	ok := errors.As(err, &ae)
+	return ae, ok
+}

--- a/backend/internal/notification/actions_test.go
+++ b/backend/internal/notification/actions_test.go
@@ -1,0 +1,98 @@
+package notification
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestActionAllowlistAcceptsSafeActionsAndRejectsCallbacks(t *testing.T) {
+	row := actionTestNotification()
+	if err := ValidateAction(row, domain.NotificationAction{ID: "open-session", Kind: "open-session", Route: "/projects/ao/sessions/ao-1"}); err != nil {
+		t.Fatalf("safe route rejected: %v", err)
+	}
+	if err := ValidateAction(row, domain.NotificationAction{ID: "open-pr", Kind: "open-pr", URL: "https://github.com/aoagents/agent-orchestrator/pull/1"}); err != nil {
+		t.Fatalf("safe url rejected: %v", err)
+	}
+	if err := ValidateAction(row, domain.NotificationAction{ID: "open-session", Kind: "open-session", Route: "javascript:alert(1)"}); err == nil {
+		t.Fatal("unsafe internal route should be rejected")
+	}
+	if err := ValidateAction(row, domain.NotificationAction{ID: "callback", Kind: "callback", Method: "POST"}); err == nil {
+		t.Fatal("arbitrary callback action should be rejected")
+	}
+}
+
+func TestExternalURLHostAllowlist(t *testing.T) {
+	allowed := []string{
+		"https://github.com/aoagents/agent-orchestrator/pull/1",
+		"https://gitlab.com/group/project/-/merge_requests/1",
+		"https://linear.app/ao/issue/AO-1",
+		"https://sub.github.com/path",
+	}
+	for _, raw := range allowed {
+		if err := ValidateExternalURL(raw); err != nil {
+			t.Fatalf("%s rejected: %v", raw, err)
+		}
+	}
+	rejected := []string{
+		"http://github.com/aoagents/agent-orchestrator/pull/1",
+		"javascript:alert(1)",
+		"data:text/plain,hi",
+		"https://evil.example/pr/1",
+		"https://github.com.evil.example/pr/1",
+	}
+	for _, raw := range rejected {
+		if err := ValidateExternalURL(raw); err == nil {
+			t.Fatalf("%s should be rejected", raw)
+		}
+	}
+}
+
+func TestExecuteMergePRPreconditionFailure(t *testing.T) {
+	store := &memoryActionStore{row: actionTestNotification()}
+	result, err := ExecuteAction(context.Background(), store, string(store.row.ID), "merge-pr", time.Now().UTC())
+	if err == nil {
+		t.Fatalf("merge-pr should fail precondition, got result=%+v", result)
+	}
+	ae, ok := IsActionError(err)
+	if !ok || ae.Code != "ACTION_PRECONDITION_FAILED" || ae.StatusCode != 409 {
+		t.Fatalf("merge-pr err = %#v ok=%v", ae, ok)
+	}
+}
+
+func actionTestNotification() domain.Notification {
+	return domain.Notification{
+		ID:           "ntf_action",
+		ProjectID:    "ao",
+		SessionID:    "ao-1",
+		SemanticType: "session.needs_input",
+		Priority:     "urgent",
+		Payload:      json.RawMessage(`{"schemaVersion":3,"subject":{"pr":{"url":"https://github.com/aoagents/agent-orchestrator/pull/1"}}}`),
+		Actions: []domain.NotificationAction{
+			{ID: "open-session", Kind: "open-session", Label: "Open session", Route: "/projects/ao/sessions/ao-1"},
+			{ID: "open-pr", Kind: "open-pr", Label: "Open PR", URL: "https://github.com/aoagents/agent-orchestrator/pull/1"},
+			{ID: "merge-pr", Kind: "merge-pr", Label: "Merge PR"},
+		},
+	}
+}
+
+type memoryActionStore struct {
+	row domain.Notification
+}
+
+func (s *memoryActionStore) GetNotification(context.Context, string) (domain.Notification, bool, error) {
+	return s.row, true, nil
+}
+
+func (s *memoryActionStore) MarkNotificationRead(_ context.Context, _ string, at time.Time) (domain.Notification, bool, error) {
+	s.row.ReadAt = at
+	return s.row, true, nil
+}
+
+func (s *memoryActionStore) ArchiveNotification(_ context.Context, _ string, at time.Time) (domain.Notification, bool, error) {
+	s.row.ArchivedAt = at
+	return s.row, true, nil
+}

--- a/backend/internal/notification/renderer.go
+++ b/backend/internal/notification/renderer.go
@@ -161,12 +161,12 @@ func mergePayload(m domain.Mergeability) *MergePayload {
 func actionsFor(projectID domain.ProjectID, sessionID domain.SessionID, pr domain.PRFacts) []domain.NotificationAction {
 	actions := []domain.NotificationAction{{
 		ID:    "open-session",
-		Kind:  "route",
+		Kind:  ActionOpenSession,
 		Label: "Open session",
 		Route: fmt.Sprintf("/projects/%s/sessions/%s", projectID, sessionID),
 	}}
 	if pr.Exists && pr.URL != "" {
-		actions = append(actions, domain.NotificationAction{ID: "open-pr", Kind: "url", Label: "Open PR", URL: pr.URL})
+		actions = append(actions, domain.NotificationAction{ID: "open-pr", Kind: ActionOpenPR, Label: "Open PR", URL: pr.URL})
 	}
 	return actions
 }

--- a/backend/internal/storage/sqlite/notification_store.go
+++ b/backend/internal/storage/sqlite/notification_store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -19,13 +20,18 @@ type NotificationRow = domain.Notification
 // NotificationFilter constrains ListNotifications. A zero filter returns the
 // newest notifications across projects.
 type NotificationFilter struct {
-	ProjectID  string
-	SessionID  string
-	UnreadOnly bool
-	Limit      int
+	ProjectID       string
+	SessionID       string
+	UnreadOnly      bool
+	IncludeArchived bool
+	Limit           int
+	BeforeSeq       int64
 }
 
 const defaultNotificationLimit = 100
+
+const notificationSelectColumns = `seq, id, project_id, session_id, source, event_type, semantic_type, priority,
+    message, payload_json, actions_json, dedupe_key, cause_key, read_at, archived_at, created_at, updated_at, routed_at`
 
 // EnqueueNotification inserts a notification exactly once per dedupe key. The
 // returned bool is true when a new row was created; false means the existing row
@@ -90,24 +96,81 @@ func (s *Store) ListNotifications(ctx context.Context, filter NotificationFilter
 		limit = defaultNotificationLimit
 	}
 
-	var (
-		rows []gen.Notification
-		err  error
-	)
-	switch {
-	case filter.UnreadOnly:
-		rows, err = s.qr.ListUnreadNotifications(ctx, limit)
-	case filter.SessionID != "":
-		rows, err = s.qr.ListNotificationsBySession(ctx, gen.ListNotificationsBySessionParams{SessionID: filter.SessionID, Limit: limit})
-	case filter.ProjectID != "":
-		rows, err = s.qr.ListNotificationsByProject(ctx, gen.ListNotificationsByProjectParams{ProjectID: filter.ProjectID, Limit: limit})
-	default:
-		rows, err = s.qr.ListNotifications(ctx, limit)
-	}
+	query, args := buildNotificationListQuery(filter, limit)
+	rows, err := s.readDB.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list notifications: %w", err)
 	}
-	return notificationsFromGen(rows)
+	defer rows.Close()
+
+	out := make([]NotificationRow, 0, limit)
+	for rows.Next() {
+		row, err := scanNotification(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list notifications: %w", err)
+	}
+	return out, nil
+}
+
+// CountUnreadNotifications returns the current unread badge count. Archived
+// notifications never contribute to the badge, even when an API list includes
+// archived rows for history/backfill.
+func (s *Store) CountUnreadNotifications(ctx context.Context, filter NotificationFilter) (int, error) {
+	var (
+		clauses = []string{"read_at IS NULL", "archived_at IS NULL"}
+		args    []any
+	)
+	if filter.ProjectID != "" {
+		clauses = append(clauses, "project_id = ?")
+		args = append(args, filter.ProjectID)
+	}
+	if filter.SessionID != "" {
+		clauses = append(clauses, "session_id = ?")
+		args = append(args, filter.SessionID)
+	}
+	query := "SELECT COUNT(*) FROM notifications WHERE " + strings.Join(clauses, " AND ")
+	var count int
+	if err := s.readDB.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count unread notifications: %w", err)
+	}
+	return count, nil
+}
+
+// MarkAllNotificationsRead marks visible unread notifications read, optionally
+// scoped by project/session, and returns the number of rows changed. SQLite
+// fires the notification_updated CDC trigger once per changed row.
+func (s *Store) MarkAllNotificationsRead(ctx context.Context, filter NotificationFilter, at time.Time) (int, error) {
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	clauses := []string{"read_at IS NULL", "archived_at IS NULL"}
+	args := []any{sql.NullTime{Time: at, Valid: true}, at}
+	if filter.ProjectID != "" {
+		clauses = append(clauses, "project_id = ?")
+		args = append(args, filter.ProjectID)
+	}
+	if filter.SessionID != "" {
+		clauses = append(clauses, "session_id = ?")
+		args = append(args, filter.SessionID)
+	}
+	query := "UPDATE notifications SET read_at = ?, updated_at = ? WHERE " + strings.Join(clauses, " AND ")
+
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	result, err := s.writeDB.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("mark all notifications read: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("mark all notifications read rows affected: %w", err)
+	}
+	return int(n), nil
 }
 
 // MarkNotificationRead marks an unread notification read. The returned bool is
@@ -154,6 +217,42 @@ func (s *Store) ArchiveNotification(ctx context.Context, id string, at time.Time
 		ID:         id,
 	})
 	return s.changedNotificationResult(ctx, row, id, true, err)
+}
+
+// UnarchiveNotification clears archived_at. Product flows currently avoid
+// surfacing unarchive, but the primitive is useful for idempotent PATCH handling
+// and tests; callers can decide whether to expose it.
+func (s *Store) UnarchiveNotification(ctx context.Context, id string, at time.Time) (NotificationRow, bool, error) {
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	row, err := s.writeDB.QueryContext(ctx, `UPDATE notifications
+SET archived_at = NULL, updated_at = ?
+WHERE id = ? AND archived_at IS NOT NULL
+RETURNING `+notificationSelectColumns, at, id)
+	if err != nil {
+		return NotificationRow{}, false, err
+	}
+	defer row.Close()
+	if row.Next() {
+		got, scanErr := scanNotification(row)
+		return got, scanErr == nil, scanErr
+	}
+	if err := row.Err(); err != nil {
+		return NotificationRow{}, false, err
+	}
+	existing, readErr := s.qw.GetNotification(ctx, id)
+	if errors.Is(readErr, sql.ErrNoRows) {
+		return NotificationRow{}, false, nil
+	}
+	if readErr != nil {
+		return NotificationRow{}, false, fmt.Errorf("get notification %s: %w", id, readErr)
+	}
+	mapped, mapErr := notificationFromGen(existing)
+	return mapped, false, mapErr
 }
 
 func (s *Store) changedNotificationResult(ctx context.Context, row gen.Notification, id string, changed bool, err error) (NotificationRow, bool, error) {
@@ -205,6 +304,68 @@ func notificationsFromGen(rows []gen.Notification) ([]NotificationRow, error) {
 		out = append(out, row)
 	}
 	return out, nil
+}
+
+func buildNotificationListQuery(filter NotificationFilter, limit int64) (string, []any) {
+	var (
+		clauses []string
+		args    []any
+	)
+	if filter.ProjectID != "" {
+		clauses = append(clauses, "project_id = ?")
+		args = append(args, filter.ProjectID)
+	}
+	if filter.SessionID != "" {
+		clauses = append(clauses, "session_id = ?")
+		args = append(args, filter.SessionID)
+	}
+	if filter.UnreadOnly {
+		clauses = append(clauses, "read_at IS NULL")
+	}
+	if !filter.IncludeArchived {
+		clauses = append(clauses, "archived_at IS NULL")
+	}
+	if filter.BeforeSeq > 0 {
+		clauses = append(clauses, "seq < ?")
+		args = append(args, filter.BeforeSeq)
+	}
+	where := ""
+	if len(clauses) > 0 {
+		where = " WHERE " + strings.Join(clauses, " AND ")
+	}
+	args = append(args, limit)
+	return "SELECT " + notificationSelectColumns + " FROM notifications" + where + " ORDER BY seq DESC LIMIT ?", args
+}
+
+type notificationScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanNotification(scanner notificationScanner) (NotificationRow, error) {
+	var r gen.Notification
+	if err := scanner.Scan(
+		&r.Seq,
+		&r.ID,
+		&r.ProjectID,
+		&r.SessionID,
+		&r.Source,
+		&r.EventType,
+		&r.SemanticType,
+		&r.Priority,
+		&r.Message,
+		&r.PayloadJson,
+		&r.ActionsJson,
+		&r.DedupeKey,
+		&r.CauseKey,
+		&r.ReadAt,
+		&r.ArchivedAt,
+		&r.CreatedAt,
+		&r.UpdatedAt,
+		&r.RoutedAt,
+	); err != nil {
+		return NotificationRow{}, err
+	}
+	return notificationFromGen(r)
 }
 
 func notificationFromGen(r gen.Notification) (NotificationRow, error) {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "agent-orchestrator-frontend",
       "version": "0.0.0",
       "devDependencies": {
+        "@types/node": "^22.19.19",
         "electron": "^33.0.0",
         "typescript": "^5.6.0"
       }
@@ -91,11 +92,10 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -302,6 +302,15 @@
       },
       "engines": {
         "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/end-of-stream": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,9 +7,11 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
+    "test": "npm run build && node --test dist/*.test.js",
     "start": "npm run build && electron ."
   },
   "devDependencies": {
+    "@types/node": "^22.19.19",
     "electron": "^33.0.0",
     "typescript": "^5.6.0"
   }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,6 +1,26 @@
-import { app, BrowserWindow } from "electron";
+import { app, BrowserWindow, Notification as ElectronNotification } from "electron";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 
-function createWindow(): void {
+import {
+  CDCEvent,
+  NotificationAction,
+  NotificationCreatedPayload,
+  desktopPayloadFor,
+  invokeNotificationAction,
+  isSafeInternalRoute,
+  notificationEventsURL,
+  notificationRecordFromCDCEvent,
+  patchNotification,
+  shouldShowDesktop,
+} from "./notifications";
+
+let mainWindow: BrowserWindow | undefined;
+let daemonOrigin = daemonOriginFromEnv();
+const shownNotifications = new Set<string>();
+const nativeNotifications = new Set<ElectronNotification>();
+
+function createWindow(): BrowserWindow {
   const window = new BrowserWindow({
     width: 1200,
     height: 800,
@@ -9,12 +29,21 @@ function createWindow(): void {
       nodeIntegration: false,
     },
   });
-
-  void window.loadURL("about:blank");
+  mainWindow = window;
+  window.on("closed", () => {
+    if (mainWindow === window) {
+      mainWindow = undefined;
+    }
+  });
+  void window.loadURL(daemonOrigin);
+  return window;
 }
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
+  daemonOrigin = daemonOriginFromEnv();
+  await waitForDaemonReady(daemonOrigin);
   createWindow();
+  void startNotificationSSE(daemonOrigin);
 
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) {
@@ -28,3 +57,214 @@ app.on("window-all-closed", () => {
     app.quit();
   }
 });
+
+async function startNotificationSSE(origin: string): Promise<void> {
+  let lastSeq = await readLastSeq();
+  for (;;) {
+    try {
+      const url = notificationEventsURL(origin);
+      const headers: Record<string, string> = {};
+      if (lastSeq > 0) {
+        headers["Last-Event-ID"] = String(lastSeq);
+      }
+      const response = await fetch(url, { headers });
+      if (!response.ok || response.body === null) {
+        throw new Error(`SSE failed with ${response.status}`);
+      }
+      for await (const event of readSSE(response.body)) {
+        if (event.id !== undefined) {
+          const seq = Number(event.id);
+          if (Number.isFinite(seq)) {
+            lastSeq = Math.max(lastSeq, seq);
+            await writeLastSeq(lastSeq);
+          }
+        }
+        if (event.event === "notification_created") {
+          await handleNotificationCreated(origin, event.data);
+        }
+      }
+    } catch (error) {
+      console.warn("AO notification SSE disconnected", error);
+      await delay(2_000);
+    }
+  }
+}
+
+async function handleNotificationCreated(origin: string, data: string): Promise<void> {
+  let event: CDCEvent<NotificationCreatedPayload>;
+  try {
+    event = JSON.parse(data) as CDCEvent<NotificationCreatedPayload>;
+  } catch (error) {
+    console.warn("Ignoring malformed notification SSE payload", error);
+    return;
+  }
+  const record = notificationRecordFromCDCEvent(event);
+  const key = `${record.id}:${event.seq}`;
+  if (shownNotifications.has(key) || !shouldShowDesktop(record)) {
+    return;
+  }
+  shownNotifications.add(key);
+  const payload = desktopPayloadFor(record);
+  const native = new ElectronNotification({
+    title: payload.title,
+    body: payload.body,
+    silent: payload.silent,
+    actions: payload.actions.map((action) => ({ type: "button" as const, text: action.label })),
+  });
+  nativeNotifications.add(native);
+  native.once("close", () => nativeNotifications.delete(native));
+  native.once("failed", (_event, error) => {
+    nativeNotifications.delete(native);
+    console.warn("AO desktop notification failed", error);
+  });
+  native.on("click", () => {
+    focusDashboard(payload.route);
+    void patchNotification(origin, record.id, { read: true }).catch((error) => {
+      console.warn("Failed to mark notification read after click", error);
+    });
+  });
+  native.on("action", (_event, index) => {
+    const action = payload.actions[index];
+    if (action !== undefined) {
+      void handleNativeAction(origin, record.id, action);
+    }
+  });
+  native.show();
+}
+
+async function handleNativeAction(origin: string, notificationId: string, action: NotificationAction): Promise<void> {
+  if (action.kind === "mark-read") {
+    await patchNotification(origin, notificationId, { read: true });
+    return;
+  }
+  if ((action.kind === "open-session" || action.kind === "restore-session") && action.route !== undefined) {
+    focusDashboard(action.route);
+  }
+  const token = process.env.AO_ACTION_TOKEN;
+  if (token !== undefined && token !== "") {
+    await invokeNotificationAction(origin, notificationId, action.id, token);
+  }
+}
+
+function focusDashboard(route?: string): void {
+  const window = mainWindow ?? createWindow();
+  if (route !== undefined && isSafeInternalRoute(route)) {
+    void window.loadURL(new URL(route, daemonOrigin).toString());
+  }
+  if (window.isMinimized()) {
+    window.restore();
+  }
+  window.show();
+  window.focus();
+}
+
+interface SSEMessage {
+  id?: string;
+  event: string;
+  data: string;
+}
+
+async function* readSSE(body: ReadableStream<Uint8Array>): AsyncGenerator<SSEMessage> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      return;
+    }
+    buffer += decoder.decode(value, { stream: true });
+    let boundary = buffer.indexOf("\n\n");
+    while (boundary !== -1) {
+      const raw = buffer.slice(0, boundary);
+      buffer = buffer.slice(boundary + 2);
+      const parsed = parseSSEMessage(raw);
+      if (parsed !== undefined) {
+        yield parsed;
+      }
+      boundary = buffer.indexOf("\n\n");
+    }
+  }
+}
+
+function parseSSEMessage(raw: string): SSEMessage | undefined {
+  let id: string | undefined;
+  let event = "message";
+  const data: string[] = [];
+  for (const line of raw.split("\n")) {
+    if (line.startsWith(":") || line === "") {
+      continue;
+    }
+    if (line.startsWith("id:")) {
+      id = line.slice(3).trimStart();
+    } else if (line.startsWith("event:")) {
+      event = line.slice(6).trimStart();
+    } else if (line.startsWith("data:")) {
+      data.push(line.slice(5).trimStart());
+    }
+  }
+  if (data.length === 0) {
+    return undefined;
+  }
+  return { id, event, data: data.join("\n") };
+}
+
+function daemonOriginFromEnv(): string {
+  if (process.env.AO_DAEMON_ORIGIN !== undefined && process.env.AO_DAEMON_ORIGIN !== "") {
+    const candidate = process.env.AO_DAEMON_ORIGIN;
+    if (isLoopbackOrigin(candidate)) {
+      return candidate;
+    }
+    console.warn("Ignoring non-loopback AO_DAEMON_ORIGIN");
+  }
+  const port = process.env.AO_PORT ?? "3001";
+  return `http://127.0.0.1:${port}`;
+}
+
+function isLoopbackOrigin(raw: string): boolean {
+  try {
+    const url = new URL(raw);
+    return url.protocol === "http:" && ["127.0.0.1", "localhost", "[::1]"].includes(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+async function waitForDaemonReady(origin: string): Promise<void> {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    try {
+      const response = await fetch(new URL("/readyz", origin));
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Daemon may still be starting.
+    }
+    await delay(500);
+  }
+}
+
+function statePath(): string {
+  return join(app.getPath("userData"), "notification-state.json");
+}
+
+async function readLastSeq(): Promise<number> {
+  try {
+    const parsed = JSON.parse(await readFile(statePath(), "utf8")) as { lastSeq?: number };
+    return typeof parsed.lastSeq === "number" && Number.isFinite(parsed.lastSeq) ? parsed.lastSeq : 0;
+  } catch {
+    return 0;
+  }
+}
+
+async function writeLastSeq(lastSeq: number): Promise<void> {
+  const path = statePath();
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify({ lastSeq })}\n`, "utf8");
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/frontend/src/notification-state.test.ts
+++ b/frontend/src/notification-state.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  initialNotificationState,
+  notificationReducer,
+  visibleNotifications,
+} from "./notification-state";
+import { CDCEvent, NotificationCreatedPayload, NotificationRecord } from "./notifications";
+
+test("notification reducer handles snapshot, unread badge, and filters", () => {
+  const records = [record("n1", "urgent", null), record("n2", "info", "2026-05-31T10:31:00Z")];
+  const state = notificationReducer(initialNotificationState(), {
+    type: "snapshot",
+    snapshot: { notifications: records, unreadCount: 1, limit: 50, nextBeforeSeq: null },
+  });
+  assert.equal(state.status, "ready");
+  assert.equal(state.unreadCount, 1);
+
+  const unread = notificationReducer(state, { type: "set-filter", filter: "unread" });
+  assert.deepEqual(
+    visibleNotifications(unread).map((item) => item.id),
+    ["n1"],
+  );
+});
+
+test("notification reducer appends created and patches updated SSE events", () => {
+  let state = notificationReducer(initialNotificationState(), {
+    type: "snapshot",
+    snapshot: { notifications: [], unreadCount: 0, limit: 50, nextBeforeSeq: null },
+  });
+  state = notificationReducer(state, { type: "sse", event: createdEvent("n3") });
+  assert.equal(state.records[0]?.id, "n3");
+  assert.equal(state.unreadCount, 1);
+
+  state = notificationReducer(state, {
+    type: "sse",
+    event: {
+      seq: 11,
+      projectId: "ao",
+      sessionId: "ao-1",
+      type: "notification_updated",
+      createdAt: "2026-05-31T10:32:00Z",
+      payload: { seq: 3, id: "n3", readAt: "2026-05-31T10:32:00Z" },
+    },
+  });
+  assert.equal(state.records[0]?.readAt, "2026-05-31T10:32:00Z");
+  assert.equal(state.unreadCount, 0);
+});
+
+test("notification reducer keeps stale records visible while reconnecting or erroring", () => {
+  let state = notificationReducer(initialNotificationState(), {
+    type: "snapshot",
+    snapshot: { notifications: [record("n1", "urgent", null)], unreadCount: 1, limit: 50, nextBeforeSeq: null },
+  });
+  state = notificationReducer(state, { type: "reconnecting" });
+  assert.equal(state.status, "reconnecting");
+  assert.equal(visibleNotifications(state).length, 1);
+
+  state = notificationReducer(state, { type: "error", message: "boom" });
+  assert.equal(state.status, "error");
+  assert.equal(visibleNotifications(state).length, 1);
+});
+
+function record(id: string, priority: NotificationRecord["event"]["priority"], readAt: string | null): NotificationRecord {
+  return {
+    seq: Number(id.replace("n", "")),
+    id,
+    receivedAt: "2026-05-31T10:30:00Z",
+    readAt,
+    archivedAt: null,
+    event: {
+      id,
+      type: "session.needs_input",
+      priority,
+      sessionId: "ao-1",
+      projectId: "ao",
+      timestamp: "2026-05-31T10:30:00Z",
+      message: "Agent needs input.",
+      data: {},
+    },
+    actions: [{ id: "open-session", kind: "open-session", label: "Open session", route: "/projects/ao/sessions/ao-1" }],
+  };
+}
+
+function createdEvent(id: string): CDCEvent<NotificationCreatedPayload> {
+  return {
+    seq: 10,
+    projectId: "ao",
+    sessionId: "ao-1",
+    type: "notification_created",
+    createdAt: "2026-05-31T10:31:00Z",
+    payload: {
+      seq: 3,
+      id,
+      type: "session.needs_input",
+      priority: "urgent",
+      message: "Agent needs input.",
+      data: {},
+      actions: [{ id: "open-session", kind: "open-session", label: "Open session", route: "/projects/ao/sessions/ao-1" }],
+      readAt: null,
+      archivedAt: null,
+    },
+  };
+}

--- a/frontend/src/notification-state.ts
+++ b/frontend/src/notification-state.ts
@@ -1,0 +1,114 @@
+import {
+  CDCEvent,
+  NotificationCreatedPayload,
+  NotificationListResponse,
+  NotificationRecord,
+  NotificationUpdatedPayload,
+  notificationRecordFromCDCEvent,
+  patchNotificationRecord,
+  reconcileNotification,
+  unreadCount,
+} from "./notifications";
+
+export type NotificationStatus = "loading" | "ready" | "empty-all" | "empty-unread" | "error" | "reconnecting";
+export type NotificationFilter = "all" | "unread";
+export type ActionStatus = "pending" | "success" | "failure";
+
+export interface NotificationState {
+  status: NotificationStatus;
+  filter: NotificationFilter;
+  records: NotificationRecord[];
+  unreadCount: number;
+  error?: string;
+  actionStatus: Record<string, ActionStatus>;
+}
+
+export type NotificationStateAction =
+  | { type: "snapshot"; snapshot: NotificationListResponse }
+  | { type: "sse"; event: CDCEvent<NotificationCreatedPayload | NotificationUpdatedPayload> }
+  | { type: "set-filter"; filter: NotificationFilter }
+  | { type: "mark-read"; id: string; readAt: string }
+  | { type: "mark-all-read"; readAt: string; projectId?: string; sessionId?: string }
+  | { type: "dismiss"; id: string; archivedAt: string }
+  | { type: "error"; message: string }
+  | { type: "reconnecting" }
+  | { type: "action-status"; key: string; status: ActionStatus };
+
+export function initialNotificationState(filter: NotificationFilter = "all"): NotificationState {
+  return {
+    status: "loading",
+    filter,
+    records: [],
+    unreadCount: 0,
+    actionStatus: {},
+  };
+}
+
+export function notificationReducer(state: NotificationState, action: NotificationStateAction): NotificationState {
+  switch (action.type) {
+    case "snapshot":
+      return withDerivedStatus({
+        ...state,
+        records: action.snapshot.notifications,
+        unreadCount: action.snapshot.unreadCount,
+        error: undefined,
+      });
+    case "sse":
+      if (action.event.type === "notification_created") {
+        const incoming = notificationRecordFromCDCEvent(action.event as CDCEvent<NotificationCreatedPayload>);
+        return withDerivedStatus({
+          ...state,
+          records: reconcileNotification(state.records, incoming),
+          unreadCount: unreadCount(reconcileNotification(state.records, incoming)),
+        });
+      }
+      if (action.event.type === "notification_updated") {
+        const records = patchNotificationRecord(state.records, action.event.payload as NotificationUpdatedPayload);
+        return withDerivedStatus({ ...state, records, unreadCount: unreadCount(records) });
+      }
+      return state;
+    case "set-filter":
+      return withDerivedStatus({ ...state, filter: action.filter });
+    case "mark-read": {
+      const records = state.records.map((record) => (record.id === action.id ? { ...record, readAt: action.readAt } : record));
+      return withDerivedStatus({ ...state, records, unreadCount: unreadCount(records) });
+    }
+    case "mark-all-read": {
+      const records = state.records.map((record) => {
+        const projectMatches = action.projectId === undefined || record.event.projectId === action.projectId;
+        const sessionMatches = action.sessionId === undefined || record.event.sessionId === action.sessionId;
+        return projectMatches && sessionMatches && record.archivedAt === null ? { ...record, readAt: action.readAt } : record;
+      });
+      return withDerivedStatus({ ...state, records, unreadCount: unreadCount(records) });
+    }
+    case "dismiss": {
+      const records = state.records.map((record) => (record.id === action.id ? { ...record, archivedAt: action.archivedAt } : record));
+      return withDerivedStatus({ ...state, records, unreadCount: unreadCount(records) });
+    }
+    case "error":
+      return { ...state, status: "error", error: action.message };
+    case "reconnecting":
+      return { ...state, status: "reconnecting" };
+    case "action-status":
+      return { ...state, actionStatus: { ...state.actionStatus, [action.key]: action.status } };
+  }
+}
+
+export function visibleNotifications(state: NotificationState): NotificationRecord[] {
+  const active = state.records.filter((record) => record.archivedAt === null);
+  if (state.filter === "unread") {
+    return active.filter((record) => record.readAt === null);
+  }
+  return active;
+}
+
+export function withDerivedStatus(state: NotificationState): NotificationState {
+  const visible = visibleNotifications(state);
+  let status: NotificationStatus = "ready";
+  if (state.filter === "unread" && visible.length === 0) {
+    status = "empty-unread";
+  } else if (state.filter === "all" && visible.length === 0) {
+    status = "empty-all";
+  }
+  return { ...state, status };
+}

--- a/frontend/src/notifications.test.ts
+++ b/frontend/src/notifications.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  desktopPayloadFor,
+  isSafeExternalUrl,
+  isSafeInternalRoute,
+  notificationEventsURL,
+  notificationRecordFromCDCEvent,
+  shouldShowDesktop,
+  type CDCEvent,
+  type NotificationCreatedPayload,
+  type NotificationRecord,
+} from "./notifications";
+
+test("safe link helpers reject unsafe internal and external targets", () => {
+  assert.equal(isSafeInternalRoute("/projects/ao/sessions/ao-1"), true);
+  assert.equal(isSafeInternalRoute("javascript:alert(1)"), false);
+  assert.equal(isSafeInternalRoute("//evil.example"), false);
+  assert.equal(isSafeInternalRoute("/projects\\ao"), false);
+
+  assert.equal(isSafeExternalUrl("https://github.com/aoagents/agent-orchestrator/pull/1"), true);
+  assert.equal(isSafeExternalUrl("https://linear.app/ao/issue/AO-1"), true);
+  assert.equal(isSafeExternalUrl("javascript:alert(1)"), false);
+  assert.equal(isSafeExternalUrl("data:text/plain,hi"), false);
+  assert.equal(isSafeExternalUrl("http://github.com/aoagents/agent-orchestrator/pull/1"), false);
+  assert.equal(isSafeExternalUrl("https://example.com/pr/1"), false);
+});
+
+test("desktop eligibility and payload follow priority defaults", () => {
+  const urgent = record("urgent");
+  assert.equal(shouldShowDesktop(urgent), true);
+  assert.equal(desktopPayloadFor(urgent).silent, false);
+  assert.equal(desktopPayloadFor(urgent).route, "/projects/ao/sessions/ao-1");
+
+  const action = { ...urgent, event: { ...urgent.event, priority: "action" as const } };
+  assert.equal(shouldShowDesktop(action), true);
+  assert.equal(desktopPayloadFor(action).silent, true);
+
+  const warning = { ...urgent, event: { ...urgent.event, priority: "warning" as const } };
+  assert.equal(shouldShowDesktop(warning), false);
+});
+
+test("CDC notification_created converts to dashboard record and drops unsafe actions", () => {
+  const event: CDCEvent<NotificationCreatedPayload> = {
+    seq: 100,
+    projectId: "ao",
+    sessionId: "ao-1",
+    type: "notification_created",
+    createdAt: "2026-05-31T10:30:00Z",
+    payload: {
+      seq: 7,
+      id: "ntf_7",
+      type: "session.needs_input",
+      priority: "urgent",
+      message: "Agent needs input.",
+      data: {},
+      actions: [
+        { id: "open-session", kind: "open-session", label: "Open", route: "/projects/ao/sessions/ao-1" },
+        { id: "open-pr", kind: "open-pr", label: "PR", url: "http://github.com/not/https" },
+      ],
+    },
+  };
+  const converted = notificationRecordFromCDCEvent(event);
+  assert.equal(converted.id, "ntf_7");
+  assert.equal(converted.actions.length, 1);
+  assert.equal(converted.actions[0]?.kind, "open-session");
+});
+
+test("notificationEventsURL targets notification SSE topic with optional replay cursor", () => {
+  const url = notificationEventsURL("http://127.0.0.1:3001", { after: 42, projectId: "ao" });
+  assert.equal(url, "http://127.0.0.1:3001/events?after=42&projectId=ao&topics=notifications");
+});
+
+test("frontend production code does not call legacy external notification backends", () => {
+  const productionFiles = ["main.js", "notifications.js", "notification-state.js"];
+  const banned = ["terminal-notifier", "osascript", "notify-send", "powershell.exe", "Slack", "Discord", "webhook"];
+  for (const file of productionFiles) {
+    const source = readFileSync(join(__dirname, file), "utf8");
+    for (const token of banned) {
+      assert.equal(source.includes(token), false, `${file} unexpectedly references ${token}`);
+    }
+  }
+});
+
+function record(priority: NotificationRecord["event"]["priority"]): NotificationRecord {
+  return {
+    seq: 1,
+    id: "ntf_1",
+    receivedAt: "2026-05-31T10:30:00Z",
+    readAt: null,
+    archivedAt: null,
+    event: {
+      id: "ntf_1",
+      type: "session.needs_input",
+      priority,
+      sessionId: "ao-1",
+      projectId: "ao",
+      timestamp: "2026-05-31T10:30:00Z",
+      message: "Agent needs input.",
+      data: {},
+    },
+    actions: [{ id: "open-session", kind: "open-session", label: "Open session", route: "/projects/ao/sessions/ao-1" }],
+  };
+}

--- a/frontend/src/notifications.ts
+++ b/frontend/src/notifications.ts
@@ -1,0 +1,328 @@
+export type NotificationPriority = "urgent" | "action" | "warning" | "info";
+
+export type NotificationActionKind =
+  | "open-session"
+  | "open-pr"
+  | "open-review"
+  | "open-ci"
+  | "restore-session"
+  | "send-message"
+  | "merge-pr"
+  | "mark-read"
+  | "dismiss";
+
+export interface NotificationAction {
+  id: string;
+  kind: NotificationActionKind;
+  label: string;
+  route?: string;
+  url?: string;
+}
+
+export interface NotificationEventBody {
+  id: string;
+  type: string;
+  priority: NotificationPriority;
+  sessionId: string;
+  projectId: string;
+  timestamp: string;
+  message: string;
+  data: Record<string, unknown>;
+}
+
+export interface NotificationRecord {
+  seq: number;
+  id: string;
+  receivedAt: string;
+  readAt: string | null;
+  archivedAt: string | null;
+  event: NotificationEventBody;
+  actions: NotificationAction[];
+}
+
+export interface NotificationListResponse {
+  notifications: NotificationRecord[];
+  unreadCount: number;
+  limit: number;
+  nextBeforeSeq: number | null;
+}
+
+export interface CDCEvent<TPayload = unknown> {
+  seq: number;
+  projectId: string;
+  sessionId?: string;
+  type: string;
+  payload: TPayload;
+  createdAt: string;
+}
+
+export interface NotificationCreatedPayload {
+  seq: number;
+  id: string;
+  type: string;
+  priority: NotificationPriority;
+  message: string;
+  data?: Record<string, unknown>;
+  actions?: NotificationAction[];
+  readAt?: string | null;
+  archivedAt?: string | null;
+}
+
+export interface NotificationUpdatedPayload {
+  seq: number;
+  id: string;
+  readAt?: string | null;
+  archivedAt?: string | null;
+}
+
+export interface DesktopNotificationPayload {
+  title: string;
+  body: string;
+  silent: boolean;
+  actions: NotificationAction[];
+  route?: string;
+}
+
+const trustedExternalHosts = new Set(["github.com", "gitlab.com", "linear.app"]);
+const desktopActionAllowlist = new Set<NotificationActionKind>([
+  "open-session",
+  "open-pr",
+  "restore-session",
+  "mark-read",
+]);
+
+export function notificationRecordFromCDCEvent(
+  event: CDCEvent<NotificationCreatedPayload>,
+): NotificationRecord {
+  return {
+    seq: event.payload.seq,
+    id: event.payload.id,
+    receivedAt: event.createdAt,
+    readAt: event.payload.readAt ?? null,
+    archivedAt: event.payload.archivedAt ?? null,
+    event: {
+      id: event.payload.id,
+      type: event.payload.type,
+      priority: event.payload.priority,
+      sessionId: event.sessionId ?? "",
+      projectId: event.projectId,
+      timestamp: event.createdAt,
+      message: event.payload.message,
+      data: event.payload.data ?? {},
+    },
+    actions: sanitizeActions(event.payload.actions ?? []),
+  };
+}
+
+export function sanitizeActions(actions: NotificationAction[]): NotificationAction[] {
+  return actions.filter((action) => {
+    if (!desktopActionAllowlist.has(action.kind) && action.kind !== "open-review" && action.kind !== "open-ci" && action.kind !== "merge-pr" && action.kind !== "send-message" && action.kind !== "dismiss") {
+      return false;
+    }
+    if (action.route !== undefined && !isSafeInternalRoute(action.route)) {
+      return false;
+    }
+    if (action.url !== undefined && !isSafeExternalUrl(action.url)) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function isSafeInternalRoute(route: string): boolean {
+  if (!route.startsWith("/") || route.startsWith("//") || route.includes("\\")) {
+    return false;
+  }
+  try {
+    const parsed = new URL(route, "http://ao.local");
+    return parsed.origin === "http://ao.local" && !route.includes("\n") && !route.includes("\r");
+  } catch {
+    return false;
+  }
+}
+
+export function isSafeExternalUrl(raw: string): boolean {
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "https:") {
+      return false;
+    }
+    const host = url.hostname.toLowerCase();
+    for (const allowed of trustedExternalHosts) {
+      if (host === allowed || host.endsWith(`.${allowed}`)) {
+        return true;
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+export function shouldShowDesktop(record: NotificationRecord): boolean {
+  if (record.archivedAt !== null || record.readAt !== null) {
+    return false;
+  }
+  return record.event.priority === "urgent" || record.event.priority === "action";
+}
+
+export function desktopPayloadFor(record: NotificationRecord): DesktopNotificationPayload {
+  const lowRiskActions = record.actions.filter((action) => desktopActionAllowlist.has(action.kind));
+  if (!lowRiskActions.some((action) => action.kind === "mark-read")) {
+    lowRiskActions.push({ id: "mark-read", kind: "mark-read", label: "Mark read" });
+  }
+  const openSession = record.actions.find((action) => action.kind === "open-session" && action.route !== undefined);
+  return {
+    title: titleFor(record),
+    body: record.event.message,
+    silent: record.event.priority !== "urgent",
+    actions: lowRiskActions,
+    route: openSession?.route,
+  };
+}
+
+export function titleFor(record: NotificationRecord): string {
+  switch (record.event.priority) {
+    case "urgent":
+      return "AO needs attention";
+    case "action":
+      return "AO action available";
+    case "warning":
+      return "AO warning";
+    case "info":
+      return "AO update";
+  }
+}
+
+export function reconcileNotification(
+  records: NotificationRecord[],
+  incoming: NotificationRecord,
+): NotificationRecord[] {
+  const idx = records.findIndex((record) => record.id === incoming.id);
+  if (idx === -1) {
+    return [incoming, ...records];
+  }
+  const next = records.slice();
+  next[idx] = incoming;
+  return next;
+}
+
+export function patchNotificationRecord(
+  records: NotificationRecord[],
+  patch: NotificationUpdatedPayload,
+): NotificationRecord[] {
+  return records.map((record) =>
+    record.id === patch.id
+      ? {
+          ...record,
+          readAt: patch.readAt === undefined ? record.readAt : patch.readAt,
+          archivedAt: patch.archivedAt === undefined ? record.archivedAt : patch.archivedAt,
+        }
+      : record,
+  );
+}
+
+export function unreadCount(records: NotificationRecord[]): number {
+  return records.filter((record) => record.readAt === null && record.archivedAt === null).length;
+}
+
+export function notificationRoute(record: NotificationRecord): string | undefined {
+  const action = record.actions.find((candidate) => candidate.kind === "open-session" && candidate.route !== undefined);
+  return action?.route;
+}
+
+export async function fetchNotifications(
+  origin: string,
+  query: Record<string, string | number | boolean | undefined> = {},
+  fetchImpl: typeof fetch = fetch,
+): Promise<NotificationListResponse> {
+  const url = new URL("/api/v1/notifications", origin);
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(`GET notifications failed with ${response.status}`);
+  }
+  return (await response.json()) as NotificationListResponse;
+}
+
+export function notificationEventsURL(
+  origin: string,
+  options: { after?: number; projectId?: string; topics?: string[] } = {},
+): string {
+  const url = new URL("/events", origin);
+  if (options.after !== undefined) {
+    url.searchParams.set("after", String(options.after));
+  }
+  if (options.projectId !== undefined) {
+    url.searchParams.set("projectId", options.projectId);
+  }
+  url.searchParams.set("topics", (options.topics ?? ["notifications"]).join(","));
+  return url.toString();
+}
+
+export function openNotificationEventSource(
+  origin: string,
+  options: { after?: number; projectId?: string } = {},
+): EventSource {
+  return new EventSource(notificationEventsURL(origin, { ...options, topics: ["notifications"] }));
+}
+
+export async function patchNotification(
+  origin: string,
+  id: string,
+  body: { read?: boolean; archived?: boolean },
+  fetchImpl: typeof fetch = fetch,
+): Promise<NotificationRecord> {
+  const response = await fetchImpl(new URL(`/api/v1/notifications/${encodeURIComponent(id)}`, origin), {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`PATCH notification failed with ${response.status}`);
+  }
+  const payload = (await response.json()) as { notification: NotificationRecord };
+  return payload.notification;
+}
+
+export async function readAllNotifications(
+  origin: string,
+  body: { projectId?: string; sessionId?: string } = {},
+  fetchImpl: typeof fetch = fetch,
+): Promise<number> {
+  const response = await fetchImpl(new URL("/api/v1/notifications/read-all", origin), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`read-all failed with ${response.status}`);
+  }
+  const payload = (await response.json()) as { updated: number };
+  return payload.updated;
+}
+
+export async function invokeNotificationAction(
+  origin: string,
+  notificationId: string,
+  actionId: string,
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<unknown> {
+  const response = await fetchImpl(
+    new URL(`/api/v1/notifications/${encodeURIComponent(notificationId)}/actions/${encodeURIComponent(actionId)}`, origin),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-AO-Action-Token": token },
+      body: "{}",
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`notification action failed with ${response.status}`);
+  }
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- add durable notification REST APIs for list/get/read/archive/read-all and allowlisted action execution
- add /events SSE replay/live streaming with filtering, heartbeats, and slow-client handling
- add dashboard notification state/client helpers plus Electron native desktop notification SSE handling

Closes #56

## Tests
- cd backend && go test ./...
- cd frontend && npm test