### PR TITLE
feat(agents): add auggie adapter

### DIFF
--- a/backend/internal/adapters/agent/auggie/auggie.go
+++ b/backend/internal/adapters/agent/auggie/auggie.go
@@ -1,0 +1,254 @@
+// Package auggie implements the Auggie (Augment Code) agent adapter: launching
+// new headless Auggie sessions and resuming sessions when a native Auggie
+// session id is known.
+//
+// Auggie is Augment Code's terminal coding agent (binary "auggie", installed via
+// `npm install -g @augmentcode/auggie`). It exposes a headless one-shot mode via
+// `--print` (alias `-p`) which runs a single instruction and exits — the mode AO
+// uses to drive it unattended.
+//
+// Launch shape:
+//
+//	auggie --print [--instruction-file <f> | --instruction <s>] [-- <prompt>]
+//
+// The prompt is the print-mode positional, passed after `--` so a prompt
+// beginning with "-" is not mistaken for a flag. A system prompt, when supplied,
+// is injected via Auggie's `--instruction-file` / `--instruction` flags, which
+// append guidance to the workspace rules.
+//
+// Permissions: Auggie has no single "approve everything" flag. It governs
+// unattended tool/file approval through granular `--permission <tool>:<allow|deny>`
+// rules (and a read-only `--ask` mode), not a 4-mode bypass like Claude Code.
+// Because there is no verifiable blanket auto-approve flag, every AO permission
+// mode emits no flag and defers to the user's Auggie configuration, rather than
+// guessing a flag that does not exist.
+//
+// Resume: Auggie supports `--resume <sessionId>` (alias `-r`), usable with
+// `--print` for headless resume. AO only has a native session id to resume from
+// when one was captured into session metadata; Auggie exposes no hook/lifecycle
+// system, so that id is not captured automatically yet. GetRestoreCommand
+// therefore returns ok=false until a native session id is present, at which point
+// callers fall back to a fresh launch.
+//
+// Hooks/activity: Auggie has no hook or lifecycle event system (it reads
+// .claude/commands/ for slash commands, but that is not Claude Code hook
+// compatibility). Hook installation and SessionInfo are intentionally no-ops
+// (Tier C) until an Auggie-specific activity integration exists.
+package auggie
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const adapterID = "auggie"
+
+// Plugin is the Auggie agent adapter. It is safe for concurrent use; the binary
+// path is resolved once and cached under binaryMu.
+type Plugin struct {
+	binaryMu       sync.Mutex
+	resolvedBinary string
+}
+
+// New returns a ready-to-register Auggie adapter.
+func New() *Plugin {
+	return &Plugin{}
+}
+
+var _ adapters.Adapter = (*Plugin)(nil)
+var _ ports.Agent = (*Plugin)(nil)
+
+// Manifest returns the adapter's static self-description.
+func (p *Plugin) Manifest() adapters.Manifest {
+	return adapters.Manifest{
+		ID:          adapterID,
+		Name:        "Auggie",
+		Description: "Run Auggie (Augment Code) worker sessions.",
+		Version:     "0.0.1",
+		Capabilities: []adapters.Capability{
+			adapters.CapabilityAgent,
+		},
+	}
+}
+
+// GetConfigSpec reports no agent-specific config keys yet.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{}, nil
+}
+
+// GetLaunchCommand builds the argv to start a new headless Auggie session:
+//
+//	auggie --print [--instruction-file <f> | --instruction <s>] [-- <prompt>]
+//
+// The prompt is passed after `--` so a prompt beginning with "-" is not mistaken
+// for a flag. A system prompt is injected via --instruction-file / --instruction,
+// mirroring the system-prompt handling of the other adapters.
+func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	binary, err := p.auggieBinary(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd = []string{binary, "--print"}
+	if cfg.SystemPromptFile != "" {
+		cmd = append(cmd, "--instruction-file", cfg.SystemPromptFile)
+	} else if cfg.SystemPrompt != "" {
+		cmd = append(cmd, "--instruction", cfg.SystemPrompt)
+	}
+	if cfg.Prompt != "" {
+		cmd = append(cmd, "--", cfg.Prompt)
+	}
+	return cmd, nil
+}
+
+// GetPromptDeliveryStrategy reports that Auggie receives its prompt in the launch
+// command itself (the print-mode positional).
+func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, cfg ports.LaunchConfig) (ports.PromptDeliveryStrategy, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return ports.PromptDeliveryInCommand, nil
+}
+
+// GetAgentHooks is intentionally a no-op: Auggie has no hook or lifecycle event
+// system, so there is nothing to install. Activity reporting will require an
+// Auggie-specific integration once one exists.
+func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
+	return ctx.Err()
+}
+
+// GetRestoreCommand rebuilds the argv that continues an existing Auggie session
+// when a native session id is available in metadata:
+//
+//	auggie --print --resume <sessionId>
+//
+// Auggie has no hook surface to capture that id automatically yet, so in practice
+// the id is empty and ok is false, letting callers fall back to a fresh launch.
+func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	agentSessionID := strings.TrimSpace(cfg.Session.Metadata[ports.MetadataKeyAgentSessionID])
+	if agentSessionID == "" {
+		return nil, false, nil
+	}
+
+	binary, err := p.auggieBinary(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	cmd = []string{binary, "--print", "--resume", agentSessionID}
+	return cmd, true, nil
+}
+
+// SessionInfo is intentionally a no-op until Auggie session metadata can be
+// captured (Auggie exposes no hook surface to derive it from).
+func (p *Plugin) SessionInfo(ctx context.Context, session ports.SessionRef) (ports.SessionInfo, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.SessionInfo{}, false, err
+	}
+	return ports.SessionInfo{}, false, nil
+}
+
+// Auggie has no single blanket auto-approve/bypass flag; unattended tool/file
+// approval is governed by granular `--permission <tool>:<allow|deny>` rules, so
+// AO emits no approval flag and defers every mode to the user's Auggie config.
+// There is therefore no appendApprovalFlags helper for this adapter.
+
+// ResolveAuggieBinary finds the `auggie` binary, searching PATH then common
+// install locations. It returns "auggie" as a last resort so callers get the
+// shell's normal command-not-found behavior if Auggie is absent.
+func ResolveAuggieBinary(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	if runtime.GOOS == "windows" {
+		for _, name := range []string{"auggie.cmd", "auggie.exe", "auggie"} {
+			if path, err := exec.LookPath(name); err == nil && path != "" {
+				return path, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+		}
+		candidates := []string{}
+		if appData := os.Getenv("APPDATA"); appData != "" {
+			candidates = append(candidates,
+				filepath.Join(appData, "npm", "auggie.cmd"),
+				filepath.Join(appData, "npm", "auggie.exe"),
+			)
+		}
+		for _, candidate := range candidates {
+			if fileExists(candidate) {
+				return candidate, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+		}
+		return "auggie", nil
+	}
+
+	if path, err := exec.LookPath("auggie"); err == nil && path != "" {
+		return path, nil
+	}
+
+	candidates := []string{
+		"/usr/local/bin/auggie",
+		"/opt/homebrew/bin/auggie",
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates,
+			filepath.Join(home, ".local", "bin", "auggie"),
+			filepath.Join(home, ".npm", "bin", "auggie"),
+			filepath.Join(home, ".npm-global", "bin", "auggie"),
+		)
+	}
+
+	for _, candidate := range candidates {
+		if fileExists(candidate) {
+			return candidate, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+	}
+
+	return "auggie", nil
+}
+
+func (p *Plugin) auggieBinary(ctx context.Context) (string, error) {
+	p.binaryMu.Lock()
+	defer p.binaryMu.Unlock()
+
+	if p.resolvedBinary != "" {
+		return p.resolvedBinary, nil
+	}
+
+	binary, err := ResolveAuggieBinary(ctx)
+	if err != nil {
+		return "", err
+	}
+	p.resolvedBinary = binary
+	return binary, nil
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/backend/internal/adapters/agent/auggie/auggie_test.go
+++ b/backend/internal/adapters/agent/auggie/auggie_test.go
@@ -1,0 +1,220 @@
+package auggie
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestManifest(t *testing.T) {
+	m := (&Plugin{}).Manifest()
+	if m.ID != "auggie" {
+		t.Fatalf("ID = %q, want auggie", m.ID)
+	}
+	if m.Name != "Auggie" {
+		t.Fatalf("Name = %q, want Auggie", m.Name)
+	}
+	hasAgent := false
+	for _, c := range m.Capabilities {
+		if c == adapters.CapabilityAgent {
+			hasAgent = true
+		}
+	}
+	if !hasAgent {
+		t.Fatal("missing CapabilityAgent")
+	}
+}
+
+func TestGetConfigSpecEmpty(t *testing.T) {
+	spec, err := (&Plugin{}).GetConfigSpec(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(spec.Fields) != 0 {
+		t.Fatalf("expected no fields, got %d", len(spec.Fields))
+	}
+}
+
+func TestGetPromptDeliveryStrategy(t *testing.T) {
+	s, err := (&Plugin{}).GetPromptDeliveryStrategy(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if s != ports.PromptDeliveryInCommand {
+		t.Fatalf("strategy = %q, want %q", s, ports.PromptDeliveryInCommand)
+	}
+}
+
+func TestGetLaunchCommandWithPrompt(t *testing.T) {
+	p := &Plugin{resolvedBinary: "auggie"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Permissions: ports.PermissionModeBypassPermissions,
+		Prompt:      "-add a health check",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"auggie", "--print", "--", "-add a health check"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+// TestGetLaunchCommandPermissionModesEmitNoFlag documents that Auggie has no
+// blanket auto-approve flag, so every AO permission mode produces the same argv
+// (no permission flag) and defers to the user's Auggie config.
+func TestGetLaunchCommandPermissionModesEmitNoFlag(t *testing.T) {
+	modes := []ports.PermissionMode{
+		ports.PermissionModeDefault,
+		"",
+		ports.PermissionModeAcceptEdits,
+		ports.PermissionModeAuto,
+		ports.PermissionModeBypassPermissions,
+	}
+	want := []string{"auggie", "--print"}
+	for _, mode := range modes {
+		t.Run(string(mode), func(t *testing.T) {
+			p := &Plugin{resolvedBinary: "auggie"}
+			cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{Permissions: mode})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(cmd, want) {
+				t.Fatalf("cmd = %#v, want %#v", cmd, want)
+			}
+			for _, arg := range cmd {
+				if arg == "--permission" || arg == "--permission-mode" {
+					t.Fatalf("cmd = %#v unexpectedly contains a permission flag", cmd)
+				}
+			}
+		})
+	}
+}
+
+func TestGetLaunchCommandAppendsSystemPrompt(t *testing.T) {
+	p := &Plugin{resolvedBinary: "auggie"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		SystemPrompt: "follow repo rules",
+		Prompt:       "do the thing",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"auggie", "--print", "--instruction", "follow repo rules", "--", "do the thing"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandPrefersSystemPromptFileFlag(t *testing.T) {
+	p := &Plugin{resolvedBinary: "auggie"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		SystemPromptFile: "/tmp/system.md",
+		SystemPrompt:     "inline ignored",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"auggie", "--print", "--instruction-file", "/tmp/system.md"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetRestoreCommand(t *testing.T) {
+	p := &Plugin{resolvedBinary: "auggie"}
+	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Session: ports.SessionRef{
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "sess-abc123"},
+		},
+		Permissions: ports.PermissionModeBypassPermissions,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want true")
+	}
+
+	want := []string{"auggie", "--print", "--resume", "sess-abc123"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetRestoreCommandNoID(t *testing.T) {
+	p := &Plugin{resolvedBinary: "auggie"}
+	_, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Session: ports.SessionRef{Metadata: map[string]string{}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("ok=true with no agentSessionId, want false")
+	}
+}
+
+func TestGetAgentHooksNoOp(t *testing.T) {
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: t.TempDir()}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v, want nil", err)
+	}
+}
+
+func TestSessionInfoNoOp(t *testing.T) {
+	info, ok, err := (&Plugin{}).SessionInfo(context.Background(), ports.SessionRef{
+		Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "sess-abc123"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatalf("ok=true with info %#v, want no-op false", info)
+	}
+	if !reflect.DeepEqual(info, ports.SessionInfo{}) {
+		t.Fatalf("info = %#v, want zero", info)
+	}
+}
+
+func TestResolveAuggieBinaryFallback(t *testing.T) {
+	// With a cancelled context the resolver returns the context error rather than
+	// a binary path; with a live context it always yields a non-empty path.
+	bin, err := ResolveAuggieBinary(context.Background())
+	if err != nil {
+		t.Fatalf("ResolveAuggieBinary err = %v", err)
+	}
+	if bin == "" {
+		t.Fatal("ResolveAuggieBinary returned empty path")
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := (&Plugin{}).GetConfigSpec(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetConfigSpec err = %v, want context.Canceled", err)
+	}
+	if _, err := (&Plugin{}).GetLaunchCommand(ctx, ports.LaunchConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetLaunchCommand err = %v, want context.Canceled", err)
+	}
+	if _, err := (&Plugin{}).GetPromptDeliveryStrategy(ctx, ports.LaunchConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetPromptDeliveryStrategy err = %v, want context.Canceled", err)
+	}
+	if err := (&Plugin{}).GetAgentHooks(ctx, ports.WorkspaceHookConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetAgentHooks err = %v, want context.Canceled", err)
+	}
+	if _, _, err := (&Plugin{}).GetRestoreCommand(ctx, ports.RestoreConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetRestoreCommand err = %v, want context.Canceled", err)
+	}
+	if _, _, err := (&Plugin{}).SessionInfo(ctx, ports.SessionRef{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("SessionInfo err = %v, want context.Canceled", err)
+	}
+}

--- a/backend/internal/adapters/agent/registry/registry.go
+++ b/backend/internal/adapters/agent/registry/registry.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agy"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/aider"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/amp"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/auggie"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/claudecode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/copilot"
@@ -43,6 +44,7 @@ func Constructors() []adapters.Adapter {
 		qwen.New(),
 		copilot.New(),
 		goose.New(),
+		auggie.New(),
 	}
 }
 

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -103,6 +103,7 @@ func TestWiring_AgentResolverResolvesRealAdapters(t *testing.T) {
 		{domain.HarnessQwen, "qwen"},
 		{domain.HarnessCopilot, "copilot"},
 		{domain.HarnessGoose, "goose"},
+		{domain.HarnessAuggie, "auggie"},
 		{"", config.DefaultAgent}, // empty harness falls back to the AO_AGENT default
 	} {
 		agent, ok := resolver.Agent(tc.harness)


### PR DESCRIPTION
Adds the **auggie** harness, stacked on #119 (agent platform). Adapter package + `Constructors()` registration + resolver test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #119
2. #120
3. #121
4. #122
5. #123
6. #124
7. #125
8. #126
9. #127
10. #128
11. #129
12. **#130** 👈 current
13. #131
14. #132
15. #133
16. #134
17. #135
18. #136
19. #137
20. #138
21. #139
<!-- stack:links:end -->