### PR TITLE
feat(messenger): `ao send` CLI + live zellij pane ping (aa-43)

### DIFF
--- a/backend/internal/adapters/messenger/composite/composite.go
+++ b/backend/internal/adapters/messenger/composite/composite.go
@@ -14,7 +14,9 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/inbox"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -24,18 +26,25 @@ import (
 // secondaries whose failures are logged at WARN and swallowed. Inner is public
 // so wiring tests can assert the daemon assembles the composite with the
 // expected ordering (inbox first, panep second).
+//
+// Each Send pins one timestamp via inbox.WithTime so inner messengers that
+// derive a filename from (t, message) agree on the same name — without this,
+// the inbox file write and a downstream panep ping would land on different
+// nanoseconds and the ping would point at a file that does not exist.
 type Messenger struct {
 	Inner  []ports.AgentMessenger
 	Logger *slog.Logger
+	Clock  func() time.Time
 }
 
 // New builds a Messenger. A nil logger is replaced with a discard logger so a
-// secondary failure never panics a misconfigured caller.
+// secondary failure never panics a misconfigured caller. Clock defaults to
+// time.Now.
 func New(inner []ports.AgentMessenger, logger *slog.Logger) *Messenger {
 	if logger == nil {
 		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	}
-	return &Messenger{Inner: inner, Logger: logger}
+	return &Messenger{Inner: inner, Logger: logger, Clock: time.Now}
 }
 
 var _ ports.AgentMessenger = (*Messenger)(nil)
@@ -47,6 +56,7 @@ func (c *Messenger) Send(ctx context.Context, id domain.SessionID, message strin
 	if len(c.Inner) == 0 {
 		return nil
 	}
+	ctx = inbox.WithTime(ctx, c.Clock())
 	if err := c.Inner[0].Send(ctx, id, message); err != nil {
 		return err
 	}

--- a/backend/internal/adapters/messenger/composite/composite.go
+++ b/backend/internal/adapters/messenger/composite/composite.go
@@ -1,0 +1,59 @@
+// Package composite fans Send out to a primary AgentMessenger followed by
+// best-effort secondaries. The primary's failure aborts the whole call (the
+// message was never delivered); a secondary's failure is logged and swallowed
+// (the message IS delivered — the secondary was a live nudge, not a record).
+//
+// This is how the daemon wires the inbox messenger (primary, durable file
+// write) with the pane-ping messenger (secondary, live zellij nudge): if we
+// could not write the file we must not tell the agent about a file that does
+// not exist, but if we wrote the file and could not ping, the agent will see
+// it on the next inbox check.
+package composite
+
+import (
+	"context"
+	"io"
+	"log/slog"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// Messenger fans Send out across Inner messengers with primary-then-secondary
+// semantics. Inner[0] is the primary (must succeed); Inner[1:] are best-effort
+// secondaries whose failures are logged at WARN and swallowed. Inner is public
+// so wiring tests can assert the daemon assembles the composite with the
+// expected ordering (inbox first, panep second).
+type Messenger struct {
+	Inner  []ports.AgentMessenger
+	Logger *slog.Logger
+}
+
+// New builds a Messenger. A nil logger is replaced with a discard logger so a
+// secondary failure never panics a misconfigured caller.
+func New(inner []ports.AgentMessenger, logger *slog.Logger) *Messenger {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return &Messenger{Inner: inner, Logger: logger}
+}
+
+var _ ports.AgentMessenger = (*Messenger)(nil)
+
+// Send invokes Inner[0] (primary); on failure, no secondaries run and the
+// error is returned. On primary success, every Inner[1:] is invoked in order
+// and their errors are logged at WARN.
+func (c *Messenger) Send(ctx context.Context, id domain.SessionID, message string) error {
+	if len(c.Inner) == 0 {
+		return nil
+	}
+	if err := c.Inner[0].Send(ctx, id, message); err != nil {
+		return err
+	}
+	for _, m := range c.Inner[1:] {
+		if err := m.Send(ctx, id, message); err != nil {
+			c.Logger.Warn("composite: secondary messenger failed", "sessionId", id, "err", err)
+		}
+	}
+	return nil
+}

--- a/backend/internal/adapters/messenger/composite/composite_test.go
+++ b/backend/internal/adapters/messenger/composite/composite_test.go
@@ -1,15 +1,18 @@
 package composite_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/composite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/inbox"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/panep"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
@@ -68,13 +71,13 @@ func TestSend_PrimaryFailureSkipsSecondaries(t *testing.T) {
 	}
 }
 
-func TestSend_SecondaryFailureIsLoggedAndSwallowed(t *testing.T) {
+func TestSend_SecondaryFailureIsLoggedAtWarnAndSwallowed(t *testing.T) {
 	var calls []string
 	primary := &recordingMessenger{name: "primary", calls: &calls}
 	secondary := &recordingMessenger{name: "secondary", err: errors.New("pipe broken"), calls: &calls}
 
-	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	rec := &levelRecorder{}
+	logger := slog.New(rec)
 
 	c := composite.New([]ports.AgentMessenger{primary, secondary}, logger)
 	if err := c.Send(context.Background(), "s-1", "hi"); err != nil {
@@ -83,9 +86,50 @@ func TestSend_SecondaryFailureIsLoggedAndSwallowed(t *testing.T) {
 	if len(calls) != 2 {
 		t.Fatalf("calls = %v, want both invoked", calls)
 	}
-	if !strings.Contains(buf.String(), "pipe broken") {
-		t.Errorf("expected secondary failure logged, got %q", buf.String())
+	if len(rec.records) != 1 {
+		t.Fatalf("want 1 log record for secondary failure, got %d", len(rec.records))
 	}
+	if rec.records[0].Level != slog.LevelWarn {
+		t.Errorf("secondary failure logged at %v, want WARN", rec.records[0].Level)
+	}
+	if !strings.Contains(rec.records[0].Message+" "+rec.attrText(0), "pipe broken") {
+		t.Errorf("expected secondary failure surfaced in log, got message=%q attrs=%q",
+			rec.records[0].Message, rec.attrText(0))
+	}
+}
+
+// levelRecorder is a slog.Handler that captures full Records so tests can
+// assert on level + message + attrs, not just a serialized substring.
+type levelRecorder struct {
+	records []slog.Record
+	attrs   [][]slog.Attr
+}
+
+func (r *levelRecorder) Enabled(context.Context, slog.Level) bool { return true }
+
+func (r *levelRecorder) Handle(_ context.Context, rec slog.Record) error {
+	var collected []slog.Attr
+	rec.Attrs(func(a slog.Attr) bool {
+		collected = append(collected, a)
+		return true
+	})
+	r.records = append(r.records, rec)
+	r.attrs = append(r.attrs, collected)
+	return nil
+}
+
+func (r *levelRecorder) WithAttrs([]slog.Attr) slog.Handler { return r }
+func (r *levelRecorder) WithGroup(string) slog.Handler      { return r }
+
+func (r *levelRecorder) attrText(i int) string {
+	var b strings.Builder
+	for _, a := range r.attrs[i] {
+		b.WriteString(a.Key)
+		b.WriteString("=")
+		b.WriteString(a.Value.String())
+		b.WriteString(" ")
+	}
+	return b.String()
 }
 
 func TestSend_AllSecondariesAttemptedEvenIfOneFails(t *testing.T) {
@@ -107,6 +151,61 @@ func TestSend_EmptyInnerListIsNoOp(t *testing.T) {
 	c := composite.New(nil, nopLogger())
 	if err := c.Send(context.Background(), "s-1", "hi"); err != nil {
 		t.Fatalf("empty composite Send should be no-op, got %v", err)
+	}
+}
+
+// inboxLookup adapts a tempdir into inbox.SessionWorkspace.
+type fixedWorkspace struct{ path string }
+
+func (f fixedWorkspace) WorkspacePath(context.Context, domain.SessionID) (string, error) {
+	return f.path, nil
+}
+
+// fixedSession adapts to panep.SessionLookup.
+type fixedSession struct{ handle, workspace string }
+
+func (f fixedSession) SessionHandle(context.Context, domain.SessionID) (string, string, error) {
+	return f.handle, f.workspace, nil
+}
+
+type recordingRuntime struct {
+	calls []string
+}
+
+func (r *recordingRuntime) WriteChars(_ context.Context, _ ports.RuntimeHandle, s string) error {
+	r.calls = append(r.calls, s)
+	return nil
+}
+
+// TestSend_PingFilenameMatchesOnDiskFilename is the end-to-end consistency
+// proof the brief implicitly requires: a single composite.Send invocation must
+// produce one inbox file on disk AND a ping body that names exactly that file.
+// Without shared time, the inbox clock and panep clock fire at different
+// nanoseconds and the filenames diverge.
+func TestSend_PingFilenameMatchesOnDiskFilename(t *testing.T) {
+	workspace := t.TempDir()
+	inboxMsg := inbox.New(fixedWorkspace{path: workspace})
+	rt := &recordingRuntime{}
+	panepMsg := panep.New(rt, fixedSession{handle: "sess-id/terminal_0", workspace: workspace})
+
+	c := composite.New([]ports.AgentMessenger{inboxMsg, panepMsg}, nopLogger())
+	if err := c.Send(context.Background(), "s-1", "hello agent"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(workspace, ".ao", "inbox"))
+	if err != nil {
+		t.Fatalf("read inbox dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("want 1 inbox file, got %d", len(entries))
+	}
+	onDisk := entries[0].Name()
+	if len(rt.calls) == 0 {
+		t.Fatal("panep did not ping the pane")
+	}
+	if !strings.Contains(rt.calls[0], onDisk) {
+		t.Fatalf("ping body must reference the on-disk file %q, got %q", onDisk, rt.calls[0])
 	}
 }
 

--- a/backend/internal/adapters/messenger/composite/composite_test.go
+++ b/backend/internal/adapters/messenger/composite/composite_test.go
@@ -1,0 +1,124 @@
+package composite_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/composite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestSatisfiesAgentMessenger(t *testing.T) {
+	var _ ports.AgentMessenger = (*composite.Messenger)(nil)
+}
+
+type recordingMessenger struct {
+	name  string
+	err   error
+	calls *[]string
+}
+
+func (r *recordingMessenger) Send(_ context.Context, _ domain.SessionID, _ string) error {
+	*r.calls = append(*r.calls, r.name)
+	return r.err
+}
+
+func nopLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestSend_FansOutInOrder(t *testing.T) {
+	var calls []string
+	primary := &recordingMessenger{name: "primary", calls: &calls}
+	secondary := &recordingMessenger{name: "secondary", calls: &calls}
+
+	c := composite.New([]ports.AgentMessenger{primary, secondary}, nopLogger())
+	if err := c.Send(context.Background(), "s-1", "hi"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("calls = %v, want 2", calls)
+	}
+	if calls[0] != "primary" || calls[1] != "secondary" {
+		t.Fatalf("call order = %v, want [primary secondary]", calls)
+	}
+}
+
+func TestSend_PrimaryFailureSkipsSecondaries(t *testing.T) {
+	var calls []string
+	primary := &recordingMessenger{name: "primary", err: errors.New("disk full"), calls: &calls}
+	secondary := &recordingMessenger{name: "secondary", calls: &calls}
+
+	c := composite.New([]ports.AgentMessenger{primary, secondary}, nopLogger())
+	err := c.Send(context.Background(), "s-1", "hi")
+	if err == nil {
+		t.Fatal("expected error when primary fails")
+	}
+	if !strings.Contains(err.Error(), "disk full") {
+		t.Errorf("error should surface primary failure, got %v", err)
+	}
+	if len(calls) != 1 || calls[0] != "primary" {
+		t.Fatalf("calls = %v, want only [primary]", calls)
+	}
+}
+
+func TestSend_SecondaryFailureIsLoggedAndSwallowed(t *testing.T) {
+	var calls []string
+	primary := &recordingMessenger{name: "primary", calls: &calls}
+	secondary := &recordingMessenger{name: "secondary", err: errors.New("pipe broken"), calls: &calls}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	c := composite.New([]ports.AgentMessenger{primary, secondary}, logger)
+	if err := c.Send(context.Background(), "s-1", "hi"); err != nil {
+		t.Fatalf("Send must succeed when only the secondary fails, got %v", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("calls = %v, want both invoked", calls)
+	}
+	if !strings.Contains(buf.String(), "pipe broken") {
+		t.Errorf("expected secondary failure logged, got %q", buf.String())
+	}
+}
+
+func TestSend_AllSecondariesAttemptedEvenIfOneFails(t *testing.T) {
+	var calls []string
+	primary := &recordingMessenger{name: "primary", calls: &calls}
+	sec1 := &recordingMessenger{name: "sec1", err: errors.New("transient"), calls: &calls}
+	sec2 := &recordingMessenger{name: "sec2", calls: &calls}
+
+	c := composite.New([]ports.AgentMessenger{primary, sec1, sec2}, nopLogger())
+	if err := c.Send(context.Background(), "s-1", "hi"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(calls) != 3 || calls[0] != "primary" || calls[1] != "sec1" || calls[2] != "sec2" {
+		t.Fatalf("call order = %v, want [primary sec1 sec2]", calls)
+	}
+}
+
+func TestSend_EmptyInnerListIsNoOp(t *testing.T) {
+	c := composite.New(nil, nopLogger())
+	if err := c.Send(context.Background(), "s-1", "hi"); err != nil {
+		t.Fatalf("empty composite Send should be no-op, got %v", err)
+	}
+}
+
+func TestNew_NilLoggerStillWorks(t *testing.T) {
+	// A nil logger should not panic — composite must default to a discard
+	// logger so misconfigured callers don't crash on the first secondary error.
+	var calls []string
+	primary := &recordingMessenger{name: "primary", calls: &calls}
+	secondary := &recordingMessenger{name: "secondary", err: errors.New("x"), calls: &calls}
+
+	c := composite.New([]ports.AgentMessenger{primary, secondary}, nil)
+	if err := c.Send(context.Background(), "s-1", "hi"); err != nil {
+		t.Fatalf("Send with nil logger and secondary error must not return error, got %v", err)
+	}
+}

--- a/backend/internal/adapters/messenger/inbox/inbox.go
+++ b/backend/internal/adapters/messenger/inbox/inbox.go
@@ -66,7 +66,7 @@ func (m *Messenger) Send(ctx context.Context, id domain.SessionID, message strin
 		return fmt.Errorf("inbox: prepare inbox for %s: %w", id, err)
 	}
 
-	name := FilenameFor(m.clock(), message)
+	name := FilenameFor(TimeFromContext(ctx, m.clock), message)
 	if err := os.WriteFile(filepath.Join(inboxDir, name), []byte(message), 0o600); err != nil {
 		return fmt.Errorf("inbox: write %s for %s: %w", name, id, err)
 	}
@@ -109,4 +109,27 @@ func FilenameFor(t time.Time, message string) string {
 	sum := sha256.Sum256([]byte(message))
 	hash := hex.EncodeToString(sum[:])[:8]
 	return strconv.FormatInt(t.UnixNano(), 10) + "_" + hash + ".md"
+}
+
+// sendTimeKey scopes the shared "Send timestamp" composite injects so inbox
+// and panep derive the same filename for one Send call. The key is unexported
+// — only the inbox.WithTime / TimeFromContext helpers can read or write it.
+type sendTimeKey struct{}
+
+// WithTime attaches t to ctx as the shared timestamp the inbox messenger and
+// any peers (panep) should use when deriving a filename via FilenameFor. The
+// composite messenger calls this so a single Send produces one filename across
+// every inner messenger, regardless of how long inbox's file I/O takes.
+func WithTime(ctx context.Context, t time.Time) context.Context {
+	return context.WithValue(ctx, sendTimeKey{}, t)
+}
+
+// TimeFromContext returns the timestamp WithTime stashed on ctx, falling back
+// to fallback() if none is present. Callers running outside the composite
+// (e.g. tests, direct use of inbox.Messenger) just get the fallback.
+func TimeFromContext(ctx context.Context, fallback func() time.Time) time.Time {
+	if t, ok := ctx.Value(sendTimeKey{}).(time.Time); ok {
+		return t
+	}
+	return fallback()
 }

--- a/backend/internal/adapters/messenger/inbox/inbox.go
+++ b/backend/internal/adapters/messenger/inbox/inbox.go
@@ -66,7 +66,7 @@ func (m *Messenger) Send(ctx context.Context, id domain.SessionID, message strin
 		return fmt.Errorf("inbox: prepare inbox for %s: %w", id, err)
 	}
 
-	name := filenameFor(m.clock(), message)
+	name := FilenameFor(m.clock(), message)
 	if err := os.WriteFile(filepath.Join(inboxDir, name), []byte(message), 0o600); err != nil {
 		return fmt.Errorf("inbox: write %s for %s: %w", name, id, err)
 	}
@@ -100,10 +100,12 @@ func ensureRealDir(path string) error {
 	}
 }
 
-// filenameFor builds a sortable, collision-resistant name from the timestamp
+// FilenameFor builds a sortable, collision-resistant name from the timestamp
 // and message body. Underscore separator keeps the timestamp's own dashes
-// distinguishable from the hash prefix.
-func filenameFor(t time.Time, message string) string {
+// distinguishable from the hash prefix. Exported so adapters that point at the
+// file (e.g. the pane-ping messenger) can derive the same name the inbox
+// messenger would write for the same (t, message).
+func FilenameFor(t time.Time, message string) string {
 	sum := sha256.Sum256([]byte(message))
 	hash := hex.EncodeToString(sum[:])[:8]
 	return strconv.FormatInt(t.UnixNano(), 10) + "_" + hash + ".md"

--- a/backend/internal/adapters/messenger/inbox/inbox_test.go
+++ b/backend/internal/adapters/messenger/inbox/inbox_test.go
@@ -2,16 +2,53 @@ package inbox_test
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/inbox"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
+
+// FilenameFor is the shared helper used by both the inbox messenger (writes the
+// file) and the panep messenger (points at the file). Both must agree on the
+// exact name for the same (timestamp, message) input.
+func TestFilenameFor_IsDeterministicForSameInput(t *testing.T) {
+	ts := time.Unix(1717171717, 42).UTC()
+	body := "ε ao test"
+	if got, want := inbox.FilenameFor(ts, body), inbox.FilenameFor(ts, body); got != want {
+		t.Fatalf("FilenameFor not deterministic: %q vs %q", got, want)
+	}
+}
+
+func TestFilenameFor_MatchesTimestampNanoAndHashPrefix(t *testing.T) {
+	ts := time.Unix(1717171717, 42).UTC()
+	body := "hello agent"
+
+	got := inbox.FilenameFor(ts, body)
+
+	sum := sha256.Sum256([]byte(body))
+	wantPrefix := strconv.FormatInt(ts.UnixNano(), 10) + "_" + hex.EncodeToString(sum[:])[:8] + ".md"
+	if got != wantPrefix {
+		t.Fatalf("FilenameFor(%v, %q) = %q, want %q", ts, body, got, wantPrefix)
+	}
+}
+
+func TestFilenameFor_DiffersByMessage(t *testing.T) {
+	ts := time.Unix(1717171717, 42).UTC()
+	a := inbox.FilenameFor(ts, "alpha")
+	b := inbox.FilenameFor(ts, "beta")
+	if a == b {
+		t.Fatalf("different messages produced same filename: %q", a)
+	}
+}
 
 func TestSatisfiesAgentMessenger(t *testing.T) {
 	var _ ports.AgentMessenger = (*inbox.Messenger)(nil)

--- a/backend/internal/adapters/messenger/panep/panep.go
+++ b/backend/internal/adapters/messenger/panep/panep.go
@@ -47,11 +47,6 @@ func New(runtime RuntimePaneWriter, lookup SessionLookup) *Messenger {
 	return &Messenger{runtime: runtime, lookup: lookup, clock: time.Now}
 }
 
-// SetClock overrides the time source used to derive the inbox filename the
-// ping points at. Exposed for tests so they can pin the filename without
-// racing the system clock.
-func (m *Messenger) SetClock(now func() time.Time) { m.clock = now }
-
 var _ ports.AgentMessenger = (*Messenger)(nil)
 
 // Send pings the agent pane with a pointer to .ao/inbox/<file>. The filename
@@ -70,7 +65,11 @@ func (m *Messenger) Send(ctx context.Context, id domain.SessionID, message strin
 		return fmt.Errorf("panep: empty workspace path for %s", id)
 	}
 
-	filename := inbox.FilenameFor(m.clock(), message)
+	// Reads the timestamp the composite messenger stashed via inbox.WithTime
+	// so the filename here matches what the inbox messenger just wrote. Outside
+	// a composite, falls back to m.clock — useful for tests and any future
+	// caller that uses panep stand-alone.
+	filename := inbox.FilenameFor(inbox.TimeFromContext(ctx, m.clock), message)
 	body := fmt.Sprintf("📥 ao: new message at .ao/inbox/%s — please read it", filename)
 	handle := ports.RuntimeHandle{ID: handleID}
 	if err := m.runtime.WriteChars(ctx, handle, body); err != nil {

--- a/backend/internal/adapters/messenger/panep/panep.go
+++ b/backend/internal/adapters/messenger/panep/panep.go
@@ -1,0 +1,83 @@
+// Package panep ("pane ping") implements ports.AgentMessenger by typing a
+// short pointer into the agent's runtime pane: "📥 ao: new message at
+// .ao/inbox/<file> — please read it". The inbox messenger writes the file;
+// panep merely tells the agent to read it. Multi-line message bodies typed
+// verbatim fight with the agent's input handler, so a pointer is robust where
+// pasting the full body is not.
+//
+// panep is best-effort: composite.Messenger logs and swallows panep errors so a
+// missed nudge never loses the message — the inbox file is still on disk.
+package panep
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/inbox"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// SessionLookup resolves a session id to its runtime handle id and workspace
+// path. The sqlite store satisfies this via a small adapter in
+// daemon/session_wiring.go. The workspace path is required so panep can prove
+// the inbox messenger had somewhere to write before pointing at the file.
+type SessionLookup interface {
+	SessionHandle(ctx context.Context, id domain.SessionID) (handleID, workspacePath string, err error)
+}
+
+// RuntimePaneWriter is the narrow runtime contract panep depends on: type
+// characters into the pane identified by handle. Kept separate from
+// ports.Runtime so adding a pane-ping does not widen the runtime port.
+type RuntimePaneWriter interface {
+	WriteChars(ctx context.Context, handle ports.RuntimeHandle, s string) error
+}
+
+// Messenger pings the agent's pane with a pointer at a freshly-written inbox
+// file. It does not write the file itself — that is the inbox messenger's job.
+type Messenger struct {
+	runtime RuntimePaneWriter
+	lookup  SessionLookup
+	clock   func() time.Time
+}
+
+// New constructs a Messenger. Both deps are required.
+func New(runtime RuntimePaneWriter, lookup SessionLookup) *Messenger {
+	return &Messenger{runtime: runtime, lookup: lookup, clock: time.Now}
+}
+
+// SetClock overrides the time source used to derive the inbox filename the
+// ping points at. Exposed for tests so they can pin the filename without
+// racing the system clock.
+func (m *Messenger) SetClock(now func() time.Time) { m.clock = now }
+
+var _ ports.AgentMessenger = (*Messenger)(nil)
+
+// Send pings the agent pane with a pointer to .ao/inbox/<file>. The filename
+// is derived from the same (clock(), message) inputs the inbox messenger uses,
+// so the two adapters agree on a single name when invoked together by the
+// composite messenger.
+func (m *Messenger) Send(ctx context.Context, id domain.SessionID, message string) error {
+	handleID, ws, err := m.lookup.SessionHandle(ctx, id)
+	if err != nil {
+		return fmt.Errorf("panep: lookup handle for %s: %w", id, err)
+	}
+	if handleID == "" {
+		return fmt.Errorf("panep: empty runtime handle for %s", id)
+	}
+	if ws == "" {
+		return fmt.Errorf("panep: empty workspace path for %s", id)
+	}
+
+	filename := inbox.FilenameFor(m.clock(), message)
+	body := fmt.Sprintf("📥 ao: new message at .ao/inbox/%s — please read it", filename)
+	handle := ports.RuntimeHandle{ID: handleID}
+	if err := m.runtime.WriteChars(ctx, handle, body); err != nil {
+		return fmt.Errorf("panep: write ping for %s: %w", id, err)
+	}
+	if err := m.runtime.WriteChars(ctx, handle, "\n"); err != nil {
+		return fmt.Errorf("panep: submit ping for %s: %w", id, err)
+	}
+	return nil
+}

--- a/backend/internal/adapters/messenger/panep/panep_test.go
+++ b/backend/internal/adapters/messenger/panep/panep_test.go
@@ -47,9 +47,11 @@ func TestSend_PingsPaneWithFilenameMatchingInbox(t *testing.T) {
 	rt := &fakeRuntime{}
 	fixed := time.Unix(1717171717, 42).UTC()
 	m := panep.New(rt, lookup)
-	m.SetClock(func() time.Time { return fixed })
 
-	if err := m.Send(context.Background(), "s-1", "ε hello"); err != nil {
+	// In production the composite injects the timestamp via inbox.WithTime so
+	// the panep ping filename matches what inbox just wrote. Pin it here.
+	ctx := inbox.WithTime(context.Background(), fixed)
+	if err := m.Send(ctx, "s-1", "ε hello"); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	if len(rt.calls) != 2 {

--- a/backend/internal/adapters/messenger/panep/panep_test.go
+++ b/backend/internal/adapters/messenger/panep/panep_test.go
@@ -1,0 +1,132 @@
+package panep_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/inbox"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/panep"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestSatisfiesAgentMessenger(t *testing.T) {
+	var _ ports.AgentMessenger = (*panep.Messenger)(nil)
+}
+
+type fakeLookup struct {
+	handle    string
+	workspace string
+	err       error
+}
+
+func (f fakeLookup) SessionHandle(context.Context, domain.SessionID) (string, string, error) {
+	return f.handle, f.workspace, f.err
+}
+
+type writeCall struct {
+	handle ports.RuntimeHandle
+	s      string
+}
+
+type fakeRuntime struct {
+	err   error
+	calls []writeCall
+}
+
+func (f *fakeRuntime) WriteChars(_ context.Context, handle ports.RuntimeHandle, s string) error {
+	f.calls = append(f.calls, writeCall{handle: handle, s: s})
+	return f.err
+}
+
+func TestSend_PingsPaneWithFilenameMatchingInbox(t *testing.T) {
+	lookup := fakeLookup{handle: "sess-id/terminal_0", workspace: "/ws"}
+	rt := &fakeRuntime{}
+	fixed := time.Unix(1717171717, 42).UTC()
+	m := panep.New(rt, lookup)
+	m.SetClock(func() time.Time { return fixed })
+
+	if err := m.Send(context.Background(), "s-1", "ε hello"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(rt.calls) != 2 {
+		t.Fatalf("want 2 WriteChars calls (body + newline), got %d", len(rt.calls))
+	}
+	// The exact filename the inbox messenger would write for the same
+	// (clock, message); panep must point at it.
+	wantFilename := inbox.FilenameFor(fixed, "ε hello")
+	if !strings.Contains(rt.calls[0].s, wantFilename) {
+		t.Errorf("ping body should reference inbox filename %q, got %q", wantFilename, rt.calls[0].s)
+	}
+	if !strings.Contains(rt.calls[0].s, ".ao/inbox/") {
+		t.Errorf("ping body should mention .ao/inbox/, got %q", rt.calls[0].s)
+	}
+	if rt.calls[0].handle.ID != "sess-id/terminal_0" {
+		t.Errorf("handle ID = %q, want sess-id/terminal_0", rt.calls[0].handle.ID)
+	}
+	if rt.calls[1].s != "\n" {
+		t.Errorf("second WriteChars should be newline to submit, got %q", rt.calls[1].s)
+	}
+}
+
+func TestSend_LookupErrorIsWrapped(t *testing.T) {
+	lookup := fakeLookup{err: errors.New("db dead")}
+	rt := &fakeRuntime{}
+	m := panep.New(rt, lookup)
+
+	err := m.Send(context.Background(), "s-1", "x")
+	if err == nil {
+		t.Fatal("expected error when SessionHandle fails")
+	}
+	if !strings.Contains(err.Error(), "db dead") {
+		t.Errorf("error should wrap lookup error, got %v", err)
+	}
+	if len(rt.calls) != 0 {
+		t.Errorf("runtime must not be called when lookup fails, got %d calls", len(rt.calls))
+	}
+}
+
+func TestSend_EmptyHandleIsError(t *testing.T) {
+	lookup := fakeLookup{handle: "", workspace: "/ws"}
+	rt := &fakeRuntime{}
+	m := panep.New(rt, lookup)
+
+	if err := m.Send(context.Background(), "s-1", "x"); err == nil {
+		t.Fatal("expected error when runtime handle is empty")
+	}
+	if len(rt.calls) != 0 {
+		t.Errorf("runtime must not be called for empty handle, got %d calls", len(rt.calls))
+	}
+}
+
+func TestSend_EmptyWorkspacePathIsError(t *testing.T) {
+	// The ping body references .ao/inbox/<filename>; with no workspace path we
+	// cannot trust the inbox messenger wrote a real file there.
+	lookup := fakeLookup{handle: "sess-id/terminal_0", workspace: ""}
+	rt := &fakeRuntime{}
+	m := panep.New(rt, lookup)
+
+	if err := m.Send(context.Background(), "s-1", "x"); err == nil {
+		t.Fatal("expected error when workspace path is empty")
+	}
+	if len(rt.calls) != 0 {
+		t.Errorf("runtime must not be called for empty workspace, got %d calls", len(rt.calls))
+	}
+}
+
+func TestSend_RuntimeErrorIsWrapped(t *testing.T) {
+	lookup := fakeLookup{handle: "sess-id/terminal_0", workspace: "/ws"}
+	rt := &fakeRuntime{err: errors.New("zellij: pipe broken")}
+	m := panep.New(rt, lookup)
+
+	err := m.Send(context.Background(), "s-1", "x")
+	if err == nil {
+		t.Fatal("expected error when WriteChars fails")
+	}
+	if !strings.Contains(err.Error(), "zellij: pipe broken") {
+		t.Errorf("error should wrap runtime error, got %v", err)
+	}
+}

--- a/backend/internal/adapters/runtime/zellij/commands.go
+++ b/backend/internal/adapters/runtime/zellij/commands.go
@@ -42,6 +42,10 @@ func sendEnterArgs(id, paneID string) []string {
 	return []string{"--session", id, "action", "send-keys", "--pane-id", paneID, "Enter"}
 }
 
+func writeCharsArgs(id, paneID, s string) []string {
+	return []string{"--session", id, "action", "write-chars", "--pane-id", paneID, s}
+}
+
 func dumpScreenArgs(id, paneID string) []string {
 	return []string{"--session", id, "action", "dump-screen", "--pane-id", paneID, "--full"}
 }

--- a/backend/internal/adapters/runtime/zellij/zellij.go
+++ b/backend/internal/adapters/runtime/zellij/zellij.go
@@ -156,6 +156,25 @@ func (r *Runtime) Destroy(ctx context.Context, handle ports.RuntimeHandle) error
 	return nil
 }
 
+// WriteChars types s into the session's pane via `zellij action write-chars`.
+// Single shot, no chunking, no follow-up Enter. The pane-ping messenger
+// (panep) sequences body + newline as two separate calls so the agent's input
+// handler sees one well-formed line followed by a submit.
+//
+// Not part of ports.Runtime — runtime adapters that don't model a typing
+// surface (none of the message-injection adapters), and panep depends on the
+// narrow RuntimePaneWriter contract instead of the full Runtime interface.
+func (r *Runtime) WriteChars(ctx context.Context, handle ports.RuntimeHandle, s string) error {
+	id, paneID, err := handleID(handle)
+	if err != nil {
+		return err
+	}
+	if _, err := r.run(ctx, writeCharsArgs(id, paneID, s)...); err != nil {
+		return fmt.Errorf("zellij runtime: write-chars %s/%s: %w", id, paneID, err)
+	}
+	return nil
+}
+
 // SendMessage pastes a message into the session's pane (chunked) and presses
 // Enter to submit it.
 func (r *Runtime) SendMessage(ctx context.Context, handle ports.RuntimeHandle, message string) error {

--- a/backend/internal/adapters/runtime/zellij/zellij_test.go
+++ b/backend/internal/adapters/runtime/zellij/zellij_test.go
@@ -291,6 +291,35 @@ func TestParseVersion(t *testing.T) {
 	}
 }
 
+// WriteChars is the narrow seam panep's RuntimePaneWriter calls — a single
+// `zellij action write-chars` against the handle's pane, no chunking, no
+// follow-up Enter. The composite messenger sequences body + newline as two
+// separate calls.
+func TestWriteCharsInvokesZellijAction(t *testing.T) {
+	fr := &fakeRunner{}
+	r := New(Options{Timeout: time.Second})
+	r.runner = fr
+
+	if err := r.WriteChars(context.Background(), ports.RuntimeHandle{ID: "sess-1/terminal_0"}, "hi"); err != nil {
+		t.Fatalf("WriteChars: %v", err)
+	}
+	if len(fr.calls) != 1 {
+		t.Fatalf("calls = %d, want 1", len(fr.calls))
+	}
+	want := []string{"--session", "sess-1", "action", "write-chars", "--pane-id", "terminal_0", "hi"}
+	if got := fr.calls[0].args; !reflect.DeepEqual(got, want) {
+		t.Fatalf("WriteChars args = %#v, want %#v", got, want)
+	}
+}
+
+func TestWriteCharsRejectsBadHandle(t *testing.T) {
+	r := New(Options{Timeout: time.Second})
+	r.runner = &fakeRunner{}
+	if err := r.WriteChars(context.Background(), ports.RuntimeHandle{ID: ""}, "hi"); err == nil {
+		t.Fatal("WriteChars with empty handle: got nil, want error")
+	}
+}
+
 func TestSendMessageChunksAndSendsEnter(t *testing.T) {
 	fr := &fakeRunner{}
 	r := New(Options{Timeout: time.Second, ChunkSize: 5})

--- a/backend/internal/cli/root.go
+++ b/backend/internal/cli/root.go
@@ -147,6 +147,7 @@ func NewRootCommand(deps Deps) *cobra.Command {
 	root.AddCommand(newStopCommand(ctx))
 	root.AddCommand(newStatusCommand(ctx))
 	root.AddCommand(newSpawnCommand(ctx))
+	root.AddCommand(newSendCommand(ctx))
 	root.AddCommand(newDoctorCommand(ctx))
 	root.AddCommand(newCompletionCommand())
 	root.AddCommand(newVersionCommand())

--- a/backend/internal/cli/send.go
+++ b/backend/internal/cli/send.go
@@ -64,7 +64,7 @@ func (c *commandContext) sendMessage(ctx context.Context, opts sendOptions) erro
 		return errors.New("AO daemon is not running; start it with `ao start`")
 	}
 
-	body, err := json.Marshal(sendAPIRequest{Message: opts.message})
+	body, err := json.Marshal(sendAPIRequest{Message: message})
 	if err != nil {
 		return fmt.Errorf("encode request: %w", err)
 	}

--- a/backend/internal/cli/send.go
+++ b/backend/internal/cli/send.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/config"
+	"github.com/aoagents/agent-orchestrator/backend/internal/runfile"
+)
+
+type sendOptions struct {
+	session string
+	message string
+}
+
+func newSendCommand(ctx *commandContext) *cobra.Command {
+	var opts sendOptions
+	cmd := &cobra.Command{
+		Use:   "send",
+		Short: "Send a message to a running agent session",
+		Args:  noArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return ctx.sendMessage(cmd.Context(), opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.session, "session", "", "Session id (required)")
+	cmd.Flags().StringVar(&opts.message, "message", "", "Message body (required)")
+	return cmd
+}
+
+type sendAPIRequest struct {
+	Message string `json:"message"`
+}
+
+func (c *commandContext) sendMessage(ctx context.Context, opts sendOptions) error {
+	message := strings.TrimSpace(opts.message)
+	if message == "" {
+		return usageError{errors.New("usage: --message is required")}
+	}
+	session := strings.TrimSpace(opts.session)
+	if session == "" {
+		return usageError{errors.New("usage: --session is required")}
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	info, err := runfile.Read(cfg.RunFilePath)
+	if err != nil {
+		return fmt.Errorf("read run-file: %w", err)
+	}
+	if info == nil {
+		return errors.New("AO daemon is not running; start it with `ao start`")
+	}
+
+	body, err := json.Marshal(sendAPIRequest{Message: opts.message})
+	if err != nil {
+		return fmt.Errorf("encode request: %w", err)
+	}
+
+	// PathEscape: session ids include "-" and digits already, but they may also
+	// come from sanitized issue refs in the future; keep the URL well-formed.
+	endpoint := fmt.Sprintf("http://%s:%d/api/v1/sessions/%s/send",
+		config.LoopbackHost, info.Port, url.PathEscape(session))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.deps.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("daemon request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	var apiErr apiError
+	if jerr := json.Unmarshal(respBody, &apiErr); jerr == nil && apiErr.Kind != "" {
+		return fmt.Errorf("%s: %s", apiErr.Kind, apiErr.Message)
+	}
+	return fmt.Errorf("daemon returned HTTP %d", resp.StatusCode)
+}

--- a/backend/internal/cli/send_test.go
+++ b/backend/internal/cli/send_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // sendServer wires an httptest server expecting POST /api/v1/sessions/{id}/send
-// and captures the request body and path the CLI hit.
+// and capturetures the request body and path the CLI hit.
 type sendCapture struct {
 	body string
 	path string
@@ -18,7 +18,7 @@ type sendCapture struct {
 
 func sendServer(t *testing.T, status int, respBody string) (*httptest.Server, *sendCapture) {
 	t.Helper()
-	cap := &sendCapture{}
+	capture := &sendCapture{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.NotFound(w, r)
@@ -32,19 +32,19 @@ func sendServer(t *testing.T, status int, respBody string) (*httptest.Server, *s
 		if err != nil {
 			t.Fatalf("read body: %v", err)
 		}
-		cap.body = string(body)
-		cap.path = r.URL.Path
+		capture.body = string(body)
+		capture.path = r.URL.Path
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(status)
 		_, _ = io.WriteString(w, respBody)
 	}))
 	t.Cleanup(srv.Close)
-	return srv, cap
+	return srv, capture
 }
 
 func TestSend_Success(t *testing.T) {
 	cfg := setConfigEnv(t)
-	srv, cap := sendServer(t, http.StatusOK,
+	srv, capture := sendServer(t, http.StatusOK,
 		`{"ok":true,"sessionId":"demo-1","message":"hello agent"}`)
 	writeRunFileFor(t, cfg, srv)
 
@@ -54,17 +54,39 @@ func TestSend_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
 	}
-	if cap.path != "/api/v1/sessions/demo-1/send" {
-		t.Errorf("path = %q, want /api/v1/sessions/demo-1/send", cap.path)
+	if capture.path != "/api/v1/sessions/demo-1/send" {
+		t.Errorf("path = %q, want /api/v1/sessions/demo-1/send", capture.path)
 	}
 	var req struct {
 		Message string `json:"message"`
 	}
-	if err := json.Unmarshal([]byte(cap.body), &req); err != nil {
-		t.Fatalf("decode body: %v\nbody=%s", err, cap.body)
+	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+		t.Fatalf("decode body: %v\nbody=%s", err, capture.body)
 	}
 	if req.Message != "hello agent" {
-		t.Errorf("captured message = %q, want %q", req.Message, "hello agent")
+		t.Errorf("capturetured message = %q, want %q", req.Message, "hello agent")
+	}
+}
+
+func TestSend_TrimsLeadingAndTrailingWhitespace(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, captureture := sendServer(t, http.StatusOK, `{"ok":true,"sessionId":"demo-1","message":"hi"}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "send", "--session", "demo-1", "--message", "  hi  ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var req struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(captureture.body), &req); err != nil {
+		t.Fatalf("decode body: %v\nbody=%s", err, captureture.body)
+	}
+	if req.Message != "hi" {
+		t.Errorf("server received %q, want trimmed %q", req.Message, "hi")
 	}
 }
 
@@ -136,7 +158,7 @@ func TestSend_ServerInternalErrorExits1(t *testing.T) {
 		`{"error":"internal","code":"SESSION_OPERATION_FAILED","message":"Session operation failed"}`)
 	writeRunFileFor(t, cfg, srv)
 
-	_, _, err := executeCLI(t, Deps{
+	_, errOut, err := executeCLI(t, Deps{
 		ProcessAlive: func(int) bool { return true },
 	}, "send", "--session", "demo-1", "--message", "hi")
 	if err == nil {
@@ -144,6 +166,12 @@ func TestSend_ServerInternalErrorExits1(t *testing.T) {
 	}
 	if got := ExitCode(err); got != 1 {
 		t.Fatalf("exit code = %d, want 1", got)
+	}
+	// Regression guard: a future change that swallows the API envelope and
+	// prints only "daemon returned HTTP 500" would silently hide what the
+	// daemon was trying to tell the operator.
+	if !strings.Contains(err.Error(), "internal") && !strings.Contains(errOut, "internal") {
+		t.Fatalf("error did not include server kind: %v\nstderr=%s", err, errOut)
 	}
 }
 

--- a/backend/internal/cli/send_test.go
+++ b/backend/internal/cli/send_test.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// sendServer wires an httptest server expecting POST /api/v1/sessions/{id}/send
+// and captures the request body and path the CLI hit.
+type sendCapture struct {
+	body string
+	path string
+}
+
+func sendServer(t *testing.T, status int, respBody string) (*httptest.Server, *sendCapture) {
+	t.Helper()
+	cap := &sendCapture{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		if !strings.HasPrefix(r.URL.Path, "/api/v1/sessions/") || !strings.HasSuffix(r.URL.Path, "/send") {
+			http.NotFound(w, r)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		cap.body = string(body)
+		cap.path = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, respBody)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, cap
+}
+
+func TestSend_Success(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, cap := sendServer(t, http.StatusOK,
+		`{"ok":true,"sessionId":"demo-1","message":"hello agent"}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "send", "--session", "demo-1", "--message", "hello agent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v\nstderr=%s", err, errOut)
+	}
+	if cap.path != "/api/v1/sessions/demo-1/send" {
+		t.Errorf("path = %q, want /api/v1/sessions/demo-1/send", cap.path)
+	}
+	var req struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(cap.body), &req); err != nil {
+		t.Fatalf("decode body: %v\nbody=%s", err, cap.body)
+	}
+	if req.Message != "hello agent" {
+		t.Errorf("captured message = %q, want %q", req.Message, "hello agent")
+	}
+}
+
+func TestSend_EmptyMessageIsUsageError(t *testing.T) {
+	setConfigEnv(t)
+	_, _, err := executeCLI(t, Deps{}, "send", "--session", "demo-1", "--message", "   ")
+	if err == nil {
+		t.Fatal("expected usage error for empty message")
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2", got)
+	}
+	if !strings.Contains(err.Error(), "--message is required") {
+		t.Fatalf("error missing usage message: %v", err)
+	}
+}
+
+func TestSend_MissingSessionIsUsageError(t *testing.T) {
+	setConfigEnv(t)
+	_, _, err := executeCLI(t, Deps{}, "send", "--message", "hi")
+	if err == nil {
+		t.Fatal("expected usage error for missing --session")
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("exit code = %d, want 2", got)
+	}
+}
+
+func TestSend_ServerBadRequestExits1(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := sendServer(t, http.StatusBadRequest,
+		`{"error":"bad_request","code":"MESSAGE_REQUIRED","message":"Message is required"}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, errOut, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "send", "--session", "demo-1", "--message", "hi")
+	if err == nil {
+		t.Fatal("expected runtime error from 400")
+	}
+	if got := ExitCode(err); got != 1 {
+		t.Fatalf("exit code = %d, want 1", got)
+	}
+	if !strings.Contains(err.Error(), "bad_request") && !strings.Contains(errOut, "bad_request") {
+		t.Fatalf("error did not include server kind: %v\nstderr=%s", err, errOut)
+	}
+}
+
+func TestSend_ServerNotFoundExits1(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := sendServer(t, http.StatusNotFound,
+		`{"error":"not_found","code":"SESSION_NOT_FOUND","message":"Unknown session"}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "send", "--session", "missing", "--message", "hi")
+	if err == nil {
+		t.Fatal("expected runtime error from 404")
+	}
+	if got := ExitCode(err); got != 1 {
+		t.Fatalf("exit code = %d, want 1", got)
+	}
+}
+
+func TestSend_ServerInternalErrorExits1(t *testing.T) {
+	cfg := setConfigEnv(t)
+	srv, _ := sendServer(t, http.StatusInternalServerError,
+		`{"error":"internal","code":"SESSION_OPERATION_FAILED","message":"Session operation failed"}`)
+	writeRunFileFor(t, cfg, srv)
+
+	_, _, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "send", "--session", "demo-1", "--message", "hi")
+	if err == nil {
+		t.Fatal("expected runtime error from 500")
+	}
+	if got := ExitCode(err); got != 1 {
+		t.Fatalf("exit code = %d, want 1", got)
+	}
+}
+
+func TestSend_DaemonNotRunningExits1(t *testing.T) {
+	setConfigEnv(t)
+	_, _, err := executeCLI(t, Deps{}, "send", "--session", "demo-1", "--message", "hi")
+	if err == nil {
+		t.Fatal("expected error when daemon is not running")
+	}
+	if got := ExitCode(err); got != 1 {
+		t.Fatalf("exit code = %d, want 1", got)
+	}
+}
+
+func TestSend_NetworkErrorExits1(t *testing.T) {
+	cfg := setConfigEnv(t)
+	// Start and immediately close a server so the run-file points at a closed port.
+	srv, _ := sendServer(t, http.StatusOK, "{}")
+	writeRunFileFor(t, cfg, srv)
+	srv.Close()
+
+	_, _, err := executeCLI(t, Deps{
+		ProcessAlive: func(int) bool { return true },
+	}, "send", "--session", "demo-1", "--message", "hi")
+	if err == nil {
+		t.Fatal("expected runtime error from network failure")
+	}
+	if got := ExitCode(err); got != 1 {
+		t.Fatalf("exit code = %d, want 1", got)
+	}
+}

--- a/backend/internal/cli/send_test.go
+++ b/backend/internal/cli/send_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // sendServer wires an httptest server expecting POST /api/v1/sessions/{id}/send
-// and capturetures the request body and path the CLI hit.
+// and captures the request body and path the CLI hit.
 type sendCapture struct {
 	body string
 	path string
@@ -64,13 +64,13 @@ func TestSend_Success(t *testing.T) {
 		t.Fatalf("decode body: %v\nbody=%s", err, capture.body)
 	}
 	if req.Message != "hello agent" {
-		t.Errorf("capturetured message = %q, want %q", req.Message, "hello agent")
+		t.Errorf("captured message = %q, want %q", req.Message, "hello agent")
 	}
 }
 
 func TestSend_TrimsLeadingAndTrailingWhitespace(t *testing.T) {
 	cfg := setConfigEnv(t)
-	srv, captureture := sendServer(t, http.StatusOK, `{"ok":true,"sessionId":"demo-1","message":"hi"}`)
+	srv, capture := sendServer(t, http.StatusOK, `{"ok":true,"sessionId":"demo-1","message":"hi"}`)
 	writeRunFileFor(t, cfg, srv)
 
 	_, _, err := executeCLI(t, Deps{
@@ -82,8 +82,8 @@ func TestSend_TrimsLeadingAndTrailingWhitespace(t *testing.T) {
 	var req struct {
 		Message string `json:"message"`
 	}
-	if err := json.Unmarshal([]byte(captureture.body), &req); err != nil {
-		t.Fatalf("decode body: %v\nbody=%s", err, captureture.body)
+	if err := json.Unmarshal([]byte(capture.body), &req); err != nil {
+		t.Fatalf("decode body: %v\nbody=%s", err, capture.body)
 	}
 	if req.Message != "hi" {
 		t.Errorf("server received %q, want trimmed %q", req.Message, "hi")

--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -11,7 +11,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/inbox"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/zellij"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
 	"github.com/aoagents/agent-orchestrator/backend/internal/httpd"
@@ -64,7 +63,7 @@ func Run() error {
 	// dual-LCM / dual-project-store hazards that fragmented adapters create.
 	runtimeAdapter := zellij.New(zellij.Options{})
 	projects := project.NewManager(store)
-	messenger := inbox.New(newStoreWorkspaceLookup(store))
+	messenger := newSessionMessenger(store, runtimeAdapter, log)
 
 	// Terminal streaming: the Zellij runtime supplies the PTY-attach command and
 	// liveness; the CDC broadcaster feeds the session-state channel. The manager

--- a/backend/internal/daemon/session_wiring.go
+++ b/backend/internal/daemon/session_wiring.go
@@ -3,11 +3,14 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/claudecode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/portshim"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/composite"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/inbox"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/panep"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/workspace/gitworktree"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/workspace/gitworktree/projectresolver"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
@@ -74,4 +77,34 @@ func (s storeWorkspaceLookup) WorkspacePath(ctx context.Context, id domain.Sessi
 		return "", fmt.Errorf("session %s not found", id)
 	}
 	return rec.Metadata.WorkspacePath, nil
+}
+
+// storeSessionHandleLookup adapts the sqlite store to panep.SessionLookup.
+// panep needs the runtime handle id (to address the right zellij pane) and the
+// workspace path (proof the inbox messenger had a real directory to write to).
+type storeSessionHandleLookup struct{ store *sqlite.Store }
+
+func newStoreSessionHandleLookup(store *sqlite.Store) panep.SessionLookup {
+	return storeSessionHandleLookup{store: store}
+}
+
+func (s storeSessionHandleLookup) SessionHandle(ctx context.Context, id domain.SessionID) (string, string, error) {
+	rec, ok, err := s.store.GetSession(ctx, id)
+	if err != nil {
+		return "", "", err
+	}
+	if !ok {
+		return "", "", fmt.Errorf("session %s not found", id)
+	}
+	return rec.Metadata.RuntimeHandleID, rec.Metadata.WorkspacePath, nil
+}
+
+// newSessionMessenger assembles the per-daemon agent messenger: inbox (durable
+// file write, primary) wrapped in a composite with panep (live pane ping,
+// best-effort secondary). Ordering matters — see composite.Messenger for the
+// "primary must succeed, secondaries are nudges" contract.
+func newSessionMessenger(store *sqlite.Store, runtime panep.RuntimePaneWriter, logger *slog.Logger) ports.AgentMessenger {
+	inboxMsg := inbox.New(newStoreWorkspaceLookup(store))
+	panepMsg := panep.New(runtime, newStoreSessionHandleLookup(store))
+	return composite.New([]ports.AgentMessenger{inboxMsg, panepMsg}, logger)
 }

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/composite"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/inbox"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/messenger/panep"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/runtime/zellij"
 	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
 	"github.com/aoagents/agent-orchestrator/backend/internal/config"
@@ -95,7 +97,7 @@ func TestWiring_SessionStackSharesSingletons(t *testing.T) {
 
 	projects := project.NewManager(store)
 	runtime := zellij.New(zellij.Options{})
-	messenger := inbox.New(newStoreWorkspaceLookup(store))
+	messenger := newSessionMessenger(store, runtime, nil)
 	lcStack := startLifecycle(ctx, store, runtime, messenger, nil)
 	// Cancel-then-Stop in order: Stop drains the reaper goroutine, which only
 	// exits when ctx is cancelled. A naive `defer cancel(); defer lcStack.Stop()`
@@ -117,6 +119,23 @@ func TestWiring_SessionStackSharesSingletons(t *testing.T) {
 	}
 	if ss.messenger != messenger {
 		t.Error("buildSessionStack must reuse the messenger it is given, not construct a second one")
+	}
+	// The daemon's session messenger is a composite: inbox first (durable
+	// file write — must succeed), then panep (best-effort live pane ping).
+	// Reversing this would tell the agent about a file the inbox messenger
+	// failed to write.
+	comp, ok := messenger.(*composite.Messenger)
+	if !ok {
+		t.Fatalf("session messenger should be *composite.Messenger, got %T", messenger)
+	}
+	if len(comp.Inner) != 2 {
+		t.Fatalf("composite should wrap exactly 2 inner messengers (inbox + panep), got %d", len(comp.Inner))
+	}
+	if _, ok := comp.Inner[0].(*inbox.Messenger); !ok {
+		t.Errorf("composite Inner[0] should be *inbox.Messenger, got %T", comp.Inner[0])
+	}
+	if _, ok := comp.Inner[1].(*panep.Messenger); !ok {
+		t.Errorf("composite Inner[1] should be *panep.Messenger, got %T", comp.Inner[1])
 	}
 
 	// End-to-end: a session row in the shared store should be reachable through


### PR DESCRIPTION
## Summary

Closes the agent-nudge loop: the inbox messenger writes a durable file under `<workspace>/.ao/inbox/`, but the agent in its zellij pane has had no way to know a new file appeared, and there has been no `ao send` CLI (only an HTTP route). This PR closes both — the e2e demo can now drive an agent end-to-end through `ao send`.

- **`inbox.FilenameFor`** — exported helper so the inbox messenger (writes) and the new panep messenger (points) agree on a single filename per Send.
- **`inbox.WithTime` / `TimeFromContext`** — the composite messenger pins one timestamp per Send and stashes it on ctx, so multiple inner messengers that derive a filename from `(t, message)` see the same `t`. Without this, inbox's clock and panep's clock fire at different nanoseconds and the ping points at a file that does not exist.
- **`panep.Messenger`** (new package) — implements `ports.AgentMessenger` by typing a pointer into the agent pane via `zellij action write-chars`: `📥 ao: new message at .ao/inbox/<file> — please read it` then a newline. Pointer over full-body typing because multi-line messages (CI tails, code blocks) fight with the agent's input handler.
- **`composite.Messenger`** (new package) — primary (must succeed) + best-effort secondaries (logged at WARN, swallowed). Daemon wires `[inbox, panep]`: if the durable file write fails we MUST NOT tell the agent about a file that doesn't exist; if the file is written but the ping fails the agent still sees it on its next inbox check.
- **`ao send` CLI** — mirrors `ao spawn`: `--session` and `--message` required, POSTs to the existing `/api/v1/sessions/{id}/send` route (HTTP route itself is unchanged on staging). Exits 0/1/2 per CLI convention.
- **`zellij.Runtime.WriteChars`** — the narrow seam panep depends on (via a local `RuntimePaneWriter` interface in the panep package). NOT added to `ports.Runtime`; the runtime port stays narrow.

## Test plan

- [x] TDD throughout — failing tests landed before implementation in every package
- [x] `go test -race ./...` — 434 pass, 1 acceptable pre-existing failure (`TestSessionStreamsRealZellijPane`, macOS socket-length issue on staging)
- [x] `go vet ./...` clean
- [x] `gofmt -l backend/` clean
- [x] `go build ./...` clean
- [x] Self-review via subagent — Critical finding (panep/inbox filename clock mismatch) fixed in follow-up commit, plus 4 Important + 1 Minor
- [x] End-to-end integration test in `composite_test.go::TestSend_PingFilenameMatchesOnDiskFilename` wires real inbox + real panep over a tempdir and asserts the on-disk filename equals the filename in the ping body — the contract the brief implicitly required

🤖 Generated with [Claude Code](https://claude.com/claude-code)