### PR TITLE
feat(agents): add kiro adapter

### DIFF
--- a/backend/internal/adapters/agent/activitydispatch/dispatch.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/cursor"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/droid"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/goose"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kiro"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/opencode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/qwen"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -47,6 +48,7 @@ var Derivers = map[string]DeriveFunc{
 	"copilot":     copilot.DeriveActivityState,
 	"goose":       goose.DeriveActivityState,
 	"cline":       cline.DeriveActivityState,
+	"kiro":        kiro.DeriveActivityState,
 }
 
 // Derive looks up the deriver for an agent token and applies it. ok=false when

--- a/backend/internal/adapters/agent/kiro/activity.go
+++ b/backend/internal/adapters/agent/kiro/activity.go
@@ -1,0 +1,31 @@
+package kiro
+
+import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
+
+// DeriveActivityState maps a Kiro hook event onto an AO activity state. The
+// bool is false when the event carries no activity signal.
+//
+// event is the AO hook sub-command name installed in kiroManagedHooks
+// ("session-start", "user-prompt-submit", "permission-request", "stop"), not
+// the native Kiro event name (agentSpawn/userPromptSubmit/preToolUse/stop).
+// Kiro currently has no session/process-end hook in the adapter, so runtime
+// exit still falls back to the lifecycle reaper.
+//
+// TODO(kiro): ActivityExited is still runtime-observation-owned. If Kiro adds a
+// native session/process-end hook, map that hook to ActivityExited here. Until
+// then, make sure the lifecycle reaper can still mark a dead Kiro runtime as
+// exited even when the last hook signal was sticky waiting_input.
+func DeriveActivityState(event string, _ []byte) (domain.ActivityState, bool) {
+	switch event {
+	case "session-start":
+		return domain.ActivityActive, true
+	case "user-prompt-submit":
+		return domain.ActivityActive, true
+	case "stop":
+		return domain.ActivityIdle, true
+	case "permission-request":
+		return domain.ActivityWaitingInput, true
+	default:
+		return "", false
+	}
+}

--- a/backend/internal/adapters/agent/kiro/hooks.go
+++ b/backend/internal/adapters/agent/kiro/hooks.go
@@ -1,0 +1,327 @@
+package kiro
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const (
+	// Kiro reads hooks from a workspace-local agent configuration file at
+	// .kiro/agents/<name>.json. AO installs its hooks into a dedicated agent
+	// file so it never clobbers a user's own agents.
+	// See https://kiro.dev/docs/cli/hooks/ and
+	// https://kiro.dev/docs/cli/custom-agents/configuration-reference#hooks-field
+	kiroHooksDirName  = ".kiro"
+	kiroAgentsDirName = "agents"
+	kiroAgentFileName = "ao.json"
+
+	// kiroHookCommandPrefix identifies the hook commands AO owns, so install
+	// skips duplicates and uninstall recognizes AO entries by prefix without an
+	// embedded template to diff against.
+	kiroHookCommandPrefix = "ao hooks kiro "
+)
+
+// kiroHookFile is the on-disk shape of .kiro/agents/ao.json. It is used by
+// tests to decode the written file. Kiro hooks are a map of camelCase event
+// name to a flat array of {matcher?, command} entries.
+type kiroHookFile struct {
+	Hooks map[string][]kiroHookEntry `json:"hooks"`
+}
+
+type kiroHookEntry struct {
+	Matcher string `json:"matcher,omitempty"`
+	Command string `json:"command"`
+}
+
+// kiroHookSpec describes one hook AO installs, defined in code rather than read
+// from an embedded hooks file.
+type kiroHookSpec struct {
+	// Event is the native Kiro hook event name (camelCase).
+	Event string
+	// Command is the AO hook command line.
+	Command string
+}
+
+// kiroManagedHooks is the source of truth for the hooks AO installs. The native
+// Kiro events are mapped onto AO hook sub-command names (the trailing word) so
+// the CLI hook dispatcher routes them to DeriveActivityState:
+//
+//	agentSpawn       -> session-start       (ActivityActive)
+//	userPromptSubmit -> user-prompt-submit  (ActivityActive)
+//	preToolUse       -> permission-request  (ActivityWaitingInput)
+//	stop             -> stop                (ActivityIdle)
+var kiroManagedHooks = []kiroHookSpec{
+	{Event: "agentSpawn", Command: kiroHookCommandPrefix + "session-start"},
+	{Event: "userPromptSubmit", Command: kiroHookCommandPrefix + "user-prompt-submit"},
+	{Event: "preToolUse", Command: kiroHookCommandPrefix + "permission-request"},
+	{Event: "stop", Command: kiroHookCommandPrefix + "stop"},
+}
+
+// GetAgentHooks installs AO's Kiro hooks into the worktree-local
+// .kiro/agents/ao.json file. Existing hook entries are preserved and duplicate
+// AO commands are not appended.
+func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(cfg.WorkspacePath) == "" {
+		return errors.New("kiro.GetAgentHooks: WorkspacePath is required")
+	}
+
+	hooksPath := kiroAgentPath(cfg.WorkspacePath)
+	topLevel, rawHooks, err := readKiroHooks(hooksPath)
+	if err != nil {
+		return fmt.Errorf("kiro.GetAgentHooks: %w", err)
+	}
+
+	for event, specs := range groupKiroHooksByEvent() {
+		var existing []kiroHookEntry
+		if err := parseKiroHookEvent(rawHooks, event, &existing); err != nil {
+			return fmt.Errorf("kiro.GetAgentHooks: %w", err)
+		}
+		for _, spec := range specs {
+			if !kiroHookCommandExists(existing, spec.Command) {
+				existing = append(existing, kiroHookEntry{Command: spec.Command})
+			}
+		}
+		if err := marshalKiroHookEvent(rawHooks, event, existing); err != nil {
+			return fmt.Errorf("kiro.GetAgentHooks: %w", err)
+		}
+	}
+
+	if err := writeKiroHooks(hooksPath, topLevel, rawHooks); err != nil {
+		return fmt.Errorf("kiro.GetAgentHooks: %w", err)
+	}
+	return nil
+}
+
+// UninstallHooks removes AO's Kiro hooks from the workspace-local
+// .kiro/agents/ao.json file, leaving user-defined hooks untouched. A missing
+// file is a no-op.
+func (p *Plugin) UninstallHooks(ctx context.Context, workspacePath string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(workspacePath) == "" {
+		return errors.New("kiro.UninstallHooks: workspacePath is required")
+	}
+
+	hooksPath := kiroAgentPath(workspacePath)
+	if _, err := os.Stat(hooksPath); errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	topLevel, rawHooks, err := readKiroHooks(hooksPath)
+	if err != nil {
+		return fmt.Errorf("kiro.UninstallHooks: %w", err)
+	}
+
+	for _, event := range kiroManagedEvents() {
+		var entries []kiroHookEntry
+		if err := parseKiroHookEvent(rawHooks, event, &entries); err != nil {
+			return fmt.Errorf("kiro.UninstallHooks: %w", err)
+		}
+		entries = removeKiroManagedHooks(entries)
+		if err := marshalKiroHookEvent(rawHooks, event, entries); err != nil {
+			return fmt.Errorf("kiro.UninstallHooks: %w", err)
+		}
+	}
+
+	if err := writeKiroHooks(hooksPath, topLevel, rawHooks); err != nil {
+		return fmt.Errorf("kiro.UninstallHooks: %w", err)
+	}
+	return nil
+}
+
+// AreHooksInstalled reports whether any AO Kiro hook is present in the
+// workspace-local agent file. A missing file means none are installed.
+func (p *Plugin) AreHooksInstalled(ctx context.Context, workspacePath string) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(workspacePath) == "" {
+		return false, errors.New("kiro.AreHooksInstalled: workspacePath is required")
+	}
+
+	hooksPath := kiroAgentPath(workspacePath)
+	if _, err := os.Stat(hooksPath); errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	_, rawHooks, err := readKiroHooks(hooksPath)
+	if err != nil {
+		return false, fmt.Errorf("kiro.AreHooksInstalled: %w", err)
+	}
+
+	for _, event := range kiroManagedEvents() {
+		var entries []kiroHookEntry
+		if err := parseKiroHookEvent(rawHooks, event, &entries); err != nil {
+			return false, fmt.Errorf("kiro.AreHooksInstalled: %w", err)
+		}
+		for _, entry := range entries {
+			if isKiroManagedHook(entry.Command) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func kiroAgentPath(workspacePath string) string {
+	return filepath.Join(workspacePath, kiroHooksDirName, kiroAgentsDirName, kiroAgentFileName)
+}
+
+// readKiroHooks loads the agent file into a top-level raw map plus the decoded
+// "hooks" sub-map, preserving keys AO doesn't manage. A missing or empty file
+// yields empty maps.
+func readKiroHooks(hooksPath string) (topLevel, rawHooks map[string]json.RawMessage, err error) {
+	topLevel = map[string]json.RawMessage{}
+	rawHooks = map[string]json.RawMessage{}
+
+	data, err := os.ReadFile(hooksPath) //nolint:gosec // path built from caller-owned workspace dir
+	if errors.Is(err, os.ErrNotExist) {
+		return topLevel, rawHooks, nil
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("read %s: %w", hooksPath, err)
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return topLevel, rawHooks, nil
+	}
+	if err := json.Unmarshal(data, &topLevel); err != nil {
+		return nil, nil, fmt.Errorf("parse %s: %w", hooksPath, err)
+	}
+	if hooksRaw, ok := topLevel["hooks"]; ok {
+		if err := json.Unmarshal(hooksRaw, &rawHooks); err != nil {
+			return nil, nil, fmt.Errorf("parse hooks in %s: %w", hooksPath, err)
+		}
+	}
+	return topLevel, rawHooks, nil
+}
+
+// writeKiroHooks folds rawHooks back into topLevel and writes the file. An
+// empty hooks map drops the "hooks" key entirely.
+func writeKiroHooks(hooksPath string, topLevel, rawHooks map[string]json.RawMessage) error {
+	if len(rawHooks) == 0 {
+		delete(topLevel, "hooks")
+	} else {
+		hooksJSON, err := json.Marshal(rawHooks)
+		if err != nil {
+			return fmt.Errorf("encode hooks: %w", err)
+		}
+		topLevel["hooks"] = hooksJSON
+	}
+
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o750); err != nil {
+		return fmt.Errorf("create hook dir: %w", err)
+	}
+	data, err := json.MarshalIndent(topLevel, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode %s: %w", hooksPath, err)
+	}
+	data = append(data, '\n')
+	if err := atomicWriteFile(hooksPath, data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", hooksPath, err)
+	}
+	return nil
+}
+
+// atomicWriteFile writes data to path via a temp file + rename, so a crash mid-
+// write can't leave a truncated/empty file that Kiro then fails to parse.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".ao-tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// groupKiroHooksByEvent groups the managed hook specs by their Kiro event so
+// each event's array is rewritten once.
+func groupKiroHooksByEvent() map[string][]kiroHookSpec {
+	byEvent := map[string][]kiroHookSpec{}
+	for _, spec := range kiroManagedHooks {
+		byEvent[spec.Event] = append(byEvent[spec.Event], spec)
+	}
+	return byEvent
+}
+
+// kiroManagedEvents returns the distinct Kiro events AO manages, in the order
+// they first appear in kiroManagedHooks.
+func kiroManagedEvents() []string {
+	seen := map[string]bool{}
+	events := make([]string, 0, len(kiroManagedHooks))
+	for _, spec := range kiroManagedHooks {
+		if !seen[spec.Event] {
+			seen[spec.Event] = true
+			events = append(events, spec.Event)
+		}
+	}
+	return events
+}
+
+func isKiroManagedHook(command string) bool {
+	return strings.HasPrefix(command, kiroHookCommandPrefix)
+}
+
+// removeKiroManagedHooks strips AO hook entries from an event's array.
+func removeKiroManagedHooks(entries []kiroHookEntry) []kiroHookEntry {
+	kept := make([]kiroHookEntry, 0, len(entries))
+	for _, entry := range entries {
+		if !isKiroManagedHook(entry.Command) {
+			kept = append(kept, entry)
+		}
+	}
+	return kept
+}
+
+func parseKiroHookEvent(rawHooks map[string]json.RawMessage, event string, target *[]kiroHookEntry) error {
+	data, ok := rawHooks[event]
+	if !ok {
+		return nil
+	}
+	if err := json.Unmarshal(data, target); err != nil {
+		return fmt.Errorf("parse %s hooks: %w", event, err)
+	}
+	return nil
+}
+
+func marshalKiroHookEvent(rawHooks map[string]json.RawMessage, event string, entries []kiroHookEntry) error {
+	if len(entries) == 0 {
+		delete(rawHooks, event)
+		return nil
+	}
+	data, err := json.Marshal(entries)
+	if err != nil {
+		return fmt.Errorf("encode %s hooks: %w", event, err)
+	}
+	rawHooks[event] = data
+	return nil
+}
+
+func kiroHookCommandExists(entries []kiroHookEntry, command string) bool {
+	for _, entry := range entries {
+		if entry.Command == command {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/adapters/agent/kiro/kiro.go
+++ b/backend/internal/adapters/agent/kiro/kiro.go
@@ -1,0 +1,270 @@
+// Package kiro implements the Kiro (AWS) agent adapter: launching new headless
+// sessions, resuming hook-tracked sessions, installing workspace-local hooks,
+// and reading hook-derived session info.
+//
+// Kiro is AWS's agentic coding assistant. Its terminal CLI ships as the
+// `kiro-cli` binary and exposes a non-interactive ("headless") mode via
+// `kiro-cli chat --no-interactive "<prompt>"`, suitable for AO-driven worker
+// sessions. See https://kiro.dev/docs/cli/headless/ and
+// https://kiro.dev/docs/cli/reference/cli-commands/.
+//
+// Launch delivers the initial prompt as a positional argument after `--` so a
+// leading "-" is not parsed as a flag. Permission/approval modes map onto
+// Kiro's tool-trust flags (`--trust-all-tools`, `--trust-tools=<categories>`).
+// Restore uses `kiro-cli chat --resume-id <UUID>` with the native session id
+// captured from a Kiro hook payload.
+//
+// AO-managed sessions derive native session identity and display metadata from
+// Kiro's native hooks (see hooks.go / activity.go) rather than transcript scans.
+package kiro
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const (
+	kiroTitleMetadataKey   = "title"
+	kiroSummaryMetadataKey = "summary"
+)
+
+// Plugin is the Kiro agent adapter. It is safe for concurrent use; the binary
+// path is resolved once and cached under binaryMu.
+type Plugin struct {
+	binaryMu       sync.Mutex
+	resolvedBinary string
+}
+
+// New returns a ready-to-register Kiro adapter.
+func New() *Plugin {
+	return &Plugin{}
+}
+
+var _ adapters.Adapter = (*Plugin)(nil)
+var _ ports.Agent = (*Plugin)(nil)
+
+// Manifest returns the adapter's static self-description.
+func (p *Plugin) Manifest() adapters.Manifest {
+	return adapters.Manifest{
+		ID:          "kiro",
+		Name:        "Kiro",
+		Description: "Run Kiro (AWS) worker sessions.",
+		Version:     "0.0.1",
+		Capabilities: []adapters.Capability{
+			adapters.CapabilityAgent,
+		},
+	}
+}
+
+// GetConfigSpec reports the agent-specific config keys. Kiro exposes none yet.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{}, nil
+}
+
+// GetLaunchCommand builds the argv to start a new headless Kiro session:
+// `kiro-cli chat --no-interactive [trust flags] -- <prompt>`.
+//
+// The prompt is passed as a positional argument after `--` so a leading "-" is
+// not read as a flag. Kiro's --no-interactive mode requires a prompt argument.
+func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
+	binary, err := p.kiroBinary(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd = []string{binary, "chat", "--no-interactive"}
+	appendApprovalFlags(&cmd, cfg.Permissions)
+
+	if cfg.Prompt != "" {
+		cmd = append(cmd, "--", cfg.Prompt)
+	}
+
+	return cmd, nil
+}
+
+// GetPromptDeliveryStrategy reports that Kiro receives its prompt in the launch
+// command itself.
+func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, cfg ports.LaunchConfig) (ports.PromptDeliveryStrategy, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return ports.PromptDeliveryInCommand, nil
+}
+
+// GetRestoreCommand rebuilds the argv that continues an existing Kiro session:
+// `kiro-cli chat --no-interactive --resume-id <agentSessionId> [trust flags]`.
+// ok is false when the hook-derived native session id has not landed yet, so
+// callers can fall back to fresh launch behavior.
+func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	agentSessionID := strings.TrimSpace(cfg.Session.Metadata[ports.MetadataKeyAgentSessionID])
+	if agentSessionID == "" {
+		return nil, false, nil
+	}
+
+	binary, err := p.kiroBinary(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	cmd = make([]string, 0, 8)
+	cmd = append(cmd, binary, "chat", "--no-interactive", "--resume-id", agentSessionID)
+	appendApprovalFlags(&cmd, cfg.Permissions)
+	return cmd, true, nil
+}
+
+// SessionInfo surfaces Kiro hook-derived metadata. Metadata is intentionally
+// nil for Kiro: callers get the normalized fields directly.
+func (p *Plugin) SessionInfo(ctx context.Context, session ports.SessionRef) (ports.SessionInfo, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.SessionInfo{}, false, err
+	}
+	info := ports.SessionInfo{
+		AgentSessionID: session.Metadata[ports.MetadataKeyAgentSessionID],
+		Title:          session.Metadata[kiroTitleMetadataKey],
+		Summary:        session.Metadata[kiroSummaryMetadataKey],
+	}
+	if info.AgentSessionID == "" && info.Title == "" && info.Summary == "" {
+		return ports.SessionInfo{}, false, nil
+	}
+	return info, true, nil
+}
+
+// ResolveKiroBinary returns the path to the kiro-cli binary on this machine,
+// searching PATH then a handful of well-known install locations. Returns
+// "kiro-cli" as a last-ditch fallback so callers see a clear "command not
+// found" rather than an empty argv.
+func ResolveKiroBinary(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	if runtime.GOOS == "windows" {
+		for _, name := range []string{"kiro-cli.cmd", "kiro-cli.exe", "kiro-cli"} {
+			path, err := exec.LookPath(name)
+			if err == nil && path != "" {
+				return path, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+		}
+
+		candidates := []string{}
+		if localAppData := os.Getenv("LOCALAPPDATA"); localAppData != "" {
+			candidates = append(candidates,
+				filepath.Join(localAppData, "Programs", "kiro", "kiro-cli.exe"),
+			)
+		}
+		if appData := os.Getenv("APPDATA"); appData != "" {
+			candidates = append(candidates,
+				filepath.Join(appData, "npm", "kiro-cli.cmd"),
+				filepath.Join(appData, "npm", "kiro-cli.exe"),
+			)
+		}
+		if home, err := os.UserHomeDir(); err == nil {
+			candidates = append(candidates,
+				filepath.Join(home, ".kiro", "bin", "kiro-cli.exe"),
+			)
+		}
+		for _, candidate := range candidates {
+			if fileExists(candidate) {
+				return candidate, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+		}
+
+		return "kiro-cli", nil
+	}
+
+	if path, err := exec.LookPath("kiro-cli"); err == nil && path != "" {
+		return path, nil
+	}
+
+	candidates := []string{
+		"/usr/local/bin/kiro-cli",
+		"/opt/homebrew/bin/kiro-cli",
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates,
+			filepath.Join(home, ".kiro", "bin", "kiro-cli"),
+			filepath.Join(home, ".local", "bin", "kiro-cli"),
+		)
+	}
+
+	for _, candidate := range candidates {
+		if fileExists(candidate) {
+			return candidate, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+	}
+
+	return "kiro-cli", nil
+}
+
+func (p *Plugin) kiroBinary(ctx context.Context) (string, error) {
+	p.binaryMu.Lock()
+	defer p.binaryMu.Unlock()
+
+	if p.resolvedBinary != "" {
+		return p.resolvedBinary, nil
+	}
+
+	binary, err := ResolveKiroBinary(ctx)
+	if err != nil {
+		return "", err
+	}
+	p.resolvedBinary = binary
+	return binary, nil
+}
+
+// appendApprovalFlags maps AO's 4 permission modes onto Kiro's tool-trust
+// flags. Default emits no flag so Kiro defers to the user's own configuration
+// (the interactive per-tool prompt). accept-edits grants the write-capable
+// built-in tools; auto/bypass grant all tools.
+func appendApprovalFlags(cmd *[]string, permissions ports.PermissionMode) {
+	switch normalizePermissionMode(permissions) {
+	case ports.PermissionModeDefault:
+		// No flag: defer to the user's Kiro config / per-tool prompting.
+	case ports.PermissionModeAcceptEdits:
+		*cmd = append(*cmd, "--trust-tools=fs_read,fs_write")
+	case ports.PermissionModeAuto:
+		*cmd = append(*cmd, "--trust-all-tools")
+	case ports.PermissionModeBypassPermissions:
+		*cmd = append(*cmd, "--trust-all-tools")
+	}
+}
+
+func normalizePermissionMode(mode ports.PermissionMode) ports.PermissionMode {
+	switch mode {
+	case ports.PermissionModeDefault,
+		ports.PermissionModeAcceptEdits,
+		ports.PermissionModeAuto,
+		ports.PermissionModeBypassPermissions:
+		return mode
+	default:
+		return ports.PermissionModeDefault
+	}
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/backend/internal/adapters/agent/kiro/kiro_test.go
+++ b/backend/internal/adapters/agent/kiro/kiro_test.go
@@ -1,0 +1,445 @@
+package kiro
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestManifestIDIsKiro(t *testing.T) {
+	m := (&Plugin{}).Manifest()
+	if m.ID != "kiro" {
+		t.Fatalf("manifest ID = %q, want %q", m.ID, "kiro")
+	}
+	if m.Name != "Kiro" {
+		t.Fatalf("manifest Name = %q, want %q", m.Name, "Kiro")
+	}
+	if len(m.Capabilities) != 1 || m.Capabilities[0] != adapters.CapabilityAgent {
+		t.Fatalf("manifest Capabilities = %#v, want [CapabilityAgent]", m.Capabilities)
+	}
+}
+
+func TestGetLaunchCommandBuildsHeadlessArgv(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kiro-cli"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Permissions: ports.PermissionModeBypassPermissions,
+		Prompt:      "-fix this",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"kiro-cli", "chat", "--no-interactive",
+		"--trust-all-tools",
+		"--", "-fix this",
+	}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetLaunchCommandMapsApprovalModes(t *testing.T) {
+	tests := []struct {
+		name        string
+		permission  ports.PermissionMode
+		want        []string
+		notExpected []string
+	}{
+		{
+			name:        "default",
+			permission:  ports.PermissionModeDefault,
+			notExpected: []string{"--trust-all-tools", "--trust-tools=fs_read,fs_write"},
+		},
+		{
+			name:       "accept-edits",
+			permission: ports.PermissionModeAcceptEdits,
+			want:       []string{"--trust-tools=fs_read,fs_write"},
+		},
+		{
+			name:       "auto",
+			permission: ports.PermissionModeAuto,
+			want:       []string{"--trust-all-tools"},
+		},
+		{
+			name:       "bypass-permissions",
+			permission: ports.PermissionModeBypassPermissions,
+			want:       []string{"--trust-all-tools"},
+		},
+		{
+			name:        "empty",
+			permission:  "",
+			notExpected: []string{"--trust-all-tools", "--trust-tools=fs_read,fs_write"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &Plugin{resolvedBinary: "kiro-cli"}
+			cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+				Permissions: tt.permission,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(tt.want) > 0 && !containsSubsequence(cmd, tt.want) {
+				t.Fatalf("command %#v does not contain %#v", cmd, tt.want)
+			}
+			for _, missing := range tt.notExpected {
+				if contains(cmd, missing) {
+					t.Fatalf("command %#v contains %q", cmd, missing)
+				}
+			}
+		})
+	}
+}
+
+func TestGetLaunchCommandCtxCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	plugin := &Plugin{}
+	if _, err := plugin.GetLaunchCommand(ctx, ports.LaunchConfig{}); err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+}
+
+func TestGetPromptDeliveryStrategyIsInCommand(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kiro-cli"}
+
+	got, err := plugin.GetPromptDeliveryStrategy(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != ports.PromptDeliveryInCommand {
+		t.Fatalf("unexpected strategy: %q", got)
+	}
+}
+
+func TestGetConfigSpecHasNoCustomFieldsYet(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kiro-cli"}
+
+	spec, err := plugin.GetConfigSpec(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(spec.Fields) != 0 {
+		t.Fatalf("unexpected config fields: %#v", spec.Fields)
+	}
+}
+
+func TestGetAgentHooksInstallsKiroHooks(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kiro-cli"}
+	workspace := t.TempDir()
+	hooksDir := filepath.Join(workspace, kiroHooksDirName, kiroAgentsDirName)
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hooksPath := filepath.Join(hooksDir, kiroAgentFileName)
+	existing := `{"name":"ao","hooks":{"stop":[{"command":"custom stop hook"}]}}`
+	if err := os.WriteFile(hooksPath, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := ports.WorkspaceHookConfig{
+		DataDir:       t.TempDir(),
+		SessionID:     "sess-1",
+		WorkspacePath: workspace,
+	}
+	if err := plugin.GetAgentHooks(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+	// A second install must not duplicate AO hook commands.
+	if err := plugin.GetAgentHooks(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The unmanaged top-level "name" key must be preserved.
+	var topLevel map[string]json.RawMessage
+	if err := json.Unmarshal(data, &topLevel); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := topLevel["name"]; !ok {
+		t.Fatalf("unmanaged top-level key 'name' was dropped: %s", data)
+	}
+
+	var config kiroHookFile
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatal(err)
+	}
+	if config.Hooks == nil {
+		t.Fatalf("hooks config missing hooks object: %#v", config)
+	}
+	for _, spec := range kiroManagedHooks {
+		entries := config.Hooks[spec.Event]
+		if count := countKiroHookCommand(entries, spec.Command); count != 1 {
+			t.Fatalf("%s command count = %d, want 1 in %#v", spec.Event, count, entries)
+		}
+	}
+	stopEntries := config.Hooks["stop"]
+	if countKiroHookCommand(stopEntries, "custom stop hook") != 1 {
+		t.Fatalf("existing stop hook was not preserved: %#v", stopEntries)
+	}
+}
+
+func TestUninstallHooksRemovesKiroHooks(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kiro-cli"}
+	workspace := t.TempDir()
+	hooksPath := kiroAgentPath(workspace)
+
+	ctx := context.Background()
+	cfg := ports.WorkspaceHookConfig{DataDir: t.TempDir(), SessionID: "sess-1", WorkspacePath: workspace}
+
+	// Pre-seed a user's own stop hook; it must survive uninstall.
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	existing := `{"hooks":{"stop":[{"command":"custom stop hook"}]}}`
+	if err := os.WriteFile(hooksPath, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := plugin.GetAgentHooks(ctx, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if installed, err := plugin.AreHooksInstalled(ctx, workspace); err != nil || !installed {
+		t.Fatalf("AreHooksInstalled after install = (%v, %v), want (true, nil)", installed, err)
+	}
+
+	if err := plugin.UninstallHooks(ctx, workspace); err != nil {
+		t.Fatal(err)
+	}
+	if installed, err := plugin.AreHooksInstalled(ctx, workspace); err != nil || installed {
+		t.Fatalf("AreHooksInstalled after uninstall = (%v, %v), want (false, nil)", installed, err)
+	}
+
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var config kiroHookFile
+	if err := json.Unmarshal(data, &config); err != nil {
+		t.Fatal(err)
+	}
+	for _, spec := range kiroManagedHooks {
+		if got := countKiroHookCommand(config.Hooks[spec.Event], spec.Command); got != 0 {
+			t.Fatalf("%s command %q count = %d after uninstall, want 0", spec.Event, spec.Command, got)
+		}
+	}
+	if countKiroHookCommand(config.Hooks["stop"], "custom stop hook") != 1 {
+		t.Fatalf("user stop hook not preserved: %#v", config.Hooks["stop"])
+	}
+}
+
+func TestAreHooksInstalledMissingFile(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kiro-cli"}
+	workspace := t.TempDir()
+	installed, err := plugin.AreHooksInstalled(context.Background(), workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if installed {
+		t.Fatal("AreHooksInstalled = true for missing file, want false")
+	}
+}
+
+func TestGetRestoreCommandReadsAgentSessionID(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kiro-cli"}
+
+	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Permissions: ports.PermissionModeAuto,
+		Session: ports.SessionRef{
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "uuid-123"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	want := []string{
+		"kiro-cli", "chat", "--no-interactive",
+		"--resume-id", "uuid-123",
+		"--trust-all-tools",
+	}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("restore cmd\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetRestoreCommandFalseWithoutAgentSessionID(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kiro-cli"}
+
+	cases := []struct {
+		name string
+		ref  ports.SessionRef
+	}{
+		{"empty session ref", ports.SessionRef{}},
+		{"empty metadata", ports.SessionRef{Metadata: map[string]string{}}},
+		{"blank agent session metadata", ports.SessionRef{Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "   "}}},
+		{"workspace path only", ports.SessionRef{WorkspacePath: "/some/path"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+				Permissions: ports.PermissionModeAuto,
+				Session:     tc.ref,
+			})
+			if err != nil {
+				t.Fatalf("err = %v, want nil", err)
+			}
+			if ok {
+				t.Fatalf("ok = true, want false")
+			}
+			if cmd != nil {
+				t.Fatalf("cmd = %#v, want nil", cmd)
+			}
+		})
+	}
+}
+
+func TestSessionInfoReadsHookMetadata(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kiro-cli"}
+
+	info, ok, err := plugin.SessionInfo(context.Background(), ports.SessionRef{
+		WorkspacePath: "/some/path",
+		Metadata: map[string]string{
+			ports.MetadataKeyAgentSessionID: "uuid-123",
+			kiroTitleMetadataKey:            "Fix login redirect",
+			kiroSummaryMetadataKey:          "Updated the auth callback and tests.",
+			"ignored":                       "not returned",
+		},
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !ok {
+		t.Fatalf("ok = false, want true")
+	}
+	if info.AgentSessionID != "uuid-123" {
+		t.Fatalf("AgentSessionID = %q, want native id", info.AgentSessionID)
+	}
+	if info.Title != "Fix login redirect" {
+		t.Fatalf("Title = %q, want hook title", info.Title)
+	}
+	if info.Summary != "Updated the auth callback and tests." {
+		t.Fatalf("Summary = %q, want hook summary", info.Summary)
+	}
+	if info.Metadata != nil {
+		t.Fatalf("Metadata = %#v, want nil for Kiro", info.Metadata)
+	}
+}
+
+func TestSessionInfoFalseWhenNoHookMetadata(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kiro-cli"}
+
+	info, ok, err := plugin.SessionInfo(context.Background(), ports.SessionRef{
+		WorkspacePath: "/some/path",
+		Metadata:      map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if ok {
+		t.Fatalf("ok = true, want false")
+	}
+	if !reflect.DeepEqual(info, ports.SessionInfo{}) {
+		t.Fatalf("info = %#v, want zero value", info)
+	}
+}
+
+func TestDeriveActivityState(t *testing.T) {
+	tests := []struct {
+		event     string
+		wantState domain.ActivityState
+		wantOK    bool
+	}{
+		{"session-start", domain.ActivityActive, true},
+		{"user-prompt-submit", domain.ActivityActive, true},
+		{"stop", domain.ActivityIdle, true},
+		{"permission-request", domain.ActivityWaitingInput, true},
+		{"unknown", "", false},
+		{"", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.event, func(t *testing.T) {
+			state, ok := DeriveActivityState(tt.event, nil)
+			if state != tt.wantState || ok != tt.wantOK {
+				t.Fatalf("DeriveActivityState(%q) = (%q, %v), want (%q, %v)", tt.event, state, ok, tt.wantState, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestResolveKiroBinaryFallback(t *testing.T) {
+	got, err := ResolveKiroBinary(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == "" {
+		t.Fatal("ResolveKiroBinary returned empty path")
+	}
+}
+
+func TestResolveKiroBinaryCtxCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := ResolveKiroBinary(ctx); err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+}
+
+func contains(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func containsSubsequence(values []string, needle []string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+
+	for start := range values {
+		if start+len(needle) > len(values) {
+			return false
+		}
+		ok := true
+		for offset, want := range needle {
+			if values[start+offset] != want {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+func countKiroHookCommand(entries []kiroHookEntry, command string) int {
+	count := 0
+	for _, entry := range entries {
+		if entry.Command == command {
+			count++
+		}
+	}
+	return count
+}

--- a/backend/internal/adapters/agent/registry/registry.go
+++ b/backend/internal/adapters/agent/registry/registry.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/goose"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/grok"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kimi"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kiro"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/opencode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/qwen"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -53,6 +54,7 @@ func Constructors() []adapters.Adapter {
 		devin.New(),
 		cline.New(),
 		kimi.New(),
+		kiro.New(),
 	}
 }
 

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -108,6 +108,7 @@ func TestWiring_AgentResolverResolvesRealAdapters(t *testing.T) {
 		{domain.HarnessDevin, "devin"},
 		{domain.HarnessCline, "cline"},
 		{domain.HarnessKimi, "kimi"},
+		{domain.HarnessKiro, "kiro"},
 		{"", config.DefaultAgent}, // empty harness falls back to the AO_AGENT default
 	} {
 		agent, ok := resolver.Agent(tc.harness)


### PR DESCRIPTION
Adds the **kiro** harness, stacked on #119 (agent platform). Adapter package + `Constructors()` registration + resolver test. Includes its own activity deriver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #119
2. #120
3. #121
4. #122
5. #123
6. #124
7. #125
8. #126
9. #127
10. #128
11. #129
12. #130
13. #131
14. #132
15. #133
16. #134
17. **#135** 👈 current
18. #136
19. #137
20. #138
21. #139
<!-- stack:links:end -->