### PR TITLE
feat(daemon): wire Session Manager + agent shim + RepoResolver + inbox messenger

### DIFF
--- a/backend/internal/adapters/agent/agent.go
+++ b/backend/internal/adapters/agent/agent.go
@@ -30,6 +30,12 @@ type Agent interface {
 	SessionInfo(ctx context.Context, session SessionRef) (info SessionInfo, ok bool, err error)
 }
 
+// MetadataKeyAgentSessionID is the SessionRef.Metadata key under which every
+// adapter persists the native agent session id captured at launch and reads it
+// back during restore. The Better-AO portshim sets it so the underlying
+// adapter's GetRestoreCommand sees a unified location regardless of harness.
+const MetadataKeyAgentSessionID = "agentSessionId"
+
 // Config contains values loaded from the selected agent's config section.
 // Agent adapters own validation for their custom keys.
 type Config map[string]any

--- a/backend/internal/adapters/agent/claudecode/claudecode.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode.go
@@ -41,10 +41,8 @@ const (
 	// Normalized session-metadata keys the Claude Code hooks persist into the
 	// Better-AO session store and SessionInfo reads back. Shared vocabulary
 	// with the Codex adapter so the dashboard treats every agent uniformly.
-	// agentSessionId is also the preferred restore id.
-	claudeAgentSessionIDMetadataKey = "agentSessionId"
-	claudeTitleMetadataKey          = "title"
-	claudeSummaryMetadataKey        = "summary"
+	claudeTitleMetadataKey   = "title"
+	claudeSummaryMetadataKey = "summary"
 )
 
 // claudeSessionNamespace seeds the UUIDv5 derivation that maps a better-ao
@@ -179,7 +177,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg agent.RestoreConfig)
 		return nil, false, err
 	}
 
-	sessionID := strings.TrimSpace(cfg.Session.Metadata[claudeAgentSessionIDMetadataKey])
+	sessionID := strings.TrimSpace(cfg.Session.Metadata[agent.MetadataKeyAgentSessionID])
 	if sessionID == "" && cfg.Session.ID != "" {
 		// Explicit fallback for pre-hook sessions: the id better-ao
 		// deterministically pinned via --session-id at launch.
@@ -210,7 +208,7 @@ func (p *Plugin) SessionInfo(ctx context.Context, session agent.SessionRef) (age
 		return agent.SessionInfo{}, false, err
 	}
 	info := agent.SessionInfo{
-		AgentSessionID: session.Metadata[claudeAgentSessionIDMetadataKey],
+		AgentSessionID: session.Metadata[agent.MetadataKeyAgentSessionID],
 		Title:          session.Metadata[claudeTitleMetadataKey],
 		Summary:        session.Metadata[claudeSummaryMetadataKey],
 	}

--- a/backend/internal/adapters/agent/claudecode/claudecode_test.go
+++ b/backend/internal/adapters/agent/claudecode/claudecode_test.go
@@ -228,7 +228,7 @@ func TestSessionInfoReadsHookMetadata(t *testing.T) {
 	info, ok, err := (&Plugin{resolvedBinary: "claude"}).SessionInfo(context.Background(), agent.SessionRef{
 		WorkspacePath: "/some/path",
 		Metadata: map[string]string{
-			claudeAgentSessionIDMetadataKey: "claude-native-1",
+			agent.MetadataKeyAgentSessionID: "claude-native-1",
 			claudeTitleMetadataKey:          "Fix login redirect",
 			claudeSummaryMetadataKey:        "Updated the auth callback and tests.",
 			"ignored":                       "not returned",
@@ -299,7 +299,7 @@ func TestGetRestoreCommandReadsAgentSessionID(t *testing.T) {
 		Permissions: agent.PermissionModeBypassPermissions,
 		Session: agent.SessionRef{
 			ID:       "sess-r",
-			Metadata: map[string]string{claudeAgentSessionIDMetadataKey: "claude-native-1"},
+			Metadata: map[string]string{agent.MetadataKeyAgentSessionID: "claude-native-1"},
 		},
 	})
 	if err != nil || !ok {
@@ -334,7 +334,7 @@ func TestGetRestoreCommandFalseWithoutSessionID(t *testing.T) {
 		ref  agent.SessionRef
 	}{
 		{"empty ref", agent.SessionRef{}},
-		{"blank agent session, no id", agent.SessionRef{Metadata: map[string]string{claudeAgentSessionIDMetadataKey: "   "}}},
+		{"blank agent session, no id", agent.SessionRef{Metadata: map[string]string{agent.MetadataKeyAgentSessionID: "   "}}},
 		{"workspace path only", agent.SessionRef{WorkspacePath: "/some/path"}},
 	}
 	for _, tc := range cases {

--- a/backend/internal/adapters/agent/codex/codex.go
+++ b/backend/internal/adapters/agent/codex/codex.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	codexAgentSessionIDMetadataKey = "agentSessionId"
+	codexAgentSessionIDMetadataKey = agent.MetadataKeyAgentSessionID
 	codexTitleMetadataKey          = "title"
 	codexSummaryMetadataKey        = "summary"
 )

--- a/backend/internal/adapters/agent/portshim/shim.go
+++ b/backend/internal/adapters/agent/portshim/shim.go
@@ -1,0 +1,114 @@
+// Package portshim bridges the richer adapters/agent.Agent interface onto the
+// narrower ports.Agent the Session Manager consumes. The richer interface
+// returns argv slices and takes a context; ports.Agent returns a single shell
+// string and is context-free. The shim joins argv with POSIX shell quoting so
+// the zellij runtime, which evaluates LaunchCommand under `sh -lc`, sees the
+// agent's argv intact.
+package portshim
+
+import (
+	"context"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// Shim wraps an adapters/agent.Agent and satisfies ports.Agent. The shim is
+// context-free at its API surface; it threads context.Background() into the
+// richer interface. That matches the existing ports.Agent shape — extending it
+// is a separate change.
+type Shim struct {
+	agent agent.Agent
+}
+
+// New constructs a Shim. agent is required; nil is not supported.
+func New(a agent.Agent) *Shim { return &Shim{agent: a} }
+
+var _ ports.Agent = (*Shim)(nil)
+
+// GetLaunchCommand asks the wrapped agent for its launch argv and renders it as
+// a single POSIX-shell-safe string. An adapter error or empty argv yields "".
+func (s *Shim) GetLaunchCommand(cfg ports.AgentConfig) string {
+	argv, err := s.agent.GetLaunchCommand(context.Background(), launchConfigFor(cfg))
+	if err != nil {
+		return ""
+	}
+	return joinShellArgv(argv)
+}
+
+// GetEnvironment returns nil: the richer agent interface doesn't carry the env
+// keys ports.AgentConfig exposes, and the SM layers AO_SESSION_ID,
+// AO_PROJECT_ID, AO_ISSUE_ID on top of whatever the agent contributes. A nil
+// map is fine here — session.spawnEnv treats nil as empty.
+func (s *Shim) GetEnvironment(ports.AgentConfig) map[string]string {
+	return nil
+}
+
+// GetRestoreCommand resumes a native agent session given its agentSessionID and
+// returns the resume command as a POSIX-shell-safe string. An adapter error or
+// ok=false yields "" — the SM falls back to a fresh Spawn.
+func (s *Shim) GetRestoreCommand(agentSessionID string) string {
+	cfg := agent.RestoreConfig{
+		Session: agent.SessionRef{
+			ID: agentSessionID,
+			Metadata: map[string]string{
+				agent.MetadataKeyAgentSessionID: agentSessionID,
+			},
+		},
+	}
+	argv, ok, err := s.agent.GetRestoreCommand(context.Background(), cfg)
+	if err != nil || !ok {
+		return ""
+	}
+	return joinShellArgv(argv)
+}
+
+func launchConfigFor(cfg ports.AgentConfig) agent.LaunchConfig {
+	return agent.LaunchConfig{
+		SessionID:     string(cfg.SessionID),
+		WorkspacePath: cfg.WorkspacePath,
+		Prompt:        cfg.Prompt,
+	}
+}
+
+// joinShellArgv renders argv as a single string the POSIX shell will re-parse
+// into the same tokens. Each arg is quoted in single quotes unless it consists
+// only of characters guaranteed safe to leave bare.
+func joinShellArgv(argv []string) string {
+	if len(argv) == 0 {
+		return ""
+	}
+	parts := make([]string, len(argv))
+	for i, a := range argv {
+		parts[i] = shellQuote(a)
+	}
+	return strings.Join(parts, " ")
+}
+
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if isShellSafe(s) {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// isShellSafe matches the conservative bash-completion convention: letters,
+// digits, and a handful of punctuation that never trigger expansion or word
+// splitting. Anything else is quoted.
+func isShellSafe(s string) bool {
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '-', r == '_', r == '/', r == '.', r == ',', r == ':', r == '+', r == '@', r == '=':
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/backend/internal/adapters/agent/portshim/shim_test.go
+++ b/backend/internal/adapters/agent/portshim/shim_test.go
@@ -1,0 +1,164 @@
+package portshim_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/portshim"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/aoagents/agent-orchestrator/backend/internal/session"
+)
+
+type fakeAgent struct {
+	launchCmd     []string
+	launchErr     error
+	restoreCmd    []string
+	restoreOK     bool
+	restoreErr    error
+	gotLaunchCfg  agent.LaunchConfig
+	gotRestoreCfg agent.RestoreConfig
+}
+
+func (f *fakeAgent) GetConfigSpec(context.Context) (agent.ConfigSpec, error) {
+	return agent.ConfigSpec{}, nil
+}
+func (f *fakeAgent) GetLaunchCommand(_ context.Context, cfg agent.LaunchConfig) ([]string, error) {
+	f.gotLaunchCfg = cfg
+	return f.launchCmd, f.launchErr
+}
+func (f *fakeAgent) GetPromptDeliveryStrategy(context.Context, agent.LaunchConfig) (agent.PromptDeliveryStrategy, error) {
+	return agent.PromptDeliveryInCommand, nil
+}
+func (f *fakeAgent) GetAgentHooks(context.Context, agent.WorkspaceHookConfig) error { return nil }
+func (f *fakeAgent) GetRestoreCommand(_ context.Context, cfg agent.RestoreConfig) ([]string, bool, error) {
+	f.gotRestoreCfg = cfg
+	return f.restoreCmd, f.restoreOK, f.restoreErr
+}
+func (f *fakeAgent) SessionInfo(context.Context, agent.SessionRef) (agent.SessionInfo, bool, error) {
+	return agent.SessionInfo{}, false, nil
+}
+
+func TestSatisfiesPortsAgent(t *testing.T) {
+	var _ ports.Agent = (*portshim.Shim)(nil)
+}
+
+func TestGetLaunchCommand_JoinsArgvShellSafely(t *testing.T) {
+	tests := []struct {
+		name string
+		argv []string
+		want string
+	}{
+		{"simple", []string{"claude"}, "claude"},
+		{"flags and prompt", []string{"claude", "--", "do it"}, "claude -- 'do it'"},
+		{"path with spaces", []string{"/Applications/My App/claude", "--flag"}, "'/Applications/My App/claude' --flag"},
+		{"prompt with single quote", []string{"claude", "--", "it's fine"}, `claude -- 'it'\''s fine'`},
+		{"empty argv", []string{}, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := portshim.New(&fakeAgent{launchCmd: tc.argv})
+			got := s.GetLaunchCommand(ports.AgentConfig{})
+			if got != tc.want {
+				t.Fatalf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetLaunchCommand_PropagatesAgentConfig(t *testing.T) {
+	fake := &fakeAgent{launchCmd: []string{"claude"}}
+	s := portshim.New(fake)
+	cfg := ports.AgentConfig{SessionID: "p-1", WorkspacePath: "/ws/p-1", Prompt: "hello"}
+	_ = s.GetLaunchCommand(cfg)
+	if fake.gotLaunchCfg.SessionID != "p-1" {
+		t.Errorf("SessionID not propagated: %+v", fake.gotLaunchCfg)
+	}
+	if fake.gotLaunchCfg.WorkspacePath != "/ws/p-1" {
+		t.Errorf("WorkspacePath not propagated: %+v", fake.gotLaunchCfg)
+	}
+	if fake.gotLaunchCfg.Prompt != "hello" {
+		t.Errorf("Prompt not propagated: %+v", fake.gotLaunchCfg)
+	}
+}
+
+func TestGetLaunchCommand_AgentErrorReturnsEmpty(t *testing.T) {
+	fake := &fakeAgent{launchErr: errors.New("boom")}
+	s := portshim.New(fake)
+	got := s.GetLaunchCommand(ports.AgentConfig{SessionID: "p-1"})
+	if got != "" {
+		t.Fatalf("expected empty on error, got %q", got)
+	}
+}
+
+func TestGetEnvironment_ReturnsAgentEnvKeysOnly(t *testing.T) {
+	// The richer Agent interface doesn't carry the env keys the SM port supplies,
+	// so the shim has nothing agent-specific to surface. SM layers AO_* on top.
+	s := portshim.New(&fakeAgent{})
+	got := s.GetEnvironment(ports.AgentConfig{SessionID: "p-1"})
+	if len(got) != 0 {
+		t.Fatalf("expected empty env from shim, got %v", got)
+	}
+	for _, k := range []string{session.EnvSessionID, session.EnvProjectID, session.EnvIssueID} {
+		if _, ok := got[k]; ok {
+			t.Errorf("shim must not pre-populate AO env key %s; SM owns it", k)
+		}
+	}
+}
+
+func TestGetRestoreCommand_JoinsWhenOK(t *testing.T) {
+	fake := &fakeAgent{restoreCmd: []string{"claude", "--resume", "abc 123"}, restoreOK: true}
+	s := portshim.New(fake)
+	got := s.GetRestoreCommand("abc 123")
+	want := `claude --resume 'abc 123'`
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+	if fake.gotRestoreCfg.Session.ID != "abc 123" {
+		t.Errorf("session id not propagated: %+v", fake.gotRestoreCfg)
+	}
+}
+
+func TestGetRestoreCommand_NotOKReturnsEmpty(t *testing.T) {
+	fake := &fakeAgent{restoreOK: false}
+	s := portshim.New(fake)
+	if got := s.GetRestoreCommand("anything"); got != "" {
+		t.Fatalf("expected empty when not restorable, got %q", got)
+	}
+}
+
+func TestGetRestoreCommand_ErrorReturnsEmpty(t *testing.T) {
+	fake := &fakeAgent{restoreErr: errors.New("boom")}
+	s := portshim.New(fake)
+	if got := s.GetRestoreCommand("x"); got != "" {
+		t.Fatalf("expected empty on restore error, got %q", got)
+	}
+}
+
+func TestGetRestoreCommand_PassesAgentSessionIDAsMetadata(t *testing.T) {
+	// Claude-code (and Codex) read the native session id off cfg.Session.Metadata
+	// ["agentSessionId"] to rebuild the --resume command. Pass it via both Session.ID
+	// (the legacy fallback) and Session.Metadata so the richer adapter can find it.
+	fake := &fakeAgent{restoreCmd: []string{"claude", "--resume", "x"}, restoreOK: true}
+	s := portshim.New(fake)
+	_ = s.GetRestoreCommand("native-uuid")
+	gotID := fake.gotRestoreCfg.Session.ID
+	if gotID != "native-uuid" {
+		t.Errorf("Session.ID want native-uuid, got %q", gotID)
+	}
+	if m := fake.gotRestoreCfg.Session.Metadata[agent.MetadataKeyAgentSessionID]; m != "native-uuid" {
+		t.Errorf("Session.Metadata[%s] want native-uuid, got %q", agent.MetadataKeyAgentSessionID, m)
+	}
+}
+
+func TestShellQuotingDoesNotDoubleQuoteSafeStrings(t *testing.T) {
+	// Safe identifiers (letters, digits, dash, dot, slash, underscore) should
+	// pass through unquoted; quoting them would inflate every command.
+	s := portshim.New(&fakeAgent{launchCmd: []string{"/usr/local/bin/claude", "--session-id", "abc-123_xyz.uuid"}})
+	got := s.GetLaunchCommand(ports.AgentConfig{})
+	if strings.Contains(got, "'") {
+		t.Fatalf("got unexpected quotes: %q", got)
+	}
+}

--- a/backend/internal/adapters/messenger/inbox/inbox.go
+++ b/backend/internal/adapters/messenger/inbox/inbox.go
@@ -1,0 +1,110 @@
+// Package inbox implements ports.AgentMessenger by writing each message as a
+// file in <session-workspace>/.ao/inbox/. The agent reads its inbox on demand;
+// pinging the runtime pane to consume new files is a separate concern that
+// lives in the runtime adapter, not here.
+package inbox
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// SessionWorkspace resolves a session id to the absolute path of its workspace.
+// The sqlite store satisfies this via GetSession; the adapter is in
+// daemon/session_wiring.go.
+type SessionWorkspace interface {
+	WorkspacePath(ctx context.Context, id domain.SessionID) (string, error)
+}
+
+// Messenger writes inbox files into per-session workspaces.
+type Messenger struct {
+	lookup SessionWorkspace
+	clock  func() time.Time
+}
+
+// New builds a Messenger over the given workspace lookup. lookup is required.
+func New(lookup SessionWorkspace) *Messenger {
+	return &Messenger{lookup: lookup, clock: time.Now}
+}
+
+var _ ports.AgentMessenger = (*Messenger)(nil)
+
+// Send writes message into <workspace>/.ao/inbox/<unix-nano>_<sha256-prefix>.md.
+//
+// Filename collisions are practically impossible: nanosecond timestamp plus an
+// 8-char hash of the body. We do not retry on EEXIST.
+//
+// Symlink safety: if .ao or .ao/inbox already exists as a symlink, refuse.
+// Otherwise os.MkdirAll creates real directories and os.WriteFile (which uses
+// O_CREATE|O_WRONLY|O_TRUNC without O_NOFOLLOW) writes the message body. The
+// inbox is owned by ao; a symlink there is either user misconfig or attack.
+func (m *Messenger) Send(ctx context.Context, id domain.SessionID, message string) error {
+	ws, err := m.lookup.WorkspacePath(ctx, id)
+	if err != nil {
+		return fmt.Errorf("inbox: lookup workspace for %s: %w", id, err)
+	}
+	if ws == "" {
+		return fmt.Errorf("inbox: empty workspace path for %s", id)
+	}
+
+	aoDir := filepath.Join(ws, ".ao")
+	if err := ensureRealDir(aoDir); err != nil {
+		return fmt.Errorf("inbox: prepare .ao for %s: %w", id, err)
+	}
+	inboxDir := filepath.Join(aoDir, "inbox")
+	if err := ensureRealDir(inboxDir); err != nil {
+		return fmt.Errorf("inbox: prepare inbox for %s: %w", id, err)
+	}
+
+	name := filenameFor(m.clock(), message)
+	if err := os.WriteFile(filepath.Join(inboxDir, name), []byte(message), 0o644); err != nil {
+		return fmt.Errorf("inbox: write %s for %s: %w", name, id, err)
+	}
+	return nil
+}
+
+// ensureRealDir creates path if missing (0755), refuses if path is a symlink.
+// Lstat (not Stat) is used so a symlink isn't followed into a different tree.
+//
+// The workspace root itself is not Lstat-checked because gitworktree.Workspace
+// resolves ManagedRoot to an absolute, symlink-free path at construction
+// (gitworktree.physicalAbs); per-session workspaces under it are created by ao.
+// A symlinked .ao or .ao/inbox inside an ao-owned workspace would be user
+// misconfig or attack, and is the only segment that can be tampered with
+// between Spawn and Send.
+func ensureRealDir(path string) error {
+	info, err := os.Lstat(path)
+	switch {
+	case err == nil:
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("%q is a symlink; refusing to follow", path)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("%q exists and is not a directory", path)
+		}
+		return nil
+	case errors.Is(err, os.ErrNotExist):
+		return os.MkdirAll(path, 0o755)
+	default:
+		return err
+	}
+}
+
+// filenameFor builds a sortable, collision-resistant name from the timestamp
+// and message body. Underscore separator keeps the timestamp's own dashes
+// distinguishable from the hash prefix.
+func filenameFor(t time.Time, message string) string {
+	sum := sha256.Sum256([]byte(message))
+	hash := hex.EncodeToString(sum[:])[:8]
+	return strconv.FormatInt(t.UnixNano(), 10) + "_" + hash + ".md"
+}

--- a/backend/internal/adapters/messenger/inbox/inbox_test.go
+++ b/backend/internal/adapters/messenger/inbox/inbox_test.go
@@ -1,0 +1,152 @@
+package inbox_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/inbox"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestSatisfiesAgentMessenger(t *testing.T) {
+	var _ ports.AgentMessenger = (*inbox.Messenger)(nil)
+}
+
+type fakeLookup struct {
+	path string
+	err  error
+}
+
+func (f fakeLookup) WorkspacePath(context.Context, domain.SessionID) (string, error) {
+	return f.path, f.err
+}
+
+func TestSend_WritesMessageFile(t *testing.T) {
+	dir := t.TempDir()
+	m := inbox.New(fakeLookup{path: dir})
+	if err := m.Send(context.Background(), "s-1", "hello agent"); err != nil {
+		t.Fatal(err)
+	}
+	inboxDir := filepath.Join(dir, ".ao", "inbox")
+	entries, err := os.ReadDir(inboxDir)
+	if err != nil {
+		t.Fatalf("inbox dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("want 1 file, got %d", len(entries))
+	}
+	name := entries[0].Name()
+	if !strings.HasSuffix(name, ".md") {
+		t.Errorf("want .md suffix, got %q", name)
+	}
+	body, err := os.ReadFile(filepath.Join(inboxDir, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "hello agent" {
+		t.Errorf("body %q want %q", body, "hello agent")
+	}
+}
+
+func TestSend_CreatesInboxDirIfMissing(t *testing.T) {
+	dir := t.TempDir()
+	// dir contains no .ao yet.
+	m := inbox.New(fakeLookup{path: dir})
+	if err := m.Send(context.Background(), "s-1", "x"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".ao", "inbox")); err != nil {
+		t.Fatalf("inbox dir not created: %v", err)
+	}
+}
+
+func TestSend_TwoSendsProduceTwoFiles(t *testing.T) {
+	dir := t.TempDir()
+	m := inbox.New(fakeLookup{path: dir})
+	ctx := context.Background()
+	if err := m.Send(ctx, "s-1", "first"); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Send(ctx, "s-1", "second"); err != nil {
+		t.Fatal(err)
+	}
+	entries, _ := os.ReadDir(filepath.Join(dir, ".ao", "inbox"))
+	if len(entries) != 2 {
+		t.Fatalf("want 2 files, got %d", len(entries))
+	}
+}
+
+func TestSend_UnknownSessionReturnsError(t *testing.T) {
+	m := inbox.New(fakeLookup{err: errors.New("not found")})
+	err := m.Send(context.Background(), "s-1", "x")
+	if err == nil {
+		t.Fatal("expected error when workspace lookup fails")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should wrap lookup error, got %v", err)
+	}
+}
+
+func TestSend_EmptyWorkspacePathReturnsError(t *testing.T) {
+	// A spawned-but-not-yet-mark-spawned row has WorkspacePath == "". The
+	// messenger must refuse rather than write into "/.ao/inbox/...".
+	m := inbox.New(fakeLookup{path: ""})
+	if err := m.Send(context.Background(), "s-1", "x"); err == nil {
+		t.Fatal("expected error for empty workspace path")
+	}
+}
+
+func TestSend_SymlinkedInboxIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	// Create .ao/inbox as a symlink to a sibling directory.
+	target := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".ao"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(dir, ".ao", "inbox")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	m := inbox.New(fakeLookup{path: dir})
+	err := m.Send(context.Background(), "s-1", "x")
+	if err == nil {
+		t.Fatal("expected refusal when inbox is a symlink")
+	}
+	if entries, _ := os.ReadDir(target); len(entries) != 0 {
+		t.Errorf("symlink target should not have received writes, got %d entries", len(entries))
+	}
+}
+
+func TestSend_EmptyMessageStillWritesAFile(t *testing.T) {
+	dir := t.TempDir()
+	m := inbox.New(fakeLookup{path: dir})
+	if err := m.Send(context.Background(), "s-1", ""); err != nil {
+		t.Fatal(err)
+	}
+	entries, _ := os.ReadDir(filepath.Join(dir, ".ao", "inbox"))
+	if len(entries) != 1 {
+		t.Fatalf("want 1 file even for empty message, got %d", len(entries))
+	}
+}
+
+func TestSend_FilenameContainsTimestampAndHashPrefix(t *testing.T) {
+	dir := t.TempDir()
+	m := inbox.New(fakeLookup{path: dir})
+	if err := m.Send(context.Background(), "s-1", "payload"); err != nil {
+		t.Fatal(err)
+	}
+	entries, _ := os.ReadDir(filepath.Join(dir, ".ao", "inbox"))
+	name := strings.TrimSuffix(entries[0].Name(), ".md")
+	// Format: <unix_nano>_<hash>; underscore separator avoids the timestamp's own dashes.
+	parts := strings.SplitN(name, "_", 2)
+	if len(parts) != 2 {
+		t.Fatalf("filename should be <timestamp>_<hash>.md, got %q", entries[0].Name())
+	}
+	if len(parts[1]) < 4 {
+		t.Errorf("hash prefix too short: %q", parts[1])
+	}
+}

--- a/backend/internal/adapters/workspace/gitworktree/projectresolver/resolver.go
+++ b/backend/internal/adapters/workspace/gitworktree/projectresolver/resolver.go
@@ -1,0 +1,47 @@
+// Package projectresolver supplies gitworktree.Workspace with a RepoResolver
+// backed by the project.Manager. It lives in its own subpackage so the
+// gitworktree package can stay free of the project package import (and the
+// import cycle that would create if project ever depended on gitworktree).
+package projectresolver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/workspace/gitworktree"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/project"
+)
+
+// Resolver maps a domain.ProjectID to its local repo path by consulting the
+// project store via project.Manager.
+type Resolver struct {
+	projects project.Manager
+}
+
+// New builds a Resolver over the given Manager. projects is required.
+func New(projects project.Manager) *Resolver {
+	return &Resolver{projects: projects}
+}
+
+var _ gitworktree.RepoResolver = (*Resolver)(nil)
+
+// RepoPath returns the absolute repo path the project is registered against.
+// A degraded project (config failed to load) and an unknown project both yield
+// an error rather than the empty path that would silently mis-create worktrees.
+//
+// The gitworktree.RepoResolver interface is context-free, so we use
+// context.Background() to call the underlying Manager.
+func (r *Resolver) RepoPath(projectID domain.ProjectID) (string, error) {
+	res, err := r.projects.Get(context.Background(), projectID)
+	if err != nil {
+		return "", fmt.Errorf("projectresolver: lookup %q: %w", projectID, err)
+	}
+	if res.Project == nil {
+		return "", fmt.Errorf("projectresolver: project %q is %s; no repo path available", projectID, res.Status)
+	}
+	if res.Project.Path == "" {
+		return "", fmt.Errorf("projectresolver: project %q has no path", projectID)
+	}
+	return res.Project.Path, nil
+}

--- a/backend/internal/adapters/workspace/gitworktree/projectresolver/resolver_test.go
+++ b/backend/internal/adapters/workspace/gitworktree/projectresolver/resolver_test.go
@@ -1,0 +1,69 @@
+package projectresolver_test
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/workspace/gitworktree"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/workspace/gitworktree/projectresolver"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/project"
+)
+
+func TestSatisfiesRepoResolver(t *testing.T) {
+	var _ gitworktree.RepoResolver = (*projectresolver.Resolver)(nil)
+}
+
+func TestRepoPath_ReturnsProjectPath(t *testing.T) {
+	mgr := project.NewMemoryManager()
+	repo := mkGitRepo(t)
+	added, err := mgr.Add(context.Background(), project.AddInput{Path: repo})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := projectresolver.New(mgr)
+	got, err := r.RepoPath(added.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != added.Path {
+		t.Fatalf("got %q want %q", got, added.Path)
+	}
+}
+
+func TestRepoPath_UnknownProjectReturnsError(t *testing.T) {
+	mgr := project.NewMemoryManager()
+	r := projectresolver.New(mgr)
+	if _, err := r.RepoPath("nope"); err == nil {
+		t.Fatal("expected error for unknown project")
+	}
+}
+
+func TestRepoPath_DegradedProjectReturnsError(t *testing.T) {
+	// Degraded resolves a status, not a Project — the resolver must surface an
+	// error rather than the empty path that would silently mis-create worktrees.
+	r := projectresolver.New(stubManagerDegraded{})
+	_, err := r.RepoPath("p1")
+	if err == nil {
+		t.Fatal("expected error for degraded project")
+	}
+}
+
+// stubManagerDegraded only overrides Get; other Manager methods would panic if
+// reached, which they should not in this test.
+type stubManagerDegraded struct{ project.Manager }
+
+func (stubManagerDegraded) Get(context.Context, domain.ProjectID) (project.GetResult, error) {
+	return project.GetResult{Status: "degraded"}, nil
+}
+
+func mkGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init", "-q", dir)
+	if err := cmd.Run(); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+	return dir
+}

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/inbox"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/zellij"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd"
@@ -58,15 +59,21 @@ func Run() error {
 		return err
 	}
 
+	// Singletons shared across the daemon. Constructing each exactly once and
+	// passing the same instance everywhere prevents the multi-zellij-socket /
+	// dual-LCM / dual-project-store hazards that fragmented adapters create.
+	runtimeAdapter := zellij.New(zellij.Options{})
+	projects := project.NewManager(store)
+	messenger := inbox.New(newStoreWorkspaceLookup(store))
+
 	// Terminal streaming: the Zellij runtime supplies the PTY-attach command and
 	// liveness; the CDC broadcaster feeds the session-state channel. The manager
 	// is handed to httpd, which mounts it at /mux. Raw PTY bytes never flow
 	// through the CDC change_log — only session-state events do.
-	runtimeAdapter := zellij.New(zellij.Options{})
 	termMgr := terminal.NewManager(runtimeAdapter, cdcPipe.Broadcaster, log)
 	defer termMgr.Close()
 
-	srv, err := httpd.NewWithDeps(cfg, log, termMgr, httpd.APIDeps{Projects: project.NewManager(store)})
+	srv, err := httpd.NewWithDeps(cfg, log, termMgr, httpd.APIDeps{Projects: projects})
 	if err != nil {
 		stop()
 		if cdcErr := cdcPipe.Stop(); cdcErr != nil {
@@ -75,10 +82,21 @@ func Run() error {
 		return err
 	}
 
-	// Bring up the Lifecycle Manager and the reaper. This makes the session
-	// lifecycle write path live end-to-end: reducer write -> store -> DB trigger
-	// -> change_log -> poller -> broadcaster.
-	lcStack := startLifecycle(ctx, store, runtimeAdapter, log)
+	// Bring up the Lifecycle Manager + reaper, then the Session Manager stack
+	// over the same lcm/runtime/projects/messenger singletons. SM has no HTTP
+	// routes yet — they land in a follow-up PR; constructing it here lets the
+	// next PR hang controllers off ss.sm without further wiring changes.
+	lcStack := startLifecycle(ctx, store, runtimeAdapter, messenger, log)
+	ss, err := buildSessionStack(cfg, store, runtimeAdapter, projects, lcStack.lcm, messenger)
+	if err != nil {
+		stop()
+		lcStack.Stop()
+		if cdcErr := cdcPipe.Stop(); cdcErr != nil {
+			log.Error("cdc pipeline shutdown", "err", cdcErr)
+		}
+		return err
+	}
+	_ = ss // sm: HTTP routes land in a follow-up PR (γ)
 
 	runErr := srv.Run(ctx)
 

--- a/backend/internal/daemon/lifecycle_wiring.go
+++ b/backend/internal/daemon/lifecycle_wiring.go
@@ -10,18 +10,21 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
 )
 
-// lifecycleStack owns the runtime reaper goroutine started with the lifecycle
-// reducer. The reducer itself is only used for wiring observations into storage.
+// lifecycleStack owns the Lifecycle Manager (which the Session Manager and the
+// reaper both depend on) and the reaper goroutine.
 type lifecycleStack struct {
+	lcm        *lifecycle.Manager
 	reaperDone <-chan struct{}
 }
 
 // startLifecycle constructs the Lifecycle Manager over the store and starts the
-// reaper. The goroutine stops when ctx is cancelled; Stop waits for it to drain.
-func startLifecycle(ctx context.Context, store *sqlite.Store, runtime ports.Runtime, logger *slog.Logger) *lifecycleStack {
-	lcm := lifecycle.New(store, nil)
+// reaper. The messenger is passed into the LCM so PR-driven reactions (CI fail,
+// review feedback, merge conflict) can nudge the agent. The goroutine stops
+// when ctx is cancelled; Stop waits for it to drain.
+func startLifecycle(ctx context.Context, store *sqlite.Store, runtime ports.Runtime, messenger ports.AgentMessenger, logger *slog.Logger) *lifecycleStack {
+	lcm := lifecycle.New(store, messenger)
 	rp := reaper.New(lcm, store, runtime, reaper.Config{Logger: logger})
-	return &lifecycleStack{reaperDone: rp.Start(ctx)}
+	return &lifecycleStack{lcm: lcm, reaperDone: rp.Start(ctx)}
 }
 
 // Stop waits for the reaper goroutine to exit. The caller must cancel the ctx

--- a/backend/internal/daemon/session_wiring.go
+++ b/backend/internal/daemon/session_wiring.go
@@ -1,0 +1,75 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/claudecode"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/portshim"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/inbox"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/workspace/gitworktree"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/workspace/gitworktree/projectresolver"
+	"github.com/aoagents/agent-orchestrator/backend/internal/config"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/lifecycle"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/aoagents/agent-orchestrator/backend/internal/project"
+	"github.com/aoagents/agent-orchestrator/backend/internal/session"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+)
+
+// sessionStack groups the per-session collaborators the daemon assembles around
+// the Session Manager. HTTP routes that expose SM operations land in a
+// follow-up PR; this PR just constructs the stack so the next one can hang
+// routes off it.
+type sessionStack struct {
+	sm        *session.Manager
+	workspace ports.Workspace
+	messenger ports.AgentMessenger
+}
+
+// buildSessionStack assembles the session-runtime stack: gitworktree workspace
+// over a project-store-backed RepoResolver, claudecode-via-portshim agent,
+// inbox-file AgentMessenger, and the Session Manager itself. The runtime, lcm,
+// projects, and store passed in are the same instances the rest of the daemon
+// uses, so there is one source of truth per collaborator.
+func buildSessionStack(cfg config.Config, store *sqlite.Store, runtime ports.Runtime, projects project.Manager, lcm *lifecycle.Manager, messenger ports.AgentMessenger) (*sessionStack, error) {
+	ws, err := gitworktree.New(gitworktree.Options{
+		ManagedRoot:  filepath.Join(cfg.DataDir, "worktrees"),
+		RepoResolver: projectresolver.New(projects),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("gitworktree: %w", err)
+	}
+	sm := session.New(session.Deps{
+		Runtime:   runtime,
+		Agent:     portshim.New(claudecode.New()),
+		Workspace: ws,
+		Store:     store,
+		Messenger: messenger,
+		Lifecycle: lcm,
+	})
+	return &sessionStack{sm: sm, workspace: ws, messenger: messenger}, nil
+}
+
+// storeWorkspaceLookup adapts the sqlite store to the SessionWorkspace lookup
+// the inbox messenger needs. WorkspacePath becomes meaningful only after the
+// LCM records spawn metadata, so a session that exists but has no path is an
+// error — Send must not invent a destination.
+type storeWorkspaceLookup struct{ store *sqlite.Store }
+
+func newStoreWorkspaceLookup(store *sqlite.Store) inbox.SessionWorkspace {
+	return storeWorkspaceLookup{store: store}
+}
+
+func (s storeWorkspaceLookup) WorkspacePath(ctx context.Context, id domain.SessionID) (string, error) {
+	rec, ok, err := s.store.GetSession(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("session %s not found", id)
+	}
+	return rec.Metadata.WorkspacePath, nil
+}

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -2,11 +2,16 @@ package daemon
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/inbox"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/zellij"
 	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/lifecycle"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
@@ -67,5 +72,76 @@ func TestWiring_WriteFlowsToBroadcaster(t *testing.T) {
 	}
 	if !sawSession {
 		t.Fatalf("expected a change_log event for %s to reach the broadcaster, got %d events", rec.ID, len(got))
+	}
+}
+
+// TestWiring_SessionStackSharesSingletons asserts the daemon's wiring shape:
+// startLifecycle and buildSessionStack share the same messenger and LCM, and
+// the messenger reaches the same store the SM reads. Two LCMs would split
+// agent-nudge state; two messengers would route inbox writes inconsistently.
+//
+// The pointer-identity check on ss.messenger proves buildSessionStack does not
+// silently construct a second messenger; the end-to-end Send through a row the
+// store owns proves the storeWorkspaceLookup is the same store SM uses.
+func TestWiring_SessionStackSharesSingletons(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	store, err := sqlite.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	cfg := config.Config{DataDir: t.TempDir()}
+
+	projects := project.NewManager(store)
+	runtime := zellij.New(zellij.Options{})
+	messenger := inbox.New(newStoreWorkspaceLookup(store))
+	lcStack := startLifecycle(ctx, store, runtime, messenger, nil)
+	// Cancel-then-Stop in order: Stop drains the reaper goroutine, which only
+	// exits when ctx is cancelled. A naive `defer cancel(); defer lcStack.Stop()`
+	// reverses this (defer is LIFO) and deadlocks.
+	t.Cleanup(func() {
+		cancel()
+		lcStack.Stop()
+	})
+
+	if lcStack.lcm == nil {
+		t.Fatal("lifecycleStack must expose its LCM so the SM can share it")
+	}
+	ss, err := buildSessionStack(cfg, store, runtime, projects, lcStack.lcm, messenger)
+	if err != nil {
+		t.Fatalf("buildSessionStack: %v", err)
+	}
+	if ss.sm == nil || ss.workspace == nil || ss.messenger == nil {
+		t.Fatal("session stack must be fully populated")
+	}
+	if ss.messenger != messenger {
+		t.Error("buildSessionStack must reuse the messenger it is given, not construct a second one")
+	}
+
+	// End-to-end: a session row in the shared store should be reachable through
+	// the messenger that buildSessionStack wired up. A second store would
+	// surface as "session not found" here.
+	if err := store.Upsert(ctx, project.Row{ID: "p", Path: "/repo/p", RegisteredAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	workspaceDir := t.TempDir()
+	rec, err := store.CreateSession(ctx, domain.SessionRecord{
+		ProjectID: "p", Kind: domain.KindWorker,
+		Activity: domain.Activity{State: domain.ActivityIdle, LastActivityAt: time.Now()},
+		Metadata: domain.SessionMetadata{WorkspacePath: workspaceDir},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ss.messenger.Send(ctx, rec.ID, "hello"); err != nil {
+		t.Fatalf("messenger.Send through shared store lookup: %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(workspaceDir, ".ao", "inbox"))
+	if err != nil {
+		t.Fatalf("inbox dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("want 1 inbox file, got %d", len(entries))
 	}
 }


### PR DESCRIPTION
## Summary

PR β in our SM-revival planning. PR #62 (merged 2026-06-01) deleted the Session Manager wiring from the daemon — every call to `session.New()` was removed; only the integration test still constructs one. This brings SM back end-to-end: calling `sm.Spawn()` now launches a real Claude Code agent in a real git worktree in a real zellij session, and lifecycle nudges actually reach the agent via an inbox file.

Branches from `origin/staging` (= main + #65) so @yyovil's `claudecode` adapter is available. PR base is `staging`.

## What's new

Four new pieces:

- **`adapters/agent/portshim`** — bridges the richer `adapters/agent.Agent` interface (PR #65) onto the narrower `ports.Agent` the SM consumes. POSIX shell-quoting joins argv into the single string the zellij `sh -lc` wrapper expects.
- **`adapters/workspace/gitworktree/projectresolver`** — `gitworktree.RepoResolver` backed by `project.Manager`. Lives in its own subpackage so `gitworktree` stays free of the `project` import.
- **`adapters/messenger/inbox`** — `ports.AgentMessenger` writing each message as `<session-workspace>/.ao/inbox/<nano>_<hash>.md`. Symlink-safe via `os.Lstat` on the `.ao` / `.ao/inbox` segments.
- **`daemon/session_wiring.go`** — assembles claudecode → portshim, gitworktree over projectresolver, inbox messenger over the sqlite store, and the SM itself. Reuses the existing zellij runtime / project manager / lcm singletons.

Also promotes the duplicated `"agentSessionId"` metadata key in `claudecode` and `codex` to a single `agent.MetadataKeyAgentSessionID` constant so the portshim has a stable place to populate `Session.Metadata` for the underlying adapter.

## Singleton sharing (the contract this PR enforces)

- One `zellij.Runtime` services both terminal mux and SM.Spawn (two adapters would race on the same socket).
- One `*lifecycle.Manager` services both the reaper and the SM (two LCMs would split agent-nudge state).
- One `project.Manager` services both httpd and the gitworktree RepoResolver.
- One `ports.AgentMessenger` services both the LCM (PR-driven reactions) and the SM (Send).

## Out of scope (covered by follow-ups)

- HTTP routes for SM (POST /sessions, etc.) — γ
- `ao session new` CLI — γ
- SCM poller — δ (depends on aa-38)
- Codex agent wiring (claude-code only)
- Zellij send-keys pane-ping (agent reads inbox on demand)

## References

- Re-introduces SM wiring deleted by #62.
- Wires the `claudecode` adapter added by #65 (@yyovil).

## Test plan

- [x] `go test -race ./...` — 323/324 pass (the 1 failure is `TestSessionStreamsRealZellijPane`, a pre-existing host-env issue: `\$TMPDIR > 103` chars exceeds zellij's IPC socket limit; also fails on `origin/staging` without these changes)
- [x] `go vet ./...` clean
- [x] `gofmt -l backend/` clean
- [x] `goimports -l` clean
- [x] portshim tests: 15 cases (shell quoting, env, restore propagation, error fall-through)
- [x] projectresolver tests: 4 cases (happy / unknown / degraded / interface satisfaction)
- [x] inbox tests: 9 cases (happy / dir-create / two-distinct / unknown session / empty workspace path / symlinked inbox refused / empty message / filename shape / interface satisfaction)
- [x] daemon wiring test: SM stack constructed, shares singletons, messenger reaches store-known workspace end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)