### PR TITLE
feat(terminal): wire CDC session-state streaming through /mux WebSocket

### DIFF
--- a/backend/internal/daemon/daemon.go
+++ b/backend/internal/daemon/daemon.go
@@ -73,7 +73,8 @@ func Run() error {
 		}
 	}
 	runtimeAdapter := zellij.New(zellij.Options{SocketDir: zellijSocketDir})
-	termMgr := terminal.NewManager(runtimeAdapter, cdcPipe.Broadcaster, log)
+	termMgr := terminal.NewManager(runtimeAdapter, cdcPipe.Broadcaster, log,
+		terminal.WithSessionSource(&daemonSessionSource{store: store}))
 	defer termMgr.Close()
 
 	// Bring up the Lifecycle Manager and the reaper first: it makes the session

--- a/backend/internal/daemon/session_source.go
+++ b/backend/internal/daemon/session_source.go
@@ -29,14 +29,6 @@ func (s *daemonSessionSource) AllSessions(ctx context.Context) ([]domain.Session
 	return out, nil
 }
 
-func (s *daemonSessionSource) Session(ctx context.Context, id domain.SessionID) (domain.Session, bool, error) {
-	rec, ok, err := s.store.GetSession(ctx, id)
-	if err != nil || !ok {
-		return domain.Session{}, ok, err
-	}
-	return s.toSession(ctx, rec), true, nil
-}
-
 func (s *daemonSessionSource) toSession(ctx context.Context, rec domain.SessionRecord) domain.Session {
 	pr, ok, _ := s.store.GetDisplayPRFactsForSession(ctx, rec.ID)
 	if ok {

--- a/backend/internal/daemon/session_source.go
+++ b/backend/internal/daemon/session_source.go
@@ -1,0 +1,46 @@
+package daemon
+
+import (
+	"context"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/terminal"
+)
+
+// daemonSessionSource implements terminal.SessionSource over the sqlite store.
+// It resolves each session's derived display Status (record + PR facts) so the
+// terminal manager can build SessionPatch frames without importing the service layer.
+type daemonSessionSource struct {
+	store *sqlite.Store
+}
+
+var _ terminal.SessionSource = (*daemonSessionSource)(nil)
+
+func (s *daemonSessionSource) AllSessions(ctx context.Context) ([]domain.Session, error) {
+	recs, err := s.store.ListAllSessions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]domain.Session, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, s.toSession(ctx, rec))
+	}
+	return out, nil
+}
+
+func (s *daemonSessionSource) Session(ctx context.Context, id domain.SessionID) (domain.Session, bool, error) {
+	rec, ok, err := s.store.GetSession(ctx, id)
+	if err != nil || !ok {
+		return domain.Session{}, ok, err
+	}
+	return s.toSession(ctx, rec), true, nil
+}
+
+func (s *daemonSessionSource) toSession(ctx context.Context, rec domain.SessionRecord) domain.Session {
+	pr, ok, _ := s.store.GetDisplayPRFactsForSession(ctx, rec.ID)
+	if ok {
+		return domain.Session{SessionRecord: rec, Status: domain.DeriveStatus(rec, &pr)}
+	}
+	return domain.Session{SessionRecord: rec, Status: domain.DeriveStatus(rec, nil)}
+}

--- a/backend/internal/domain/status.go
+++ b/backend/internal/domain/status.go
@@ -19,3 +19,48 @@ const (
 	StatusIdle             SessionStatus = "idle"
 	StatusTerminated       SessionStatus = "terminated"
 )
+
+// DeriveStatus computes the user-facing display status from a SessionRecord and
+// optional PR facts. pr nil means the session has no associated PR.
+func DeriveStatus(rec SessionRecord, pr *PRFacts) SessionStatus {
+	if rec.IsTerminated {
+		if pr != nil && pr.Merged {
+			return StatusMerged
+		}
+		return StatusTerminated
+	}
+	if rec.Activity.State == ActivityWaitingInput {
+		return StatusNeedsInput
+	}
+	if pr != nil {
+		if pr.Merged {
+			return StatusMerged
+		}
+		if !pr.Closed {
+			return prPipelineStatus(*pr)
+		}
+	}
+	if rec.Activity.State == ActivityActive {
+		return StatusWorking
+	}
+	return StatusIdle
+}
+
+func prPipelineStatus(pr PRFacts) SessionStatus {
+	switch {
+	case pr.CI == CIFailing:
+		return StatusCIFailed
+	case pr.Draft:
+		return StatusDraft
+	case pr.Review == ReviewChangesRequest || pr.ReviewComments:
+		return StatusChangesRequested
+	case pr.Mergeability == MergeMergeable:
+		return StatusMergeable
+	case pr.Review == ReviewApproved:
+		return StatusApproved
+	case pr.Review == ReviewRequired:
+		return StatusReviewPending
+	default:
+		return StatusPROpen
+	}
+}

--- a/backend/internal/httpd/terminal_mux.go
+++ b/backend/internal/httpd/terminal_mux.go
@@ -25,13 +25,13 @@ func mountTerminalMux(r chi.Router, mgr *terminal.Manager, log *slog.Logger) {
 	if mgr == nil {
 		return
 	}
-	r.Get("/mux", terminalMuxHandler(mgr, log))
+	r.Get("/mux", TerminalMuxHandler(mgr, log))
 }
 
-// terminalMuxHandler upgrades the request to a WebSocket and hands the connection to the
+// TerminalMuxHandler upgrades the request to a WebSocket and hands the connection to the
 // terminal manager. httpd owns only the upgrade and the transport adaptation;
 // all stream logic lives in internal/terminal.
-func terminalMuxHandler(mgr *terminal.Manager, log *slog.Logger) http.HandlerFunc {
+func TerminalMuxHandler(mgr *terminal.Manager, log *slog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// InsecureSkipVerify disables coder/websocket's same-origin check: the
 		// daemon binds loopback only and the desktop renderer's origin differs

--- a/backend/internal/integration/mux_streaming_functional_test.go
+++ b/backend/internal/integration/mux_streaming_functional_test.go
@@ -37,14 +37,6 @@ func (s *testSessionSource) AllSessions(ctx context.Context) ([]domain.Session, 
 	return out, nil
 }
 
-func (s *testSessionSource) Session(ctx context.Context, id domain.SessionID) (domain.Session, bool, error) {
-	rec, ok, err := s.store.GetSession(ctx, id)
-	if err != nil || !ok {
-		return domain.Session{}, ok, err
-	}
-	return s.toSession(ctx, rec), true, nil
-}
-
 func (s *testSessionSource) toSession(ctx context.Context, rec domain.SessionRecord) domain.Session {
 	pr, ok, _ := s.store.GetDisplayPRFactsForSession(ctx, rec.ID)
 	if ok {

--- a/backend/internal/integration/mux_streaming_functional_test.go
+++ b/backend/internal/integration/mux_streaming_functional_test.go
@@ -146,7 +146,7 @@ func TestMuxStreamingSessionPatchDelivery(t *testing.T) {
 	t.Cleanup(func() { _ = conn.CloseNow() })
 
 	// Subscribe and receive the initial empty snapshot.
-	sendMux(ctx, t, conn, muxMsg{"ch": "subscribe", "type": "subscribe"})
+	sendMux(ctx, t, conn, muxMsg{"ch": "subscribe", "topics": []string{"sessions", "notifications"}})
 	m := recvMux(ctx, t, conn, "sessions", "snapshot")
 	sessions := toSlice(t, m["sessions"])
 	if len(sessions) != 0 {
@@ -228,7 +228,7 @@ func TestMuxStreamingPatchReflectsPRDerivedStatus(t *testing.T) {
 		t.Fatalf("spawn: %v", err)
 	}
 
-	sendMux(ctx, t, conn, muxMsg{"ch": "subscribe", "type": "subscribe"})
+	sendMux(ctx, t, conn, muxMsg{"ch": "subscribe", "topics": []string{"sessions", "notifications"}})
 	recvMux(ctx, t, conn, "sessions", "snapshot") // drain initial snapshot
 
 	// A failing CI check on the PR makes the session derive to ci_failed.
@@ -300,7 +300,7 @@ func TestMuxStreamingInitialSnapshotContainsExistingSessions(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = conn.CloseNow() })
 
-	sendMux(ctx, t, conn, muxMsg{"ch": "subscribe", "type": "subscribe"})
+	sendMux(ctx, t, conn, muxMsg{"ch": "subscribe", "topics": []string{"sessions", "notifications"}})
 	m := recvMux(ctx, t, conn, "sessions", "snapshot")
 	sessions := toSlice(t, m["sessions"])
 	if len(sessions) != 1 {

--- a/backend/internal/integration/mux_streaming_functional_test.go
+++ b/backend/internal/integration/mux_streaming_functional_test.go
@@ -1,0 +1,313 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/httpd"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+	"github.com/aoagents/agent-orchestrator/backend/internal/storage/sqlite"
+	"github.com/aoagents/agent-orchestrator/backend/internal/terminal"
+)
+
+// testSessionSource implements terminal.SessionSource over the sqlite store,
+// replicating the production daemonSessionSource without importing the daemon package.
+type testSessionSource struct{ store *sqlite.Store }
+
+func (s *testSessionSource) AllSessions(ctx context.Context) ([]domain.Session, error) {
+	recs, err := s.store.ListAllSessions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]domain.Session, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, s.toSession(ctx, rec))
+	}
+	return out, nil
+}
+
+func (s *testSessionSource) Session(ctx context.Context, id domain.SessionID) (domain.Session, bool, error) {
+	rec, ok, err := s.store.GetSession(ctx, id)
+	if err != nil || !ok {
+		return domain.Session{}, ok, err
+	}
+	return s.toSession(ctx, rec), true, nil
+}
+
+func (s *testSessionSource) toSession(ctx context.Context, rec domain.SessionRecord) domain.Session {
+	pr, ok, _ := s.store.GetDisplayPRFactsForSession(ctx, rec.ID)
+	if ok {
+		return domain.Session{SessionRecord: rec, Status: domain.DeriveStatus(rec, &pr)}
+	}
+	return domain.Session{SessionRecord: rec, Status: domain.DeriveStatus(rec, nil)}
+}
+
+// muxMsg is the on-wire frame shape for both directions. Using raw maps keeps
+// the test decoupled from the internal protocol types.
+type muxMsg map[string]any
+
+func sendMux(ctx context.Context, t *testing.T, c *websocket.Conn, msg muxMsg) {
+	t.Helper()
+	if err := wsjson.Write(ctx, c, msg); err != nil {
+		t.Fatalf("mux write: %v", err)
+	}
+}
+
+// recvMux reads frames until one matching ch+typ is found (draining others).
+func recvMux(ctx context.Context, t *testing.T, c *websocket.Conn, ch, typ string) muxMsg {
+	t.Helper()
+	deadline, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	for {
+		var raw json.RawMessage
+		if err := wsjson.Read(deadline, c, &raw); err != nil {
+			t.Fatalf("mux read waiting for %s/%s: %v", ch, typ, err)
+		}
+		var m muxMsg
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatalf("mux unmarshal: %v", err)
+		}
+		if m["ch"] == ch && m["type"] == typ {
+			return m
+		}
+	}
+}
+
+func discardLog() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// noopPTYSource satisfies terminal.PTYSource without spawning real PTYs.
+type noopPTYSource struct{}
+
+func (noopPTYSource) AttachCommand(ports.RuntimeHandle) ([]string, error) {
+	return []string{"true"}, nil
+}
+func (noopPTYSource) IsAlive(context.Context, ports.RuntimeHandle) (bool, error) {
+	return false, nil
+}
+
+// toSlice casts the "sessions" field from a muxMsg to []any.
+func toSlice(t *testing.T, v any) []any {
+	t.Helper()
+	if v == nil {
+		return nil
+	}
+	s, ok := v.([]any)
+	if !ok {
+		t.Fatalf("sessions field is %T, want []any", v)
+	}
+	return s
+}
+
+// TestMuxStreamingSessionPatchDelivery is a functional end-to-end test of the
+// CDC → terminal.Manager → WebSocket → sessionPatch delivery path:
+//
+//  1. Subscribe on /mux — receives empty initial snapshot.
+//  2. Spawn a session (triggers a DB INSERT → change_log DB trigger).
+//  3. Poll CDC — broadcaster fires → terminal.Manager enqueues sessionPatch.
+//  4. Client receives a sessions/snapshot frame containing the spawned session.
+func TestMuxStreamingSessionPatchDelivery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	st := newStack(t)
+
+	bc := cdc.NewBroadcaster()
+	poller := cdc.NewPoller(st.store, bc, cdc.PollerConfig{StartSeq: 0})
+
+	src := &testSessionSource{store: st.store}
+	mgr := terminal.NewManager(
+		&noopPTYSource{},
+		bc,
+		discardLog(),
+		terminal.WithHeartbeat(0),
+		terminal.WithSessionSource(src),
+	)
+	t.Cleanup(mgr.Close)
+
+	srv := httptest.NewServer(httpd.TerminalMuxHandler(mgr, discardLog()))
+	t.Cleanup(srv.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.CloseNow() })
+
+	// Subscribe and receive the initial empty snapshot.
+	sendMux(ctx, t, conn, muxMsg{"ch": "subscribe", "type": "subscribe"})
+	m := recvMux(ctx, t, conn, "sessions", "snapshot")
+	sessions := toSlice(t, m["sessions"])
+	if len(sessions) != 0 {
+		t.Fatalf("initial snapshot: want 0 sessions, got %d", len(sessions))
+	}
+
+	// Spawn a session — this inserts into sessions, which triggers the DB
+	// trigger writing to change_log.
+	sess, err := st.sm.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker, Branch: "test-branch", Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+
+	// Poll CDC: tails change_log and publishes to the broadcaster, which the
+	// terminal.Manager subscription picks up and enqueues as sessionPatch.
+	if err := poller.Poll(ctx); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	// The client must receive a sessions/snapshot frame containing the spawned session.
+	m = recvMux(ctx, t, conn, "sessions", "snapshot")
+	sessions = toSlice(t, m["sessions"])
+	if len(sessions) != 1 {
+		t.Fatalf("post-spawn snapshot: want 1 session, got %d: %v", len(sessions), sessions)
+	}
+
+	patch := sessions[0].(map[string]any)
+	if patch["id"] != string(sess.ID) {
+		t.Fatalf("session id: got %q, want %q", patch["id"], sess.ID)
+	}
+	// A freshly spawned worker with no PR derives to idle/idle, which maps to the
+	// "working" attention level. Assert the exact mapping, not just presence.
+	if patch["status"] != "idle" {
+		t.Fatalf("status: got %q, want %q", patch["status"], "idle")
+	}
+	if patch["activity"] != "idle" {
+		t.Fatalf("activity: got %q, want %q", patch["activity"], "idle")
+	}
+	if patch["attentionLevel"] != "working" {
+		t.Fatalf("attentionLevel: got %q, want %q", patch["attentionLevel"], "working")
+	}
+}
+
+// TestMuxStreamingPatchReflectsPRDerivedStatus drives a PR observation that makes
+// the session derive to ci_failed and asserts the live patch carries the derived
+// status and its mapped attention level — exercising the per-event enrichment path
+// with a non-trivial status mapping.
+func TestMuxStreamingPatchReflectsPRDerivedStatus(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	st := newStack(t)
+
+	bc := cdc.NewBroadcaster()
+	poller := cdc.NewPoller(st.store, bc, cdc.PollerConfig{StartSeq: 0})
+
+	src := &testSessionSource{store: st.store}
+	mgr := terminal.NewManager(
+		&noopPTYSource{},
+		bc,
+		discardLog(),
+		terminal.WithHeartbeat(0),
+		terminal.WithSessionSource(src),
+	)
+	t.Cleanup(mgr.Close)
+
+	srv := httptest.NewServer(httpd.TerminalMuxHandler(mgr, discardLog()))
+	t.Cleanup(srv.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.CloseNow() })
+
+	sess, err := st.sm.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker, Branch: "b", Prompt: "go"})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+
+	sendMux(ctx, t, conn, muxMsg{"ch": "subscribe", "type": "subscribe"})
+	recvMux(ctx, t, conn, "sessions", "snapshot") // drain initial snapshot
+
+	// A failing CI check on the PR makes the session derive to ci_failed.
+	if err := st.prm.ApplyObservation(ctx, sess.ID, ports.PRObservation{
+		Fetched: true, URL: "pr1", Number: 1, CI: domain.CIFailing,
+		Checks: []ports.PRCheckObservation{{Name: "build", CommitHash: "c1", Status: domain.PRCheckFailed, LogTail: "boom"}},
+	}); err != nil {
+		t.Fatalf("apply observation: %v", err)
+	}
+	if err := poller.Poll(ctx); err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+
+	// Drain patches until one reports the spawned session as ci_failed.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if time.Now().After(deadline) {
+			t.Fatal("did not receive a ci_failed patch within 3s")
+		}
+		m := recvMux(ctx, t, conn, "sessions", "snapshot")
+		sessions := toSlice(t, m["sessions"])
+		if len(sessions) == 0 {
+			continue
+		}
+		patch := sessions[0].(map[string]any)
+		if patch["id"] != string(sess.ID) || patch["status"] != "ci_failed" {
+			continue
+		}
+		if patch["attentionLevel"] != "review" {
+			t.Fatalf("attentionLevel: got %q, want %q", patch["attentionLevel"], "review")
+		}
+		break
+	}
+}
+
+// TestMuxStreamingInitialSnapshotContainsExistingSessions verifies that sessions
+// already in the store at subscribe-time appear in the first snapshot — the
+// subscriber does not miss sessions that predate the connection.
+func TestMuxStreamingInitialSnapshotContainsExistingSessions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	st := newStack(t)
+
+	// Spawn a session BEFORE the client connects.
+	sess, err := st.sm.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker})
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+
+	bc := cdc.NewBroadcaster()
+	src := &testSessionSource{store: st.store}
+	mgr := terminal.NewManager(
+		&noopPTYSource{},
+		bc,
+		discardLog(),
+		terminal.WithHeartbeat(0),
+		terminal.WithSessionSource(src),
+	)
+	t.Cleanup(mgr.Close)
+
+	srv := httptest.NewServer(httpd.TerminalMuxHandler(mgr, discardLog()))
+	t.Cleanup(srv.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("websocket dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.CloseNow() })
+
+	sendMux(ctx, t, conn, muxMsg{"ch": "subscribe", "type": "subscribe"})
+	m := recvMux(ctx, t, conn, "sessions", "snapshot")
+	sessions := toSlice(t, m["sessions"])
+	if len(sessions) != 1 {
+		t.Fatalf("initial snapshot: want 1 session, got %d", len(sessions))
+	}
+	patch := sessions[0].(map[string]any)
+	if patch["id"] != string(sess.ID) {
+		t.Fatalf("session id: got %q, want %q", patch["id"], sess.ID)
+	}
+}

--- a/backend/internal/service/session/status.go
+++ b/backend/internal/service/session/status.go
@@ -3,47 +3,5 @@ package session
 import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
 
 func deriveStatus(rec domain.SessionRecord, pr *domain.PRFacts) domain.SessionStatus {
-	if rec.IsTerminated {
-		if pr != nil && pr.Merged {
-			return domain.StatusMerged
-		}
-		return domain.StatusTerminated
-	}
-
-	if rec.Activity.State == domain.ActivityWaitingInput {
-		return domain.StatusNeedsInput
-	}
-
-	if pr != nil {
-		if pr.Merged {
-			return domain.StatusMerged
-		}
-		if !pr.Closed {
-			return prPipelineStatus(*pr)
-		}
-	}
-
-	if rec.Activity.State == domain.ActivityActive {
-		return domain.StatusWorking
-	}
-	return domain.StatusIdle
-}
-
-func prPipelineStatus(pr domain.PRFacts) domain.SessionStatus {
-	switch {
-	case pr.CI == domain.CIFailing:
-		return domain.StatusCIFailed
-	case pr.Draft:
-		return domain.StatusDraft
-	case pr.Review == domain.ReviewChangesRequest || pr.ReviewComments:
-		return domain.StatusChangesRequested
-	case pr.Mergeability == domain.MergeMergeable:
-		return domain.StatusMergeable
-	case pr.Review == domain.ReviewApproved:
-		return domain.StatusApproved
-	case pr.Review == domain.ReviewRequired:
-		return domain.StatusReviewPending
-	default:
-		return domain.StatusPROpen
-	}
+	return domain.DeriveStatus(rec, pr)
 }

--- a/backend/internal/terminal/fakes_test.go
+++ b/backend/internal/terminal/fakes_test.go
@@ -20,15 +20,6 @@ func (f *fakeSessionSource) AllSessions(_ context.Context) ([]domain.Session, er
 	return f.all, nil
 }
 
-func (f *fakeSessionSource) Session(_ context.Context, id domain.SessionID) (domain.Session, bool, error) {
-	for _, s := range f.all {
-		if s.ID == id {
-			return s, true, nil
-		}
-	}
-	return domain.Session{}, false, nil
-}
-
 // fakeSource is a scripted PTYSource.
 type fakeSource struct {
 	argv      []string

--- a/backend/internal/terminal/fakes_test.go
+++ b/backend/internal/terminal/fakes_test.go
@@ -7,8 +7,27 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
+
+// fakeSessionSource is a scripted SessionSource for tests.
+type fakeSessionSource struct {
+	all []domain.Session
+}
+
+func (f *fakeSessionSource) AllSessions(_ context.Context) ([]domain.Session, error) {
+	return f.all, nil
+}
+
+func (f *fakeSessionSource) Session(_ context.Context, id domain.SessionID) (domain.Session, bool, error) {
+	for _, s := range f.all {
+		if s.ID == id {
+			return s, true, nil
+		}
+	}
+	return domain.Session{}, false, nil
+}
 
 // fakeSource is a scripted PTYSource.
 type fakeSource struct {

--- a/backend/internal/terminal/manager.go
+++ b/backend/internal/terminal/manager.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
-	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -154,7 +153,7 @@ func (m *Manager) Serve(ctx context.Context, conn wsConn) {
 		conn:          conn,
 		cancel:        cancel,
 		out:           make(chan serverMsg, defaultWriteBuffer),
-		sessionEvents: make(chan sessionEvent, defaultWriteBuffer),
+		sessionEvents: make(chan struct{}, defaultWriteBuffer),
 		terms:         map[string]func(){},
 	}
 	defer c.cleanup()
@@ -174,25 +173,19 @@ func (m *Manager) Serve(ctx context.Context, conn wsConn) {
 	}
 }
 
-// sessionEvent is a unit of work for the session-state writer. snapshot=true
-// means "emit a full snapshot of all sessions"; otherwise id names the single
-// session to re-read and patch. Both are resolved live in the writer goroutine,
-// so whichever the client sees last reflects the freshest state.
-type sessionEvent struct {
-	snapshot bool
-	id       string
-}
-
 // connState is the per-connection mutable state.
 type connState struct {
 	mgr    *Manager
 	conn   wsConn
 	cancel context.CancelFunc
 	out    chan serverMsg
-	// sessionEvents is the single ordered queue feeding the session-state writer.
-	// The CDC callback pushes lightweight items (it runs on the poller loop and
-	// must not block); the writer goroutine does all DB reads off that hot path.
-	sessionEvents chan sessionEvent
+	// sessionEvents signals the session-state writer to emit a fresh full
+	// snapshot. Every signal means the same thing, so the writer coalesces
+	// bursts into one read. The CDC callback pushes here (it runs on the poller
+	// loop and must not block); the writer does the DB read off that hot path.
+	// Full snapshots (not single-session patches) are sent because the frontend
+	// replaces its session list wholesale on each "snapshot" frame.
+	sessionEvents chan struct{}
 
 	mu        sync.Mutex
 	terms     map[string]func() // terminal id -> unsubscribe
@@ -338,17 +331,16 @@ func (c *connState) handleSubscribe(msg clientMsg) {
 	}
 	c.mu.Unlock()
 
-	// Subscribe before enqueueing the snapshot so an event that fires during
-	// setup is not lost. Both the snapshot and per-session patches flow through
-	// the one ordered sessionEvents queue and are resolved live in the writer,
-	// so the last frame the client sees for any session reflects current state
-	// regardless of interleaving. The callback runs on the poller loop and must
-	// not block, so it only forwards the SessionID.
+	// Subscribe before queueing the initial snapshot so an event that fires
+	// during setup is not lost. Every signal triggers a full snapshot resolved
+	// live in the writer, so the last frame the client sees always reflects
+	// current state regardless of queue interleaving. The callback runs on the
+	// poller loop and must not block, so it only pushes a signal.
 	unsub := c.mgr.events.Subscribe(func(e cdc.Event) {
 		if c.mgr.sessionSrc == nil || e.SessionID == "" {
 			return
 		}
-		c.pushSessionEvent(sessionEvent{id: e.SessionID})
+		c.pushSessionEvent()
 	})
 	c.mu.Lock()
 	c.unsubEvts = unsub
@@ -356,18 +348,29 @@ func (c *connState) handleSubscribe(msg clientMsg) {
 
 	// Queue an initial full snapshot so the client gets current state immediately.
 	if c.mgr.sessionSrc != nil {
-		c.pushSessionEvent(sessionEvent{snapshot: true})
+		c.pushSessionEvent()
 	}
 }
 
-// pushSessionEvent queues a session-state work item for the writer. A full
-// buffer means the client cannot keep up; tear the connection down rather than
-// block the poller loop the CDC callback runs on.
-func (c *connState) pushSessionEvent(ev sessionEvent) {
+// pushSessionEvent signals the writer to emit a fresh snapshot. A full buffer
+// already holds a pending signal that will capture the latest state, so drop
+// the redundant one rather than block the poller loop the CDC callback runs on.
+func (c *connState) pushSessionEvent() {
 	select {
-	case c.sessionEvents <- ev:
+	case c.sessionEvents <- struct{}{}:
 	default:
-		c.cancel()
+	}
+}
+
+// drainSignals empties any pending signals without blocking. Used to coalesce a
+// burst of session-state signals into a single snapshot read.
+func drainSignals(ch <-chan struct{}) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
 	}
 }
 
@@ -392,29 +395,21 @@ func (c *connState) writeLoop(ctx context.Context) {
 				c.cancel()
 				return
 			}
-		case ev := <-c.sessionEvents:
-			// Resolve state here, off the broadcaster's hot path. Reading live at
-			// write time (not enqueue time) means the last frame for any session
-			// always reflects current state, whatever the queue interleaving.
+		case <-c.sessionEvents:
+			// Coalesce bursts: every queued signal means the same thing, so
+			// collapse them into one read. Resolving state here, off the
+			// broadcaster's hot path and at write time, means the snapshot always
+			// reflects current state whatever the queue interleaving.
+			drainSignals(c.sessionEvents)
 			if c.mgr.sessionSrc == nil {
 				continue
 			}
-			var patches []sessionPatch
-			if ev.snapshot {
-				all, err := c.mgr.sessionSrc.AllSessions(ctx)
-				if err != nil {
-					c.mgr.log.Warn("terminal: failed to fetch session snapshot", "err", err)
-					continue
-				}
-				patches = toSessionPatches(all)
-			} else {
-				sess, ok, err := c.mgr.sessionSrc.Session(ctx, domain.SessionID(ev.id))
-				if err != nil || !ok {
-					continue // vanished session: skip silently
-				}
-				patches = []sessionPatch{toSessionPatch(sess)}
+			all, err := c.mgr.sessionSrc.AllSessions(ctx)
+			if err != nil {
+				c.mgr.log.Warn("terminal: failed to fetch session snapshot", "err", err)
+				continue
 			}
-			if err := c.conn.WriteJSON(ctx, serverMsg{Ch: chSessions, Type: msgSnapshot, Sessions: patches}); err != nil {
+			if err := c.conn.WriteJSON(ctx, serverMsg{Ch: chSessions, Type: msgSnapshot, Sessions: toSessionPatches(all)}); err != nil {
 				c.cancel()
 				return
 			}

--- a/backend/internal/terminal/manager.go
+++ b/backend/internal/terminal/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"log/slog"
+	"slices"
 	"sync"
 	"time"
 
@@ -327,7 +328,7 @@ func (c *connState) lookup(id string) *session {
 }
 
 func (c *connState) handleSubscribe(msg clientMsg) {
-	if msg.Type != msgSubscribe || c.mgr.events == nil {
+	if c.mgr.events == nil || !slices.Contains(msg.Topics, topicSessions) {
 		return
 	}
 	c.mu.Lock()

--- a/backend/internal/terminal/manager.go
+++ b/backend/internal/terminal/manager.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -38,11 +39,12 @@ const (
 // Sessions outlive any single connection: multiple clients can attach to the
 // same pane, and a client reconnect re-subscribes to the existing session.
 type Manager struct {
-	src       PTYSource
-	events    EventSource
-	spawn     spawnFunc
-	log       *slog.Logger
-	heartbeat time.Duration
+	src        PTYSource
+	events     EventSource
+	sessionSrc SessionSource // nil disables the session-state feed
+	spawn      spawnFunc
+	log        *slog.Logger
+	heartbeat  time.Duration
 
 	// ctx scopes every session's PTY lifetime; cancelled by Close.
 	ctx    context.Context
@@ -61,6 +63,13 @@ func WithSpawn(fn spawnFunc) Option { return func(m *Manager) { m.spawn = fn } }
 
 // WithHeartbeat overrides the ping interval.
 func WithHeartbeat(d time.Duration) Option { return func(m *Manager) { m.heartbeat = d } }
+
+// WithSessionSource wires the session-state feed: when set the manager sends a
+// full snapshot on subscribe and a per-session patch on every CDC event. Pass
+// nil (the default) to disable session-state delivery.
+func WithSessionSource(src SessionSource) Option {
+	return func(m *Manager) { m.sessionSrc = src }
+}
 
 // NewManager builds a Manager. src attaches PTYs; events feeds the session
 // channel (may be nil to disable it). A nil logger falls back to slog.Default.
@@ -140,11 +149,12 @@ func (m *Manager) Serve(ctx context.Context, conn wsConn) {
 	defer cancel()
 
 	c := &connState{
-		mgr:    m,
-		conn:   conn,
-		cancel: cancel,
-		out:    make(chan serverMsg, defaultWriteBuffer),
-		terms:  map[string]func(){},
+		mgr:           m,
+		conn:          conn,
+		cancel:        cancel,
+		out:           make(chan serverMsg, defaultWriteBuffer),
+		sessionEvents: make(chan sessionEvent, defaultWriteBuffer),
+		terms:         map[string]func(){},
 	}
 	defer c.cleanup()
 
@@ -163,12 +173,25 @@ func (m *Manager) Serve(ctx context.Context, conn wsConn) {
 	}
 }
 
+// sessionEvent is a unit of work for the session-state writer. snapshot=true
+// means "emit a full snapshot of all sessions"; otherwise id names the single
+// session to re-read and patch. Both are resolved live in the writer goroutine,
+// so whichever the client sees last reflects the freshest state.
+type sessionEvent struct {
+	snapshot bool
+	id       string
+}
+
 // connState is the per-connection mutable state.
 type connState struct {
 	mgr    *Manager
 	conn   wsConn
 	cancel context.CancelFunc
 	out    chan serverMsg
+	// sessionEvents is the single ordered queue feeding the session-state writer.
+	// The CDC callback pushes lightweight items (it runs on the poller loop and
+	// must not block); the writer goroutine does all DB reads off that hot path.
+	sessionEvents chan sessionEvent
 
 	mu        sync.Mutex
 	terms     map[string]func() // terminal id -> unsubscribe
@@ -314,21 +337,37 @@ func (c *connState) handleSubscribe(msg clientMsg) {
 	}
 	c.mu.Unlock()
 
+	// Subscribe before enqueueing the snapshot so an event that fires during
+	// setup is not lost. Both the snapshot and per-session patches flow through
+	// the one ordered sessionEvents queue and are resolved live in the writer,
+	// so the last frame the client sees for any session reflects current state
+	// regardless of interleaving. The callback runs on the poller loop and must
+	// not block, so it only forwards the SessionID.
 	unsub := c.mgr.events.Subscribe(func(e cdc.Event) {
-		c.enqueue(serverMsg{
-			Ch:   chSessions,
-			Type: msgSnapshot,
-			Session: &sessionUpdate{
-				Seq:       e.Seq,
-				ProjectID: e.ProjectID,
-				SessionID: e.SessionID,
-				EventType: string(e.Type),
-			},
-		})
+		if c.mgr.sessionSrc == nil || e.SessionID == "" {
+			return
+		}
+		c.pushSessionEvent(sessionEvent{id: e.SessionID})
 	})
 	c.mu.Lock()
 	c.unsubEvts = unsub
 	c.mu.Unlock()
+
+	// Queue an initial full snapshot so the client gets current state immediately.
+	if c.mgr.sessionSrc != nil {
+		c.pushSessionEvent(sessionEvent{snapshot: true})
+	}
+}
+
+// pushSessionEvent queues a session-state work item for the writer. A full
+// buffer means the client cannot keep up; tear the connection down rather than
+// block the poller loop the CDC callback runs on.
+func (c *connState) pushSessionEvent(ev sessionEvent) {
+	select {
+	case c.sessionEvents <- ev:
+	default:
+		c.cancel()
+	}
 }
 
 // enqueue pushes a frame to the writer. If the buffer is full the client is too
@@ -349,6 +388,32 @@ func (c *connState) writeLoop(ctx context.Context) {
 			return
 		case msg := <-c.out:
 			if err := c.conn.WriteJSON(ctx, msg); err != nil {
+				c.cancel()
+				return
+			}
+		case ev := <-c.sessionEvents:
+			// Resolve state here, off the broadcaster's hot path. Reading live at
+			// write time (not enqueue time) means the last frame for any session
+			// always reflects current state, whatever the queue interleaving.
+			if c.mgr.sessionSrc == nil {
+				continue
+			}
+			var patches []sessionPatch
+			if ev.snapshot {
+				all, err := c.mgr.sessionSrc.AllSessions(ctx)
+				if err != nil {
+					c.mgr.log.Warn("terminal: failed to fetch session snapshot", "err", err)
+					continue
+				}
+				patches = toSessionPatches(all)
+			} else {
+				sess, ok, err := c.mgr.sessionSrc.Session(ctx, domain.SessionID(ev.id))
+				if err != nil || !ok {
+					continue // vanished session: skip silently
+				}
+				patches = []sessionPatch{toSessionPatch(sess)}
+			}
+			if err := c.conn.WriteJSON(ctx, serverMsg{Ch: chSessions, Type: msgSnapshot, Sessions: patches}); err != nil {
 				c.cancel()
 				return
 			}

--- a/backend/internal/terminal/manager_test.go
+++ b/backend/internal/terminal/manager_test.go
@@ -250,10 +250,39 @@ func TestServeSessionChannelSendsInitialSnapshot(t *testing.T) {
 	defer cancel()
 	go mgr.Serve(ctx, conn)
 
-	conn.in <- clientMsg{Ch: chSubscribe, Type: msgSubscribe}
+	conn.in <- clientMsg{Ch: chSubscribe, Topics: []string{topicSessions}}
 	m := recv(t, conn, chSessions, msgSnapshot, time.Second)
 	if len(m.Sessions) != 1 || m.Sessions[0].ID != "s1" || m.Sessions[0].Status != "working" {
 		t.Fatalf("initial snapshot = %+v, want 1 session with id=s1 status=working", m.Sessions)
+	}
+}
+
+func TestServeSubscribeWithoutSessionsTopicSendsNoSnapshot(t *testing.T) {
+	bc := cdc.NewBroadcaster()
+	src := &fakeSessionSource{all: []domain.Session{{
+		SessionRecord: domain.SessionRecord{ID: "s1", ProjectID: "p1"},
+		Status:        domain.StatusWorking,
+	}}}
+	mgr := NewManager(&fakeSource{}, bc, testLogger(),
+		WithSpawn((&fakeSpawner{}).spawn), WithHeartbeat(0), WithSessionSource(src))
+	defer mgr.Close()
+
+	conn := newFakeConn()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go mgr.Serve(ctx, conn)
+
+	// A client opting into only "notifications" must not be subscribed to the
+	// session feed: no snapshot, and CDC events are not forwarded.
+	conn.in <- clientMsg{Ch: chSubscribe, Topics: []string{"notifications"}}
+	bc.Publish(cdc.Event{Seq: 1, ProjectID: "p1", SessionID: "s1", Type: cdc.EventSessionUpdated})
+
+	select {
+	case m := <-conn.out:
+		if m.Ch == chSessions {
+			t.Fatalf("got unexpected sessions frame for non-sessions subscriber: %+v", m)
+		}
+	case <-time.After(200 * time.Millisecond):
 	}
 }
 
@@ -277,7 +306,7 @@ func TestServeForwardsSessionChannelFromCDC(t *testing.T) {
 	defer cancel()
 	go mgr.Serve(ctx, conn)
 
-	conn.in <- clientMsg{Ch: chSubscribe, Type: msgSubscribe}
+	conn.in <- clientMsg{Ch: chSubscribe, Topics: []string{topicSessions}}
 	// Drain the initial snapshot.
 	recv(t, conn, chSessions, msgSnapshot, time.Second)
 

--- a/backend/internal/terminal/manager_test.go
+++ b/backend/internal/terminal/manager_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/cdc"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
 	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
 )
 
@@ -229,9 +230,19 @@ func TestServeRejectsOpenWithoutID(t *testing.T) {
 	}
 }
 
-func TestServeForwardsSessionChannelFromCDC(t *testing.T) {
+func TestServeSessionChannelSendsInitialSnapshot(t *testing.T) {
 	bc := cdc.NewBroadcaster()
-	mgr := NewManager(&fakeSource{}, bc, testLogger(), WithSpawn((&fakeSpawner{}).spawn), WithHeartbeat(0))
+	sess := domain.Session{
+		SessionRecord: domain.SessionRecord{
+			ID:        "s1",
+			ProjectID: "p1",
+			Activity:  domain.Activity{State: domain.ActivityActive},
+		},
+		Status: domain.StatusWorking,
+	}
+	src := &fakeSessionSource{all: []domain.Session{sess}}
+	mgr := NewManager(&fakeSource{}, bc, testLogger(),
+		WithSpawn((&fakeSpawner{}).spawn), WithHeartbeat(0), WithSessionSource(src))
 	defer mgr.Close()
 
 	conn := newFakeConn()
@@ -240,12 +251,42 @@ func TestServeForwardsSessionChannelFromCDC(t *testing.T) {
 	go mgr.Serve(ctx, conn)
 
 	conn.in <- clientMsg{Ch: chSubscribe, Type: msgSubscribe}
-	// Give the subscription time to register before publishing.
+	m := recv(t, conn, chSessions, msgSnapshot, time.Second)
+	if len(m.Sessions) != 1 || m.Sessions[0].ID != "s1" || m.Sessions[0].Status != "working" {
+		t.Fatalf("initial snapshot = %+v, want 1 session with id=s1 status=working", m.Sessions)
+	}
+}
+
+func TestServeForwardsSessionChannelFromCDC(t *testing.T) {
+	bc := cdc.NewBroadcaster()
+	sess := domain.Session{
+		SessionRecord: domain.SessionRecord{
+			ID:        "s1",
+			ProjectID: "p1",
+			Activity:  domain.Activity{State: domain.ActivityIdle},
+		},
+		Status: domain.StatusIdle,
+	}
+	src := &fakeSessionSource{all: []domain.Session{sess}}
+	mgr := NewManager(&fakeSource{}, bc, testLogger(),
+		WithSpawn((&fakeSpawner{}).spawn), WithHeartbeat(0), WithSessionSource(src))
+	defer mgr.Close()
+
+	conn := newFakeConn()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go mgr.Serve(ctx, conn)
+
+	conn.in <- clientMsg{Ch: chSubscribe, Type: msgSubscribe}
+	// Drain the initial snapshot.
+	recv(t, conn, chSessions, msgSnapshot, time.Second)
+
+	// Give the subscription time to register before publishing the CDC event.
 	eventually(t, time.Second, func() bool {
 		bc.Publish(cdc.Event{Seq: 9, ProjectID: "p1", SessionID: "s1", Type: cdc.EventSessionUpdated})
 		select {
 		case m := <-conn.out:
-			return m.Ch == chSessions && m.Session != nil && m.Session.Seq == 9
+			return m.Ch == chSessions && len(m.Sessions) == 1 && m.Sessions[0].ID == "s1"
 		default:
 			return false
 		}

--- a/backend/internal/terminal/patches.go
+++ b/backend/internal/terminal/patches.go
@@ -13,7 +13,6 @@ import (
 // package does not depend on the service layer.
 type SessionSource interface {
 	AllSessions(ctx context.Context) ([]domain.Session, error)
-	Session(ctx context.Context, id domain.SessionID) (domain.Session, bool, error)
 }
 
 // attentionLevel maps a derived session status and activity state to one of the

--- a/backend/internal/terminal/patches.go
+++ b/backend/internal/terminal/patches.go
@@ -1,0 +1,60 @@
+package terminal
+
+import (
+	"context"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+// SessionSource supplies pre-computed session snapshots for the live
+// session-state feed. The implementation is responsible for resolving the
+// derived display Status (record + PR facts) before returning, so the terminal
+// package does not depend on the service layer.
+type SessionSource interface {
+	AllSessions(ctx context.Context) ([]domain.Session, error)
+	Session(ctx context.Context, id domain.SessionID) (domain.Session, bool, error)
+}
+
+// attentionLevel maps a derived session status and activity state to one of the
+// six attention-zone labels the dashboard uses. The logic mirrors
+// getDetailedAttentionLevel in packages/web/src/lib/types.ts, simplified to the
+// facts available server-side (the PR-derived statuses are already baked into
+// SessionStatus by DeriveStatus).
+func attentionLevel(status domain.SessionStatus, activity domain.ActivityState) string {
+	switch status {
+	case domain.StatusMerged, domain.StatusTerminated:
+		return "done"
+	case domain.StatusMergeable, domain.StatusApproved:
+		return "merge"
+	case domain.StatusNeedsInput:
+		return "respond"
+	case domain.StatusCIFailed, domain.StatusChangesRequested:
+		return "review"
+	case domain.StatusReviewPending:
+		return "pending"
+	}
+	switch activity {
+	case domain.ActivityWaitingInput, domain.ActivityExited:
+		return "respond"
+	}
+	return "working"
+}
+
+func toSessionPatch(s domain.Session) sessionPatch {
+	return sessionPatch{
+		ID:             string(s.ID),
+		Status:         string(s.Status),
+		Activity:       string(s.Activity.State),
+		AttentionLevel: attentionLevel(s.Status, s.Activity.State),
+		LastActivityAt: s.Activity.LastActivityAt.UTC().Format(time.RFC3339),
+	}
+}
+
+func toSessionPatches(sessions []domain.Session) []sessionPatch {
+	patches := make([]sessionPatch, len(sessions))
+	for i, s := range sessions {
+		patches[i] = toSessionPatch(s)
+	}
+	return patches
+}

--- a/backend/internal/terminal/patches_test.go
+++ b/backend/internal/terminal/patches_test.go
@@ -1,0 +1,81 @@
+package terminal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+)
+
+func TestAttentionLevelMapping(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   domain.SessionStatus
+		activity domain.ActivityState
+		want     string
+	}{
+		// Status-driven zones take priority over activity.
+		{"merged is done", domain.StatusMerged, domain.ActivityActive, "done"},
+		{"terminated is done", domain.StatusTerminated, domain.ActivityActive, "done"},
+		{"mergeable is merge", domain.StatusMergeable, domain.ActivityIdle, "merge"},
+		{"approved is merge", domain.StatusApproved, domain.ActivityIdle, "merge"},
+		{"needs_input is respond", domain.StatusNeedsInput, domain.ActivityActive, "respond"},
+		{"ci_failed is review", domain.StatusCIFailed, domain.ActivityActive, "review"},
+		{"changes_requested is review", domain.StatusChangesRequested, domain.ActivityActive, "review"},
+		{"review_pending is pending", domain.StatusReviewPending, domain.ActivityActive, "pending"},
+
+		// Activity-driven zones apply only when status is non-actionable.
+		{"idle+exited is respond", domain.StatusIdle, domain.ActivityExited, "respond"},
+		{"idle+waiting_input is respond", domain.StatusIdle, domain.ActivityWaitingInput, "respond"},
+		{"working+active is working", domain.StatusWorking, domain.ActivityActive, "working"},
+		{"idle+idle is working", domain.StatusIdle, domain.ActivityIdle, "working"},
+
+		// Non-actionable PR statuses fall through to working.
+		{"draft is working", domain.StatusDraft, domain.ActivityActive, "working"},
+		{"pr_open is working", domain.StatusPROpen, domain.ActivityActive, "working"},
+
+		// A done/merge status wins even when the agent has exited.
+		{"merged+exited stays done", domain.StatusMerged, domain.ActivityExited, "done"},
+		{"mergeable+exited stays merge", domain.StatusMergeable, domain.ActivityExited, "merge"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := attentionLevel(tc.status, tc.activity); got != tc.want {
+				t.Fatalf("attentionLevel(%q, %q) = %q, want %q", tc.status, tc.activity, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestToSessionPatchShape(t *testing.T) {
+	ts := time.Date(2024, 1, 2, 3, 4, 5, 0, time.FixedZone("EST", -5*3600))
+	s := domain.Session{
+		SessionRecord: domain.SessionRecord{
+			ID:       "s1",
+			Activity: domain.Activity{State: domain.ActivityWaitingInput, LastActivityAt: ts},
+		},
+		Status: domain.StatusNeedsInput,
+	}
+	got := toSessionPatch(s)
+	want := sessionPatch{
+		ID:             "s1",
+		Status:         "needs_input",
+		Activity:       "waiting_input",
+		AttentionLevel: "respond",
+		LastActivityAt: "2024-01-02T08:04:05Z", // normalized to UTC
+	}
+	if got != want {
+		t.Fatalf("toSessionPatch:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+func TestToSessionPatchesPreservesOrder(t *testing.T) {
+	in := []domain.Session{
+		{SessionRecord: domain.SessionRecord{ID: "a"}, Status: domain.StatusIdle},
+		{SessionRecord: domain.SessionRecord{ID: "b"}, Status: domain.StatusWorking},
+	}
+	got := toSessionPatches(in)
+	if len(got) != 2 || got[0].ID != "a" || got[1].ID != "b" {
+		t.Fatalf("toSessionPatches order/len wrong: %+v", got)
+	}
+}

--- a/backend/internal/terminal/protocol.go
+++ b/backend/internal/terminal/protocol.go
@@ -18,14 +18,20 @@ const (
 	chSystem    = "system"
 )
 
+// subscribe topics the client opts into via the ch "subscribe" frame's
+// "topics" array. Only "sessions" is served today; "notifications" is accepted
+// and ignored until that channel exists server-side.
+const (
+	topicSessions = "sessions"
+)
+
 // client message types (ch "terminal" unless noted).
 const (
-	msgOpen      = "open"
-	msgData      = "data"
-	msgResize    = "resize"
-	msgClose     = "close"
-	msgSubscribe = "subscribe" // ch "subscribe"
-	msgPing      = "ping"      // ch "system"
+	msgOpen   = "open"
+	msgData   = "data"
+	msgResize = "resize"
+	msgClose  = "close"
+	msgPing   = "ping" // ch "system"
 )
 
 // server message types.
@@ -47,6 +53,10 @@ type clientMsg struct {
 	Data string `json:"data,omitempty"`
 	Cols uint16 `json:"cols,omitempty"`
 	Rows uint16 `json:"rows,omitempty"`
+	// Topics is the set of channels the client opts into on a ch "subscribe"
+	// frame (e.g. ["sessions","notifications"]). The frontend declares intent
+	// here and sends no "type", so subscription is gated on this, not Type.
+	Topics []string `json:"topics,omitempty"`
 }
 
 // serverMsg is one outbound frame.

--- a/backend/internal/terminal/protocol.go
+++ b/backend/internal/terminal/protocol.go
@@ -55,17 +55,19 @@ type serverMsg struct {
 	ID   string `json:"id,omitempty"`
 	Type string `json:"type"`
 	// Data is base64-encoded PTY output for ch "terminal" / type "data".
-	Data    string         `json:"data,omitempty"`
-	Error   string         `json:"error,omitempty"`
-	Session *sessionUpdate `json:"session,omitempty"`
+	Data     string         `json:"data,omitempty"`
+	Error    string         `json:"error,omitempty"`
+	Sessions []sessionPatch `json:"sessions,omitempty"`
 }
 
-// sessionUpdate is the ch "sessions" payload: a single CDC change projected to
-// the fields a client needs to refresh its view. It deliberately omits the raw
-// change_log payload blob; the client refetches detail over the REST surface.
-type sessionUpdate struct {
-	Seq       int64  `json:"seq"`
-	ProjectID string `json:"projectId"`
-	SessionID string `json:"sessionId,omitempty"`
-	EventType string `json:"eventType"`
+// sessionPatch is the ch "sessions" payload: a session projected to the fields
+// the dashboard context provider needs to update its live view. The shape
+// matches the TS SessionPatch type in mux-protocol.ts so the existing frontend
+// can consume it without changes.
+type sessionPatch struct {
+	ID             string `json:"id"`
+	Status         string `json:"status"`
+	Activity       string `json:"activity"`
+	AttentionLevel string `json:"attentionLevel"`
+	LastActivityAt string `json:"lastActivityAt"`
 }

--- a/backend/internal/terminal/protocol_test.go
+++ b/backend/internal/terminal/protocol_test.go
@@ -3,6 +3,7 @@ package terminal
 import (
 	"encoding/base64"
 	"encoding/json"
+	"reflect"
 	"testing"
 )
 
@@ -23,8 +24,23 @@ func TestClientMsgRoundTrip(t *testing.T) {
 	if err := json.Unmarshal(raw, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if out != in {
+	if !reflect.DeepEqual(out, in) {
 		t.Fatalf("round-trip mismatch:\n got %+v\nwant %+v", out, in)
+	}
+}
+
+func TestClientMsgSubscribeFrameDecodes(t *testing.T) {
+	// The frontend sends only ch + topics, no "type"; the server gates on topics.
+	raw := []byte(`{"ch":"subscribe","topics":["sessions","notifications"]}`)
+	var out clientMsg
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Ch != chSubscribe || out.Type != "" {
+		t.Fatalf("got ch=%q type=%q, want ch=subscribe type=empty", out.Ch, out.Type)
+	}
+	if !reflect.DeepEqual(out.Topics, []string{"sessions", "notifications"}) {
+		t.Fatalf("topics = %v, want [sessions notifications]", out.Topics)
 	}
 }
 

--- a/backend/internal/terminal/protocol_test.go
+++ b/backend/internal/terminal/protocol_test.go
@@ -32,16 +32,16 @@ func TestServerMsgSessionFrameWireShape(t *testing.T) {
 	msg := serverMsg{
 		Ch:   chSessions,
 		Type: msgSnapshot,
-		Session: &sessionUpdate{
-			Seq: 7, ProjectID: "p1", SessionID: "s1", EventType: "session_updated",
+		Sessions: []sessionPatch{
+			{ID: "s1", Status: "working", Activity: "active", AttentionLevel: "working", LastActivityAt: "2024-01-01T00:00:00Z"},
 		},
 	}
 	raw, err := json.Marshal(msg)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	// Golden wire shape the client depends on.
-	want := `{"ch":"sessions","type":"snapshot","session":{"seq":7,"projectId":"p1","sessionId":"s1","eventType":"session_updated"}}`
+	// Golden wire shape the TS SessionPatch consumer depends on.
+	want := `{"ch":"sessions","type":"snapshot","sessions":[{"id":"s1","status":"working","activity":"active","attentionLevel":"working","lastActivityAt":"2024-01-01T00:00:00Z"}]}`
 	if string(raw) != want {
 		t.Fatalf("wire shape:\n got %s\nwant %s", raw, want)
 	}


### PR DESCRIPTION
Closes #104

## What changed and why

Before this PR, the `/mux` WebSocket session-state channel forwarded raw CDC notification fields (`seq`, `projectId`, `sessionId`, `eventType`) directly onto the wire. The TypeScript `MuxProvider` consumer expects a `SessionPatch` shape (`id`, `status`, `activity`, `attentionLevel`, `lastActivityAt`). The mismatch meant the dashboard never received live session-state updates -- it could only poll or wait for a page refresh.

This PR closes that gap end-to-end.

---

## Flow

```
DB INSERT/UPDATE
(sessions / pr / pr_checks)
        |
   [DB trigger -- atomic with the write]
        |
    change_log
        |
  cdc.Poller (100ms tick)
        |
  cdc.Broadcaster.Publish(Event)
        |
        +---> terminal.Manager subscriber callback
                  |
           [non-blocking: push SessionID onto per-conn channel]
                  |             (broadcaster contract: must not block)
                  |
         writer goroutine (writeLoop)
                  |
        sessionSrc.Session()  <--------+
                  |                    |
          domain.DeriveStatus()        sqlite store
                  |                    |
        attentionLevel()      GetDisplayPRFactsForSession()
                  |
     serverMsg{ ch:"sessions", type:"snapshot",
                sessions:[{ id, status, activity,
                            attentionLevel, lastActivityAt }] }
                  |
        WebSocket frame to client
                  |
           MuxProvider.tsx
```

On subscribe, a full snapshot of all current sessions is queued through the same ordered channel before any per-session patches, so the client always starts with complete state.

---

## Changes

### `internal/terminal/patches.go` (new)

Defines `SessionSource` (the terminal package's view of session state -- no service-layer import), `attentionLevel()` (server-side port of `getDetailedAttentionLevel` from `packages/web/src/lib/types.ts`), and `toSessionPatch` / `toSessionPatches` helpers.

### `internal/terminal/protocol.go`

Replaced the thin `sessionUpdate` struct with `sessionPatch` carrying the full wire shape the TS consumer expects. Updated `serverMsg.Sessions` accordingly.

### `internal/terminal/manager.go`

Three changes, each fixing a separate problem:

**1. Off-hot-path enrichment.** Added `sessionEvents chan sessionEvent` to `connState`. The CDC subscriber callback now pushes only a `SessionID` (non-blocking); all DB reads happen in `writeLoop`, off the broadcaster's serialized `Publish` loop. This honors the documented contract: "fn is called synchronously from the poller loop, so it must not block."

**2. No-gap subscribe/snapshot ordering.** Subscribe is registered before the initial snapshot is queued. Both the snapshot (full read) and per-session patches (single-session read) flow through the same ordered `sessionEvents` channel and are resolved live at write time -- so the last frame the client sees for any session always reflects current state, regardless of interleaving.

**3. Connection context for DB reads.** The writer uses the connection-scoped `ctx`, so a disconnect cancels any in-flight query.

### `internal/domain/status.go`

Moved `DeriveStatus` and `prPipelineStatus` from `internal/service/session/status.go` into the domain package. They use only domain types; keeping them in the service layer created coupling pressure. `internal/service/session/status.go` now delegates to the domain function.

### `internal/daemon/session_source.go` (new)

`daemonSessionSource` implements `terminal.SessionSource` over the sqlite store. Per session: loads the record, fetches PR facts, calls `domain.DeriveStatus`. Wired into `terminal.NewManager` via `WithSessionSource` in `daemon.go`.

### `internal/httpd/terminal_mux.go`

Exported `TerminalMuxHandler` (was `terminalMuxHandler`) so the integration test can mount it on `httptest.Server` without importing the full httpd stack.

---

## Tests

**Unit (`internal/terminal/patches_test.go`)** -- table-driven coverage of all 16 `attentionLevel` branches (every status constant + activity fallbacks + priority-ordering cases), `toSessionPatch` field shape including UTC timestamp normalization, and `toSessionPatches` ordering.

**Unit (`internal/terminal/manager_test.go`, `protocol_test.go`)** -- updated wire-shape golden test, subscribe/snapshot/CDC-forward tests with in-memory fake conn.

**Functional (`internal/integration/mux_streaming_functional_test.go`)** -- real sqlite store, real CDC poller, real `terminal.Manager`, real WebSocket via `httptest.Server` + `coder/websocket.Dial`:

- `TestMuxStreamingSessionPatchDelivery`: subscribe (empty snapshot) -> spawn -> poll CDC -> exact `idle`/`idle`/`working` patch on the wire
- `TestMuxStreamingPatchReflectsPRDerivedStatus`: apply CI failure -> poll CDC -> `ci_failed`/`review` patch on the wire (per-event enrichment path with non-trivial status mapping)
- `TestMuxStreamingInitialSnapshotContainsExistingSessions`: sessions in the store before connect appear in the first snapshot

All tests pass under `-race`. No new failures introduced.