### PR TITLE
feat(agents): add continue adapter

### DIFF
--- a/backend/internal/adapters/agent/continueagent/continueagent.go
+++ b/backend/internal/adapters/agent/continueagent/continueagent.go
@@ -1,0 +1,280 @@
+// Package continueagent implements the Continue CLI agent adapter.
+//
+// Continue (https://docs.continue.dev/guides/cli) is Continue's terminal coding
+// agent. Its binary is "cn" (npm package @continuedev/cli) and the AO harness /
+// manifest id is the string "continue". The Go package and directory are named
+// "continueagent" because "continue" is a reserved keyword.
+//
+// Tier B (Claude Code-compatible hooks): the Continue CLI natively reads Claude
+// Code hook settings (.claude/settings.json and .claude/settings.local.json) and
+// dispatches Claude-format hook events (SessionStart, UserPromptSubmit,
+// PreToolUse, PostToolUse, Stop, Notification) with the standard hook payload
+// (session_id, hook_event_name, hookSpecificOutput, permissionDecision,
+// additionalContext). So we reuse the claudecode hook installer and route hook
+// callbacks through the existing "ao hooks claude-code <evt>" dispatcher — no
+// Continue-specific native hook config or activity deriver is needed.
+//
+// Launch is headless via `cn --print [--auto|--readonly] <prompt>`; the prompt
+// is the positional argument (in-command delivery). Restore continues a specific
+// native session by id with `cn --fork <sessionId>` (Continue's `--resume` only
+// continues the *last* session, so it cannot target a particular AO session).
+package continueagent
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/claudecode"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+// adapterID is the AO harness / manifest id. It is the string "continue"
+// (NOT the Go package name "continueagent").
+const adapterID = "continue"
+
+// Plugin is the Continue CLI agent adapter. It is safe for concurrent use; the
+// binary path is resolved once and cached under binaryMu.
+type Plugin struct {
+	binaryMu       sync.Mutex
+	resolvedBinary string
+}
+
+// New returns a ready-to-register Continue adapter.
+func New() *Plugin {
+	return &Plugin{}
+}
+
+var _ adapters.Adapter = (*Plugin)(nil)
+var _ ports.Agent = (*Plugin)(nil)
+
+// Manifest returns the adapter's static self-description. ID is "continue".
+func (p *Plugin) Manifest() adapters.Manifest {
+	return adapters.Manifest{
+		ID:          adapterID,
+		Name:        "Continue",
+		Description: "Run Continue CLI worker sessions.",
+		Version:     "0.0.1",
+		Capabilities: []adapters.Capability{
+			adapters.CapabilityAgent,
+		},
+	}
+}
+
+// GetConfigSpec reports no agent-specific config keys yet.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{}, nil
+}
+
+// GetLaunchCommand builds `cn --print [--auto|--readonly] <prompt>`.
+//
+// `--print` runs Continue in non-interactive (headless) mode. The prompt is the
+// positional argument and is delivered in-command. Permission flags map AO's 4
+// modes onto Continue's two booleans (--auto / --readonly); Default and
+// AcceptEdits emit no flag so Continue resolves behavior from the user's config.
+func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
+	binary, err := p.continueBinary(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd = []string{binary, "--print"}
+	appendApprovalFlags(&cmd, cfg.Permissions)
+
+	if cfg.Prompt != "" {
+		cmd = append(cmd, "--", cfg.Prompt)
+	}
+
+	return cmd, nil
+}
+
+// GetPromptDeliveryStrategy reports that the prompt is delivered in the launch command.
+func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, cfg ports.LaunchConfig) (ports.PromptDeliveryStrategy, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return ports.PromptDeliveryInCommand, nil
+}
+
+// GetAgentHooks reuses the Claude Code hook installer because the Continue CLI
+// natively reads Claude Code hook settings.
+//
+// The installed commands are "ao hooks claude-code <evt>", so the existing CLI
+// hook dispatcher routes them to the claude derive logic. The Continue CLI reads
+// .claude/settings.local.json from the worktree and fires Claude-format events
+// (SessionStart / UserPromptSubmit / Stop / Notification), giving AO
+// title/summary/agentSessionId + activity for free without a Continue-specific
+// hook implementation or code duplication.
+func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return (&claudecode.Plugin{}).GetAgentHooks(ctx, cfg)
+}
+
+// GetRestoreCommand builds `cn --print [--auto|--readonly] --fork <agentSessionId>`
+// when a hook-captured native session id is available. ok=false otherwise (the
+// manager falls back to a fresh launch). `--fork <id>` continues a specific
+// session by id; Continue's `--resume` only continues the last session and so
+// cannot target a particular AO session.
+func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	agentSessionID := strings.TrimSpace(cfg.Session.Metadata[ports.MetadataKeyAgentSessionID])
+	if agentSessionID == "" {
+		return nil, false, nil
+	}
+
+	binary, err := p.continueBinary(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	cmd = make([]string, 0, 4)
+	cmd = append(cmd, binary, "--print")
+	appendApprovalFlags(&cmd, cfg.Permissions)
+	cmd = append(cmd, "--fork", agentSessionID)
+	return cmd, true, nil
+}
+
+// SessionInfo reads hook-derived metadata. Since hook install is delegated to
+// the claude hooks (via Continue's compat layer), the metadata keys are the
+// claude ones ("title", "summary", "agentSessionId").
+func (p *Plugin) SessionInfo(ctx context.Context, session ports.SessionRef) (ports.SessionInfo, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.SessionInfo{}, false, err
+	}
+	info := ports.SessionInfo{
+		AgentSessionID: session.Metadata[ports.MetadataKeyAgentSessionID],
+		Title:          session.Metadata[ports.MetadataKeyTitle],
+		Summary:        session.Metadata[ports.MetadataKeySummary],
+	}
+	if info.AgentSessionID == "" && info.Title == "" && info.Summary == "" {
+		return ports.SessionInfo{}, false, nil
+	}
+	return info, true, nil
+}
+
+// ResolveContinueBinary finds the `cn` binary (Continue CLI), searching PATH then
+// common npm/global install locations. It returns "cn" as a last resort so
+// callers get the shell's normal command-not-found behavior if Continue is
+// absent.
+func ResolveContinueBinary(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	if runtime.GOOS == "windows" {
+		for _, name := range []string{"cn.cmd", "cn.exe", "cn"} {
+			if path, err := exec.LookPath(name); err == nil && path != "" {
+				return path, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+		}
+		candidates := []string{}
+		if appData := os.Getenv("APPDATA"); appData != "" {
+			candidates = append(candidates,
+				filepath.Join(appData, "npm", "cn.cmd"),
+				filepath.Join(appData, "npm", "cn.exe"),
+			)
+		}
+		for _, candidate := range candidates {
+			if fileExists(candidate) {
+				return candidate, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+		}
+		return "cn", nil
+	}
+
+	if path, err := exec.LookPath("cn"); err == nil && path != "" {
+		return path, nil
+	}
+
+	candidates := []string{
+		"/usr/local/bin/cn",
+		"/opt/homebrew/bin/cn",
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates,
+			filepath.Join(home, ".npm-global", "bin", "cn"),
+			filepath.Join(home, ".local", "bin", "cn"),
+			filepath.Join(home, ".npm", "bin", "cn"),
+		)
+	}
+
+	for _, candidate := range candidates {
+		if fileExists(candidate) {
+			return candidate, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+	}
+
+	return "cn", nil
+}
+
+func (p *Plugin) continueBinary(ctx context.Context) (string, error) {
+	p.binaryMu.Lock()
+	defer p.binaryMu.Unlock()
+
+	if p.resolvedBinary != "" {
+		return p.resolvedBinary, nil
+	}
+
+	binary, err := ResolveContinueBinary(ctx)
+	if err != nil {
+		return "", err
+	}
+	p.resolvedBinary = binary
+	return binary, nil
+}
+
+// appendApprovalFlags maps AO's 4 permission modes onto Continue's two boolean
+// flags. Continue exposes only `--readonly` (plan mode, read-only tools) and
+// `--auto` (all tools allowed); there is no separate yolo/bypass beyond --auto,
+// and the two flags are mutually exclusive. Default and AcceptEdits emit no flag
+// so Continue defers to the user's own config / default behavior.
+func appendApprovalFlags(cmd *[]string, permissions ports.PermissionMode) {
+	switch normalizePermissionMode(permissions) {
+	case ports.PermissionModeDefault:
+		// No flag: defer to the user's Continue config / default behavior.
+	case ports.PermissionModeAcceptEdits:
+		// Continue has no granular "accept edits only" mode; defer to config.
+	case ports.PermissionModeAuto:
+		*cmd = append(*cmd, "--auto")
+	case ports.PermissionModeBypassPermissions:
+		*cmd = append(*cmd, "--auto")
+	}
+}
+
+func normalizePermissionMode(mode ports.PermissionMode) ports.PermissionMode {
+	switch mode {
+	case ports.PermissionModeDefault,
+		ports.PermissionModeAcceptEdits,
+		ports.PermissionModeAuto,
+		ports.PermissionModeBypassPermissions:
+		return mode
+	default:
+		return ports.PermissionModeDefault
+	}
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/backend/internal/adapters/agent/continueagent/continueagent_test.go
+++ b/backend/internal/adapters/agent/continueagent/continueagent_test.go
@@ -1,0 +1,269 @@
+package continueagent
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestManifest(t *testing.T) {
+	m := (&Plugin{}).Manifest()
+	if m.ID != "continue" {
+		t.Fatalf("ID = %q, want continue", m.ID)
+	}
+	if m.Name != "Continue" {
+		t.Fatalf("Name = %q, want Continue", m.Name)
+	}
+	hasAgent := false
+	for _, c := range m.Capabilities {
+		if c == adapters.CapabilityAgent {
+			hasAgent = true
+		}
+	}
+	if !hasAgent {
+		t.Fatal("missing CapabilityAgent")
+	}
+}
+
+func TestGetConfigSpecEmpty(t *testing.T) {
+	spec, err := (&Plugin{}).GetConfigSpec(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(spec.Fields) != 0 {
+		t.Fatalf("expected no fields, got %d", len(spec.Fields))
+	}
+}
+
+func TestGetPromptDeliveryStrategy(t *testing.T) {
+	s, err := (&Plugin{}).GetPromptDeliveryStrategy(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if s != ports.PromptDeliveryInCommand {
+		t.Fatalf("strategy = %q, want in_command", s)
+	}
+}
+
+func TestGetLaunchCommandBypass(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "cn"}
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Prompt:      "do the thing",
+		Permissions: ports.PermissionModeBypassPermissions,
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := []string{"cn", "--print", "--auto", "--", "do the thing"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandAuto(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "cn"}
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Prompt:      "refactor auth",
+		Permissions: ports.PermissionModeAuto,
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := []string{"cn", "--print", "--auto", "--", "refactor auth"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandDefaultPerms(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "cn"}
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Prompt: "fix it",
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := []string{"cn", "--print", "--", "fix it"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+	joined := strings.Join(cmd, " ")
+	if strings.Contains(joined, "--auto") || strings.Contains(joined, "--readonly") {
+		t.Fatal("should not emit a permission flag for default perms")
+	}
+}
+
+func TestGetLaunchCommandAcceptEditsNoFlag(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "cn"}
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Prompt:      "tidy up",
+		Permissions: ports.PermissionModeAcceptEdits,
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := []string{"cn", "--print", "--", "tidy up"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v (accept-edits should emit no flag)", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandNoPrompt(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "cn"}
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := []string{"cn", "--print"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// Force binary resolution (unset cache) so ctx.Err() is hit.
+	_, err := (&Plugin{}).GetLaunchCommand(ctx, ports.LaunchConfig{Prompt: "x"})
+	if err == nil {
+		t.Fatal("expected error from canceled context, got nil")
+	}
+}
+
+func TestGetRestoreCommand(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "cn"}
+	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Session: ports.SessionRef{
+			Metadata: map[string]string{
+				ports.MetadataKeyAgentSessionID: "sess-abc123",
+			},
+		},
+		Permissions: ports.PermissionModeBypassPermissions,
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want true")
+	}
+	want := []string{"cn", "--print", "--auto", "--fork", "sess-abc123"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetRestoreCommandDefaultPerms(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "cn"}
+	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Session: ports.SessionRef{
+			Metadata: map[string]string{
+				ports.MetadataKeyAgentSessionID: "sess-xyz",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want true")
+	}
+	want := []string{"cn", "--print", "--fork", "sess-xyz"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetRestoreCommandNoID(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "cn"}
+	_, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Session: ports.SessionRef{Metadata: map[string]string{}},
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatal("ok=true with no agentSessionId, want false")
+	}
+}
+
+func TestGetRestoreCommandWhitespaceID(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "cn"}
+	_, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Session: ports.SessionRef{Metadata: map[string]string{
+			ports.MetadataKeyAgentSessionID: "   ",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatal("ok=true with whitespace agentSessionId, want false")
+	}
+}
+
+func TestSessionInfoReadsHookMetadata(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "cn"}
+	info, ok, err := plugin.SessionInfo(context.Background(), ports.SessionRef{
+		Metadata: map[string]string{
+			ports.MetadataKeyAgentSessionID: "cn-ses-1",
+			ports.MetadataKeyTitle:          "Fix login redirect",
+			ports.MetadataKeySummary:        "Updated the auth callback and tests.",
+		},
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want true")
+	}
+	if info.AgentSessionID != "cn-ses-1" {
+		t.Fatalf("AgentSessionID = %q, want cn-ses-1", info.AgentSessionID)
+	}
+	if info.Title != "Fix login redirect" {
+		t.Fatalf("Title = %q", info.Title)
+	}
+	if info.Summary != "Updated the auth callback and tests." {
+		t.Fatalf("Summary = %q", info.Summary)
+	}
+}
+
+func TestSessionInfoFalseWhenNoHookMetadata(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "cn"}
+	info, ok, err := plugin.SessionInfo(context.Background(), ports.SessionRef{
+		Metadata: map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatalf("ok=true with empty metadata, want false")
+	}
+	if !reflect.DeepEqual(info, ports.SessionInfo{}) {
+		t.Fatalf("info = %#v, want zero", info)
+	}
+}
+
+func TestGetAgentHooksDelegates(t *testing.T) {
+	// We don't exercise the full hook merge here (claude tests cover it); just
+	// ensure delegation is wired and succeeds against a temp workspace.
+	plugin := &Plugin{resolvedBinary: "cn"}
+	ws := t.TempDir()
+	if err := plugin.GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{
+		WorkspacePath: ws,
+		SessionID:     "continue-test-1",
+	}); err != nil {
+		t.Fatalf("GetAgentHooks: %v", err)
+	}
+}
+
+func TestResolveContinueBinaryContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := ResolveContinueBinary(ctx); err == nil {
+		t.Fatal("expected error from canceled context, got nil")
+	}
+}

--- a/backend/internal/adapters/agent/registry/registry.go
+++ b/backend/internal/adapters/agent/registry/registry.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/auggie"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/claudecode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/continueagent"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/copilot"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/crush"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/cursor"
@@ -45,6 +46,7 @@ func Constructors() []adapters.Adapter {
 		copilot.New(),
 		goose.New(),
 		auggie.New(),
+		continueagent.New(),
 	}
 }
 

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -104,6 +104,7 @@ func TestWiring_AgentResolverResolvesRealAdapters(t *testing.T) {
 		{domain.HarnessCopilot, "copilot"},
 		{domain.HarnessGoose, "goose"},
 		{domain.HarnessAuggie, "auggie"},
+		{domain.HarnessContinue, "continue"},
 		{"", config.DefaultAgent}, // empty harness falls back to the AO_AGENT default
 	} {
 		agent, ok := resolver.Agent(tc.harness)


### PR DESCRIPTION
Adds the **continue** harness, stacked on #119 (agent platform). Adapter package + `Constructors()` registration + resolver test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #119
2. #120
3. #121
4. #122
5. #123
6. #124
7. #125
8. #126
9. #127
10. #128
11. #129
12. #130
13. **#131** 👈 current
14. #132
15. #133
16. #134
17. #135
18. #136
19. #137
20. #138
21. #139
<!-- stack:links:end -->