### PR TITLE
feat(agents): add aider adapter

### DIFF
--- a/backend/internal/adapters/agent/aider/aider.go
+++ b/backend/internal/adapters/agent/aider/aider.go
@@ -1,0 +1,222 @@
+// Package aider implements the Aider agent adapter: launching headless Aider
+// worker sessions.
+//
+// Aider is a Tier C adapter: it has no lifecycle hook surface, no native
+// session id, and no resume-by-id mechanism, so hook installation, restore, and
+// SessionInfo are intentionally no-ops. The permission mapping is lossy because
+// Aider lacks a graduated approval ladder or sandbox (see the comments on
+// appendApprovalFlags).
+package aider
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const adapterID = "aider"
+
+// Plugin is the Aider agent adapter. It is safe for concurrent use; the binary
+// path is resolved once and cached under binaryMu.
+type Plugin struct {
+	binaryMu       sync.Mutex
+	resolvedBinary string
+}
+
+// New returns a ready-to-register Aider adapter.
+func New() *Plugin {
+	return &Plugin{}
+}
+
+var _ adapters.Adapter = (*Plugin)(nil)
+var _ ports.Agent = (*Plugin)(nil)
+
+// Manifest returns the adapter's static self-description.
+func (p *Plugin) Manifest() adapters.Manifest {
+	return adapters.Manifest{
+		ID:          adapterID,
+		Name:        "Aider",
+		Description: "Run Aider worker sessions.",
+		Version:     "0.0.1",
+		Capabilities: []adapters.Capability{
+			adapters.CapabilityAgent,
+		},
+	}
+}
+
+// GetConfigSpec reports no agent-specific config keys yet.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{}, nil
+}
+
+// GetLaunchCommand builds the argv to start a headless Aider session:
+//
+//	aider -m <prompt> [permission flags] --no-check-update --no-stream --no-pretty [--read <system prompt file>]
+//
+// The prompt is delivered with `-m <prompt>` rather than positionally: Aider
+// treats positional arguments as files to add to the chat, so a positional
+// prompt would be misread. The `-m` pair is only appended when a prompt is set.
+//
+// Aider has no inline system-prompt mechanism; only SystemPromptFile is honored
+// via --read. The --no-check-update --no-stream --no-pretty flags keep Aider
+// well-behaved in a non-interactive, captured-output context.
+func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
+	binary, err := p.aiderBinary(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd = []string{binary}
+	if cfg.Prompt != "" {
+		cmd = append(cmd, "-m", cfg.Prompt)
+	}
+	appendApprovalFlags(&cmd, cfg.Permissions)
+	cmd = append(cmd, "--no-check-update", "--no-stream", "--no-pretty")
+	if cfg.SystemPromptFile != "" {
+		cmd = append(cmd, "--read", cfg.SystemPromptFile)
+	}
+	// aider has no inline system-prompt mechanism; only SystemPromptFile is
+	// honored via --read. A cfg.SystemPrompt with no file is intentionally
+	// dropped here rather than written to disk.
+	return cmd, nil
+}
+
+// GetPromptDeliveryStrategy reports that Aider receives its prompt in the launch
+// command itself (via -m).
+func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, cfg ports.LaunchConfig) (ports.PromptDeliveryStrategy, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return ports.PromptDeliveryInCommand, nil
+}
+
+// GetAgentHooks is a no-op: Aider emits no lifecycle hooks (Tier C), so there
+// is no native hook config to install AO hooks into.
+func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
+	return ctx.Err()
+}
+
+// GetRestoreCommand always reports that no native session can be continued.
+// Aider has no native session id or resume-by-id mechanism
+// (see github.com/Aider-AI/aider issues/166), so the manager always falls back
+// to a fresh launch.
+func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	return nil, false, nil
+}
+
+// SessionInfo is a no-op: Aider exposes no captureable session metadata.
+func (p *Plugin) SessionInfo(ctx context.Context, session ports.SessionRef) (ports.SessionInfo, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.SessionInfo{}, false, err
+	}
+	return ports.SessionInfo{}, false, nil
+}
+
+// normalizePermissionMode collapses an empty mode onto PermissionModeDefault so
+// callers can switch over a stable set of values.
+func normalizePermissionMode(mode ports.PermissionMode) ports.PermissionMode {
+	if mode == "" {
+		return ports.PermissionModeDefault
+	}
+	return mode
+}
+
+// appendApprovalFlags maps AO's permission modes onto Aider's flags. The mapping
+// is lossy: Aider has no graduated approval ladder and no sandbox, so multiple
+// AO modes collapse onto the same Aider behavior.
+func appendApprovalFlags(cmd *[]string, mode ports.PermissionMode) {
+	switch normalizePermissionMode(mode) {
+	case ports.PermissionModeDefault:
+		// No flags: Aider's interactive confirmation prompts apply. In headless
+		// -m mode an unanswered confirm can hang; this is acceptable and
+		// documented, deferring the choice to the user's own Aider config.
+	case ports.PermissionModeAcceptEdits:
+		// Apply edits without prompting but leave them uncommitted.
+		*cmd = append(*cmd, "--yes-always", "--no-auto-commits")
+	case ports.PermissionModeAuto:
+		// Apply edits without prompting and keep Aider's default auto-commit.
+		*cmd = append(*cmd, "--yes-always")
+	case ports.PermissionModeBypassPermissions:
+		// Lossy: Aider has no sandbox/bypass, so this is identical to auto.
+		*cmd = append(*cmd, "--yes-always")
+	default:
+		// Unhandled/future modes: no flags, deferring to the user's Aider config.
+	}
+}
+
+// ResolveAiderBinary finds the `aider` binary, searching PATH then common
+// install locations. It returns "aider" as a last resort so callers get the
+// shell's normal command-not-found behavior if Aider is absent.
+func ResolveAiderBinary(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	if runtime.GOOS == "windows" {
+		for _, name := range []string{"aider.exe", "aider.cmd", "aider"} {
+			if path, err := exec.LookPath(name); err == nil && path != "" {
+				return path, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+		}
+		return "aider", nil
+	}
+
+	if path, err := exec.LookPath("aider"); err == nil && path != "" {
+		return path, nil
+	}
+
+	candidates := []string{
+		"/usr/local/bin/aider",
+		"/opt/homebrew/bin/aider",
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append([]string{filepath.Join(home, ".local", "bin", "aider")}, candidates...)
+	}
+
+	for _, candidate := range candidates {
+		if fileExists(candidate) {
+			return candidate, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+	}
+
+	return "aider", nil
+}
+
+func (p *Plugin) aiderBinary(ctx context.Context) (string, error) {
+	p.binaryMu.Lock()
+	defer p.binaryMu.Unlock()
+
+	if p.resolvedBinary != "" {
+		return p.resolvedBinary, nil
+	}
+
+	binary, err := ResolveAiderBinary(ctx)
+	if err != nil {
+		return "", err
+	}
+	p.resolvedBinary = binary
+	return binary, nil
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/backend/internal/adapters/agent/aider/aider_test.go
+++ b/backend/internal/adapters/agent/aider/aider_test.go
@@ -1,0 +1,291 @@
+package aider
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestManifest(t *testing.T) {
+	m := (&Plugin{}).Manifest()
+	if m.ID != "aider" {
+		t.Fatalf("ID = %q, want aider", m.ID)
+	}
+	if m.Name != "Aider" {
+		t.Fatalf("Name = %q, want Aider", m.Name)
+	}
+	hasAgent := false
+	for _, c := range m.Capabilities {
+		if c == adapters.CapabilityAgent {
+			hasAgent = true
+		}
+	}
+	if !hasAgent {
+		t.Fatal("missing CapabilityAgent")
+	}
+}
+
+func TestGetConfigSpecEmpty(t *testing.T) {
+	spec, err := (&Plugin{}).GetConfigSpec(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(spec.Fields) != 0 {
+		t.Fatalf("expected no fields, got %d", len(spec.Fields))
+	}
+}
+
+func TestGetPromptDeliveryStrategy(t *testing.T) {
+	s, err := (&Plugin{}).GetPromptDeliveryStrategy(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if s != ports.PromptDeliveryInCommand {
+		t.Fatalf("strategy = %q, want %q", s, ports.PromptDeliveryInCommand)
+	}
+}
+
+func TestGetLaunchCommandDeliversPromptWithFlag(t *testing.T) {
+	p := &Plugin{resolvedBinary: "aider"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Prompt: "add a health check",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"aider", "-m", "add a health check", "--no-check-update", "--no-stream", "--no-pretty"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetLaunchCommandOmitsPromptFlagWhenEmpty(t *testing.T) {
+	p := &Plugin{resolvedBinary: "aider"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"aider", "--no-check-update", "--no-stream", "--no-pretty"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+	for _, arg := range cmd {
+		if arg == "-m" {
+			t.Fatalf("cmd = %#v unexpectedly contains -m for empty prompt", cmd)
+		}
+	}
+}
+
+func TestGetLaunchCommandAlwaysAppendsHeadlessFlags(t *testing.T) {
+	p := &Plugin{resolvedBinary: "aider"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{Prompt: "do the thing"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{"--no-check-update", "--no-stream", "--no-pretty"} {
+		found := false
+		for _, arg := range cmd {
+			if arg == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("cmd = %#v missing headless flag %q", cmd, want)
+		}
+	}
+}
+
+func TestGetLaunchCommandMapsPermissionModes(t *testing.T) {
+	tests := []struct {
+		name       string
+		mode       ports.PermissionMode
+		wantFlags  []string
+		wantAbsent []string
+	}{
+		{
+			name:       "default omits approval flags",
+			mode:       ports.PermissionModeDefault,
+			wantFlags:  nil,
+			wantAbsent: []string{"--yes-always", "--no-auto-commits"},
+		},
+		{
+			name:       "empty omits approval flags",
+			mode:       "",
+			wantFlags:  nil,
+			wantAbsent: []string{"--yes-always", "--no-auto-commits"},
+		},
+		{
+			name:       "accept edits applies but leaves uncommitted",
+			mode:       ports.PermissionModeAcceptEdits,
+			wantFlags:  []string{"--yes-always", "--no-auto-commits"},
+			wantAbsent: nil,
+		},
+		{
+			name:       "auto applies and auto-commits",
+			mode:       ports.PermissionModeAuto,
+			wantFlags:  []string{"--yes-always"},
+			wantAbsent: []string{"--no-auto-commits"},
+		},
+		{
+			name:       "bypass collapses onto auto",
+			mode:       ports.PermissionModeBypassPermissions,
+			wantFlags:  []string{"--yes-always"},
+			wantAbsent: []string{"--no-auto-commits"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Plugin{resolvedBinary: "aider"}
+			cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+				Prompt:      "do the thing",
+				Permissions: tt.mode,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for _, want := range tt.wantFlags {
+				found := false
+				for _, arg := range cmd {
+					if arg == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("cmd = %#v missing expected flag %q", cmd, want)
+				}
+			}
+			for _, absent := range tt.wantAbsent {
+				for _, arg := range cmd {
+					if arg == absent {
+						t.Fatalf("cmd = %#v unexpectedly contains %q", cmd, absent)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestGetLaunchCommandSystemPromptFileUsesRead(t *testing.T) {
+	p := &Plugin{resolvedBinary: "aider"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Prompt:           "do the thing",
+		SystemPromptFile: "/tmp/system.md",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"aider", "-m", "do the thing", "--no-check-update", "--no-stream", "--no-pretty", "--read", "/tmp/system.md"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandInlineSystemPromptIsDropped(t *testing.T) {
+	p := &Plugin{resolvedBinary: "aider"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Prompt:       "do the thing",
+		SystemPrompt: "inline ignored",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"aider", "-m", "do the thing", "--no-check-update", "--no-stream", "--no-pretty"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+	for _, arg := range cmd {
+		if arg == "--read" {
+			t.Fatalf("cmd = %#v unexpectedly contains --read for inline system prompt", cmd)
+		}
+		if arg == "inline ignored" {
+			t.Fatalf("cmd = %#v unexpectedly contains inline system prompt text", cmd)
+		}
+	}
+}
+
+func TestGetRestoreCommandAlwaysFalse(t *testing.T) {
+	p := &Plugin{resolvedBinary: "aider"}
+	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Session: ports.SessionRef{
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "abc123"},
+		},
+		Permissions: ports.PermissionModeBypassPermissions,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatalf("ok=true, want false (aider has no resume-by-id)")
+	}
+	if cmd != nil {
+		t.Fatalf("cmd = %#v, want nil", cmd)
+	}
+}
+
+func TestGetAgentHooksNoOp(t *testing.T) {
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: t.TempDir()}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v, want nil", err)
+	}
+}
+
+func TestSessionInfoNoOp(t *testing.T) {
+	info, ok, err := (&Plugin{}).SessionInfo(context.Background(), ports.SessionRef{
+		Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "abc123"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatalf("ok=true with info %#v, want no-op false", info)
+	}
+	if !reflect.DeepEqual(info, ports.SessionInfo{}) {
+		t.Fatalf("info = %#v, want zero", info)
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := (&Plugin{}).GetConfigSpec(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetConfigSpec err = %v, want context.Canceled", err)
+	}
+	if _, err := (&Plugin{}).GetLaunchCommand(ctx, ports.LaunchConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetLaunchCommand err = %v, want context.Canceled", err)
+	}
+	if _, err := (&Plugin{}).GetPromptDeliveryStrategy(ctx, ports.LaunchConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetPromptDeliveryStrategy err = %v, want context.Canceled", err)
+	}
+	if err := (&Plugin{}).GetAgentHooks(ctx, ports.WorkspaceHookConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetAgentHooks err = %v, want context.Canceled", err)
+	}
+	if _, _, err := (&Plugin{}).GetRestoreCommand(ctx, ports.RestoreConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetRestoreCommand err = %v, want context.Canceled", err)
+	}
+	if _, _, err := (&Plugin{}).SessionInfo(ctx, ports.SessionRef{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("SessionInfo err = %v, want context.Canceled", err)
+	}
+}
+
+func TestResolveAiderBinaryFallback(t *testing.T) {
+	bin, err := ResolveAiderBinary(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if bin == "" {
+		t.Fatal("ResolveAiderBinary returned empty string")
+	}
+}

--- a/backend/internal/adapters/agent/registry/registry.go
+++ b/backend/internal/adapters/agent/registry/registry.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agy"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/aider"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/amp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/claudecode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
@@ -33,6 +34,7 @@ func Constructors() []adapters.Adapter {
 		amp.New(),
 		agy.New(),
 		crush.New(),
+		aider.New(),
 	}
 }
 

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -98,6 +98,7 @@ func TestWiring_AgentResolverResolvesRealAdapters(t *testing.T) {
 		{domain.HarnessAmp, "amp"},
 		{domain.HarnessAgy, "agy"},
 		{domain.HarnessCrush, "crush"},
+		{domain.HarnessAider, "aider"},
 		{"", config.DefaultAgent}, // empty harness falls back to the AO_AGENT default
 	} {
 		agent, ok := resolver.Agent(tc.harness)


### PR DESCRIPTION
Adds the **aider** harness, stacked on #119 (agent platform). Adapter package + `Constructors()` registration + resolver test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #119
2. #120
3. #121
4. #122
5. #123
6. #124
7. **#125** 👈 current
8. #126
9. #127
10. #128
11. #129
12. #130
13. #131
14. #132
15. #133
16. #134
17. #135
18. #136
19. #137
20. #138
21. #139
<!-- stack:links:end -->