### PR TITLE
feat(agents): add kimi adapter

### DIFF
--- a/backend/internal/adapters/agent/kimi/kimi.go
+++ b/backend/internal/adapters/agent/kimi/kimi.go
@@ -1,0 +1,261 @@
+// Package kimi implements the Kimi CLI (Moonshot AI) agent adapter: launching
+// new non-interactive sessions and resuming sessions when a native Kimi session
+// id is known.
+//
+// Kimi CLI (binary "kimi") is Moonshot AI's terminal-native agentic coding
+// agent. A new task is run non-interactively with `kimi -p <prompt>`, which
+// streams the assistant output to stdout without opening the TUI. Sessions are
+// resumed by id with `kimi --session <id>`.
+//
+// Kimi exposes no native lifecycle/hook system and is not documented as
+// Claude Code hook-compatible, so this is a Tier C adapter: hook installation
+// and SessionInfo are intentionally no-ops, and activity is left to the
+// lifecycle reaper. There is also no documented system-prompt flag, so AO's
+// system prompt is not injected. Both should be upgraded if/when Kimi adds the
+// corresponding CLI surface.
+package kimi
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const adapterID = "kimi"
+
+// Plugin is the Kimi CLI agent adapter. It is safe for concurrent use; the
+// binary path is resolved once and cached under binaryMu.
+type Plugin struct {
+	binaryMu       sync.Mutex
+	resolvedBinary string
+}
+
+// New returns a ready-to-register Kimi adapter.
+func New() *Plugin {
+	return &Plugin{}
+}
+
+var _ adapters.Adapter = (*Plugin)(nil)
+var _ ports.Agent = (*Plugin)(nil)
+
+// Manifest returns the adapter's static self-description.
+func (p *Plugin) Manifest() adapters.Manifest {
+	return adapters.Manifest{
+		ID:          adapterID,
+		Name:        "Kimi",
+		Description: "Run Kimi CLI (Moonshot AI) worker sessions.",
+		Version:     "0.0.1",
+		Capabilities: []adapters.Capability{
+			adapters.CapabilityAgent,
+		},
+	}
+}
+
+// GetConfigSpec reports no agent-specific config keys yet.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{}, nil
+}
+
+// GetLaunchCommand builds the argv to start a new non-interactive Kimi session:
+//
+//	kimi [-y|--auto] -p <prompt>
+//
+// The prompt is delivered via `-p` (in command), which runs a single prompt
+// without opening the TUI. Kimi has no documented system-prompt flag, so
+// cfg.SystemPrompt / cfg.SystemPromptFile are not injected.
+func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
+	binary, err := p.kimiBinary(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd = []string{binary}
+	appendApprovalFlags(&cmd, cfg.Permissions)
+
+	if cfg.Prompt != "" {
+		cmd = append(cmd, "-p", cfg.Prompt)
+	}
+
+	return cmd, nil
+}
+
+// GetPromptDeliveryStrategy reports that Kimi receives its prompt in the launch
+// command itself.
+func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, cfg ports.LaunchConfig) (ports.PromptDeliveryStrategy, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return ports.PromptDeliveryInCommand, nil
+}
+
+// GetAgentHooks is intentionally a no-op: Kimi CLI exposes no native hook system
+// and is not documented as Claude Code hook-compatible.
+func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
+	return ctx.Err()
+}
+
+// GetRestoreCommand rebuilds the argv that continues an existing Kimi session
+// when a native Kimi session id is known:
+//
+//	kimi [-y|--auto] --session <agentSessionId>
+//
+// ok is false when no native session id has been captured, so callers fall back
+// to fresh launch behavior. Kimi has no lifecycle hook for AO to capture the
+// native session id from yet, so in practice this returns ok=false today.
+func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	agentSessionID := strings.TrimSpace(cfg.Session.Metadata[ports.MetadataKeyAgentSessionID])
+	if agentSessionID == "" {
+		return nil, false, nil
+	}
+
+	binary, err := p.kimiBinary(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	cmd = make([]string, 0, 4)
+	cmd = append(cmd, binary)
+	appendApprovalFlags(&cmd, cfg.Permissions)
+	cmd = append(cmd, "--session", agentSessionID)
+	return cmd, true, nil
+}
+
+// SessionInfo is intentionally a no-op until Kimi exposes a way to capture its
+// native session id and display metadata.
+func (p *Plugin) SessionInfo(ctx context.Context, session ports.SessionRef) (ports.SessionInfo, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.SessionInfo{}, false, err
+	}
+	return ports.SessionInfo{}, false, nil
+}
+
+// appendApprovalFlags maps AO's permission modes onto Kimi's approval flags.
+//
+//   - Default: no flag, deferring to the user's Kimi config/default behavior.
+//   - AcceptEdits / Auto: `--auto` (auto permission mode; approvals handled
+//     automatically).
+//   - BypassPermissions: `-y` (yolo; auto-approve regular tool calls including
+//     file writes and shell execution).
+func appendApprovalFlags(cmd *[]string, permissions ports.PermissionMode) {
+	switch normalizePermissionMode(permissions) {
+	case ports.PermissionModeDefault:
+		// No flag: defer to the user's Kimi config/default behavior.
+	case ports.PermissionModeAcceptEdits, ports.PermissionModeAuto:
+		*cmd = append(*cmd, "--auto")
+	case ports.PermissionModeBypassPermissions:
+		*cmd = append(*cmd, "-y")
+	}
+}
+
+func normalizePermissionMode(mode ports.PermissionMode) ports.PermissionMode {
+	switch mode {
+	case ports.PermissionModeDefault,
+		ports.PermissionModeAcceptEdits,
+		ports.PermissionModeAuto,
+		ports.PermissionModeBypassPermissions:
+		return mode
+	default:
+		return ports.PermissionModeDefault
+	}
+}
+
+// ResolveKimiBinary finds the `kimi` binary, searching PATH then common install
+// locations (the uv tool/curl installer drops it in ~/.local/bin, plus Homebrew
+// and ~/.cargo/bin). It returns "kimi" as a last resort so callers get the
+// shell's normal command-not-found behavior if Kimi is absent.
+func ResolveKimiBinary(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	if runtime.GOOS == "windows" {
+		for _, name := range []string{"kimi.cmd", "kimi.exe", "kimi"} {
+			if path, err := exec.LookPath(name); err == nil && path != "" {
+				return path, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+		}
+		candidates := []string{}
+		if appData := os.Getenv("APPDATA"); appData != "" {
+			candidates = append(candidates,
+				filepath.Join(appData, "npm", "kimi.cmd"),
+				filepath.Join(appData, "npm", "kimi.exe"),
+			)
+		}
+		if home, err := os.UserHomeDir(); err == nil {
+			candidates = append(candidates,
+				filepath.Join(home, ".local", "bin", "kimi.exe"),
+			)
+		}
+		for _, candidate := range candidates {
+			if fileExists(candidate) {
+				return candidate, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+		}
+		return "kimi", nil
+	}
+
+	if path, err := exec.LookPath("kimi"); err == nil && path != "" {
+		return path, nil
+	}
+
+	candidates := []string{
+		"/usr/local/bin/kimi",
+		"/opt/homebrew/bin/kimi",
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates,
+			filepath.Join(home, ".local", "bin", "kimi"),
+			filepath.Join(home, ".cargo", "bin", "kimi"),
+		)
+	}
+
+	for _, candidate := range candidates {
+		if fileExists(candidate) {
+			return candidate, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+	}
+
+	return "kimi", nil
+}
+
+func (p *Plugin) kimiBinary(ctx context.Context) (string, error) {
+	p.binaryMu.Lock()
+	defer p.binaryMu.Unlock()
+
+	if p.resolvedBinary != "" {
+		return p.resolvedBinary, nil
+	}
+
+	binary, err := ResolveKimiBinary(ctx)
+	if err != nil {
+		return "", err
+	}
+	p.resolvedBinary = binary
+	return binary, nil
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/backend/internal/adapters/agent/kimi/kimi.go
+++ b/backend/internal/adapters/agent/kimi/kimi.go
@@ -66,13 +66,18 @@ func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
 	return ports.ConfigSpec{}, nil
 }
 
-// GetLaunchCommand builds the argv to start a new non-interactive Kimi session:
+// GetLaunchCommand builds the argv to start a new Kimi session:
 //
-//	kimi [-y|--auto] -p <prompt>
+//	kimi -p <prompt>                            (non-interactive, default)
+//	kimi [--yolo|--auto]                        (interactive, no prompt)
 //
-// The prompt is delivered via `-p` (in command), which runs a single prompt
-// without opening the TUI. Kimi has no documented system-prompt flag, so
-// cfg.SystemPrompt / cfg.SystemPromptFile are not injected.
+// When a prompt is supplied, it is delivered via `-p` (in command), which runs
+// a single prompt without opening the TUI. Per Kimi docs, `--prompt` cannot be
+// combined with `--yolo`, `--auto`, or `--plan` — non-interactive mode already
+// uses the `auto` permission policy by default, so approval flags would be
+// rejected at startup. They are only emitted on the (interactive) path with no
+// prompt. Kimi has no documented system-prompt flag, so cfg.SystemPrompt /
+// cfg.SystemPromptFile are not injected.
 func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
 	binary, err := p.kimiBinary(ctx)
 	if err != nil {
@@ -80,12 +85,13 @@ func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (
 	}
 
 	cmd = []string{binary}
-	appendApprovalFlags(&cmd, cfg.Permissions)
 
 	if cfg.Prompt != "" {
 		cmd = append(cmd, "-p", cfg.Prompt)
+		return cmd, nil
 	}
 
+	appendApprovalFlags(&cmd, cfg.Permissions)
 	return cmd, nil
 }
 
@@ -107,10 +113,13 @@ func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfi
 // GetRestoreCommand rebuilds the argv that continues an existing Kimi session
 // when a native Kimi session id is known:
 //
-//	kimi [-y|--auto] --session <agentSessionId>
+//	kimi --session <agentSessionId>
 //
 // ok is false when no native session id has been captured, so callers fall back
-// to fresh launch behavior. Kimi has no lifecycle hook for AO to capture the
+// to fresh launch behavior. Per Kimi docs, `--yolo` and `--auto` cannot be
+// combined with `--session` (or `--continue`) — resumed sessions inherit the
+// approval settings of the original session — so cfg.Permissions is
+// intentionally ignored here. Kimi has no lifecycle hook for AO to capture the
 // native session id from yet, so in practice this returns ok=false today.
 func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
 	if err := ctx.Err(); err != nil {
@@ -125,10 +134,7 @@ func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig)
 	if err != nil {
 		return nil, false, err
 	}
-	cmd = make([]string, 0, 4)
-	cmd = append(cmd, binary)
-	appendApprovalFlags(&cmd, cfg.Permissions)
-	cmd = append(cmd, "--session", agentSessionID)
+	cmd = []string{binary, "--session", agentSessionID}
 	return cmd, true, nil
 }
 
@@ -141,7 +147,10 @@ func (p *Plugin) SessionInfo(ctx context.Context, session ports.SessionRef) (por
 	return ports.SessionInfo{}, false, nil
 }
 
-// appendApprovalFlags maps AO's permission modes onto Kimi's approval flags.
+// appendApprovalFlags maps AO's permission modes onto Kimi's approval flags
+// for interactive launches. Per Kimi docs these flags cannot be combined with
+// `--prompt`, `--session`, or `--continue`, so callers on those paths must
+// skip this mapping.
 //
 //   - Default: no flag, deferring to the user's Kimi config/default behavior.
 //   - AcceptEdits / Auto: `--auto` (auto permission mode; approvals handled

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -1,0 +1,212 @@
+package kimi
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestManifest(t *testing.T) {
+	m := (&Plugin{}).Manifest()
+	if m.ID != "kimi" {
+		t.Fatalf("ID = %q, want kimi", m.ID)
+	}
+	if m.Name != "Kimi" {
+		t.Fatalf("Name = %q, want Kimi", m.Name)
+	}
+	hasAgent := false
+	for _, c := range m.Capabilities {
+		if c == adapters.CapabilityAgent {
+			hasAgent = true
+		}
+	}
+	if !hasAgent {
+		t.Fatal("missing CapabilityAgent")
+	}
+}
+
+func TestGetConfigSpecEmpty(t *testing.T) {
+	spec, err := (&Plugin{}).GetConfigSpec(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(spec.Fields) != 0 {
+		t.Fatalf("expected no fields, got %d", len(spec.Fields))
+	}
+}
+
+func TestGetPromptDeliveryStrategy(t *testing.T) {
+	s, err := (&Plugin{}).GetPromptDeliveryStrategy(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if s != ports.PromptDeliveryInCommand {
+		t.Fatalf("strategy = %q, want %q", s, ports.PromptDeliveryInCommand)
+	}
+}
+
+func TestGetLaunchCommandBypassWithPrompt(t *testing.T) {
+	p := &Plugin{resolvedBinary: "kimi"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Permissions: ports.PermissionModeBypassPermissions,
+		Prompt:      "-add a health check",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"kimi", "-y", "-p", "-add a health check"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetLaunchCommandMapsPermissionModes(t *testing.T) {
+	tests := []struct {
+		name       string
+		mode       ports.PermissionMode
+		want       []string
+		wantAbsent string
+	}{
+		{"default omits flag", ports.PermissionModeDefault, []string{"kimi"}, "--auto"},
+		{"empty omits flag", "", []string{"kimi"}, "--auto"},
+		{"accept edits", ports.PermissionModeAcceptEdits, []string{"kimi", "--auto"}, "-y"},
+		{"auto", ports.PermissionModeAuto, []string{"kimi", "--auto"}, "-y"},
+		{"bypass", ports.PermissionModeBypassPermissions, []string{"kimi", "-y"}, "--auto"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Plugin{resolvedBinary: "kimi"}
+			cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{Permissions: tt.mode})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(cmd, tt.want) {
+				t.Fatalf("cmd = %#v, want %#v", cmd, tt.want)
+			}
+			if tt.wantAbsent != "" {
+				for _, arg := range cmd {
+					if arg == tt.wantAbsent {
+						t.Fatalf("cmd = %#v unexpectedly contains %q", cmd, tt.wantAbsent)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestGetLaunchCommandIgnoresSystemPrompt(t *testing.T) {
+	p := &Plugin{resolvedBinary: "kimi"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		SystemPrompt:     "follow repo rules",
+		SystemPromptFile: "/tmp/system.md",
+		Prompt:           "do the thing",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Kimi has no documented system-prompt flag, so neither is injected.
+	want := []string{"kimi", "-p", "do the thing"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetRestoreCommand(t *testing.T) {
+	p := &Plugin{resolvedBinary: "kimi"}
+	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Session: ports.SessionRef{
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "01HZABC"},
+		},
+		Permissions: ports.PermissionModeBypassPermissions,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want true")
+	}
+
+	want := []string{"kimi", "-y", "--session", "01HZABC"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetRestoreCommandNoID(t *testing.T) {
+	p := &Plugin{resolvedBinary: "kimi"}
+
+	cases := []struct {
+		name string
+		ref  ports.SessionRef
+	}{
+		{"empty session ref", ports.SessionRef{}},
+		{"empty metadata", ports.SessionRef{Metadata: map[string]string{}}},
+		{"blank agent session metadata", ports.SessionRef{Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "   "}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{Session: tc.ref})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ok {
+				t.Fatal("ok=true with no agentSessionId, want false")
+			}
+			if cmd != nil {
+				t.Fatalf("cmd = %#v, want nil", cmd)
+			}
+		})
+	}
+}
+
+func TestGetAgentHooksNoOp(t *testing.T) {
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: t.TempDir()}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v, want nil", err)
+	}
+}
+
+func TestSessionInfoNoOp(t *testing.T) {
+	info, ok, err := (&Plugin{}).SessionInfo(context.Background(), ports.SessionRef{
+		Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "01HZABC"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatalf("ok=true with info %#v, want no-op false", info)
+	}
+	if !reflect.DeepEqual(info, ports.SessionInfo{}) {
+		t.Fatalf("info = %#v, want zero", info)
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := (&Plugin{}).GetConfigSpec(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetConfigSpec err = %v, want context.Canceled", err)
+	}
+	if _, err := (&Plugin{}).GetPromptDeliveryStrategy(ctx, ports.LaunchConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetPromptDeliveryStrategy err = %v, want context.Canceled", err)
+	}
+	if err := (&Plugin{}).GetAgentHooks(ctx, ports.WorkspaceHookConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetAgentHooks err = %v, want context.Canceled", err)
+	}
+	if _, _, err := (&Plugin{}).GetRestoreCommand(ctx, ports.RestoreConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetRestoreCommand err = %v, want context.Canceled", err)
+	}
+	if _, _, err := (&Plugin{}).SessionInfo(ctx, ports.SessionRef{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("SessionInfo err = %v, want context.Canceled", err)
+	}
+	if _, err := ResolveKimiBinary(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("ResolveKimiBinary err = %v, want context.Canceled", err)
+	}
+}

--- a/backend/internal/adapters/agent/kimi/kimi_test.go
+++ b/backend/internal/adapters/agent/kimi/kimi_test.go
@@ -49,23 +49,47 @@ func TestGetPromptDeliveryStrategy(t *testing.T) {
 	}
 }
 
-func TestGetLaunchCommandBypassWithPrompt(t *testing.T) {
-	p := &Plugin{resolvedBinary: "kimi"}
-	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
-		Permissions: ports.PermissionModeBypassPermissions,
-		Prompt:      "-add a health check",
-	})
-	if err != nil {
-		t.Fatal(err)
+// Kimi docs: `--prompt` cannot be combined with `--yolo`, `--auto`, or `--plan`
+// — non-interactive mode already runs under the `auto` permission policy. The
+// adapter must not emit approval flags on the `-p` launch path regardless of
+// the requested AO PermissionMode.
+func TestGetLaunchCommandWithPromptOmitsApprovalFlags(t *testing.T) {
+	modes := []ports.PermissionMode{
+		ports.PermissionModeDefault,
+		"",
+		ports.PermissionModeAcceptEdits,
+		ports.PermissionModeAuto,
+		ports.PermissionModeBypassPermissions,
 	}
 
-	want := []string{"kimi", "-y", "-p", "-add a health check"}
-	if !reflect.DeepEqual(cmd, want) {
-		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	for _, mode := range modes {
+		t.Run(string(mode), func(t *testing.T) {
+			p := &Plugin{resolvedBinary: "kimi"}
+			cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+				Permissions: mode,
+				Prompt:      "-add a health check",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			want := []string{"kimi", "-p", "-add a health check"}
+			if !reflect.DeepEqual(cmd, want) {
+				t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+			}
+			for _, arg := range cmd {
+				switch arg {
+				case "--auto", "-y", "--yolo", "--yes", "--auto-approve", "--plan":
+					t.Fatalf("cmd = %#v unexpectedly contains approval/plan flag %q", cmd, arg)
+				}
+			}
+		})
 	}
 }
 
-func TestGetLaunchCommandMapsPermissionModes(t *testing.T) {
+// Without a prompt the launch is interactive, so approval flags are valid and
+// the AO PermissionMode mapping applies.
+func TestGetLaunchCommandInteractiveMapsPermissionModes(t *testing.T) {
 	tests := []struct {
 		name       string
 		mode       ports.PermissionMode
@@ -118,24 +142,46 @@ func TestGetLaunchCommandIgnoresSystemPrompt(t *testing.T) {
 	}
 }
 
+// Kimi docs: `--yolo` and `--auto` cannot be used together with `--continue`
+// or `--session` — resumed sessions inherit the approval settings of the
+// original session — so the restore path must not emit approval flags
+// regardless of the requested AO PermissionMode.
 func TestGetRestoreCommand(t *testing.T) {
-	p := &Plugin{resolvedBinary: "kimi"}
-	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
-		Session: ports.SessionRef{
-			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "01HZABC"},
-		},
-		Permissions: ports.PermissionModeBypassPermissions,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok {
-		t.Fatal("ok=false, want true")
+	modes := []ports.PermissionMode{
+		ports.PermissionModeDefault,
+		"",
+		ports.PermissionModeAcceptEdits,
+		ports.PermissionModeAuto,
+		ports.PermissionModeBypassPermissions,
 	}
 
-	want := []string{"kimi", "-y", "--session", "01HZABC"}
-	if !reflect.DeepEqual(cmd, want) {
-		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	for _, mode := range modes {
+		t.Run(string(mode), func(t *testing.T) {
+			p := &Plugin{resolvedBinary: "kimi"}
+			cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+				Session: ports.SessionRef{
+					Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "01HZABC"},
+				},
+				Permissions: mode,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !ok {
+				t.Fatal("ok=false, want true")
+			}
+
+			want := []string{"kimi", "--session", "01HZABC"}
+			if !reflect.DeepEqual(cmd, want) {
+				t.Fatalf("cmd = %#v, want %#v", cmd, want)
+			}
+			for _, arg := range cmd {
+				switch arg {
+				case "--auto", "-y", "--yolo", "--yes", "--auto-approve", "--plan":
+					t.Fatalf("cmd = %#v unexpectedly contains approval/plan flag %q", cmd, arg)
+				}
+			}
+		})
 	}
 }
 

--- a/backend/internal/adapters/agent/registry/registry.go
+++ b/backend/internal/adapters/agent/registry/registry.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/droid"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/goose"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/grok"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kimi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/opencode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/qwen"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -51,6 +52,7 @@ func Constructors() []adapters.Adapter {
 		continueagent.New(),
 		devin.New(),
 		cline.New(),
+		kimi.New(),
 	}
 }
 

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -107,6 +107,7 @@ func TestWiring_AgentResolverResolvesRealAdapters(t *testing.T) {
 		{domain.HarnessContinue, "continue"},
 		{domain.HarnessDevin, "devin"},
 		{domain.HarnessCline, "cline"},
+		{domain.HarnessKimi, "kimi"},
 		{"", config.DefaultAgent}, // empty harness falls back to the AO_AGENT default
 	} {
 		agent, ok := resolver.Agent(tc.harness)


### PR DESCRIPTION
Adds the **kimi** harness, stacked on #119 (agent platform). Adapter package + `Constructors()` registration + resolver test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #119
2. #120
3. #121
4. #122
5. #123
6. #124
7. #125
8. #126
9. #127
10. #128
11. #129
12. #130
13. #131
14. #132
15. #133
16. **#134** 👈 current
17. #135
18. #136
19. #137
20. #138
21. #139
<!-- stack:links:end -->