### PR TITLE
feat(agents): add kilocode adapter

### DIFF
--- a/backend/internal/adapters/agent/activitydispatch/dispatch.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/cursor"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/droid"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/goose"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kilocode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kiro"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/opencode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/qwen"
@@ -49,6 +50,7 @@ var Derivers = map[string]DeriveFunc{
 	"goose":       goose.DeriveActivityState,
 	"cline":       cline.DeriveActivityState,
 	"kiro":        kiro.DeriveActivityState,
+	"kilocode":    kilocode.DeriveActivityState,
 }
 
 // Derive looks up the deriver for an agent token and applies it. ok=false when

--- a/backend/internal/adapters/agent/kilocode/activity.go
+++ b/backend/internal/adapters/agent/kilocode/activity.go
@@ -1,0 +1,31 @@
+package kilocode
+
+import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
+
+// DeriveActivityState maps a Kilo Code plugin hook event onto an AO activity
+// state. The bool is false when the event carries no activity signal.
+//
+// event is the AO hook sub-command name the installed plugin shells via
+// `ao hooks kilocode <event>` (see kilocodeManagedEvents in hooks.go), not a
+// native Kilo event name. The plugin reports:
+//   - "session-start"      → a Kilo session was created (turn begins).
+//   - "user-prompt-submit" → the user submitted a prompt (turn begins).
+//   - "permission-request" → Kilo is asking the user to approve a tool call.
+//   - "stop"               → the current turn went idle/finished.
+//
+// Kilo has no native session/process-end plugin event the adapter maps to
+// ActivityExited, so runtime exit still falls back to the lifecycle reaper.
+func DeriveActivityState(event string, _ []byte) (domain.ActivityState, bool) {
+	switch event {
+	case "session-start":
+		return domain.ActivityActive, true
+	case "user-prompt-submit":
+		return domain.ActivityActive, true
+	case "stop":
+		return domain.ActivityIdle, true
+	case "permission-request":
+		return domain.ActivityWaitingInput, true
+	default:
+		return "", false
+	}
+}

--- a/backend/internal/adapters/agent/kilocode/assets/ao-activity.ts
+++ b/backend/internal/adapters/agent/kilocode/assets/ao-activity.ts
@@ -1,0 +1,203 @@
+// agent-orchestrator: managed kilocode activity plugin (do not edit)
+//
+// The Kilo Code CLI (binary "kilocode") is a fork of sst/opencode and loads the
+// @opencode-ai/plugin runtime, so this plugin uses the same lifecycle surface.
+// It maps Kilo's native lifecycle events onto AO's normalized activity events:
+//   session.created                        -> `ao hooks kilocode session-start`
+//   message.updated / message.part.updated  -> `ao hooks kilocode user-prompt-submit`
+//   permission.ask hook                     -> `ao hooks kilocode permission-request`
+//   session.status (status.type == idle)    -> `ao hooks kilocode stop`
+//
+// The native session id (and prompt/model where known) is piped to the hook
+// command as JSON on stdin, run with cwd set to the worktree so AO can correlate
+// the Kilo session to its AO session. Every invocation is best-effort and must
+// never crash the user's Kilo session: a missing `ao` binary is a guarded no-op
+// (`command -v ao`), and spawn exceptions, non-zero exit codes, and malformed
+// event payloads are caught and surfaced through Kilo's structured logger
+// (client.app.log) for diagnosis — never rethrown.
+//
+// `import type` is erased at runtime by Bun's transpiler, so this loads even
+// before Kilo has installed @opencode-ai/plugin into the config dir.
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const aoActivity: Plugin = async ({ directory, client }) => {
+  // ao hooks must never be able to hang Kilo: cap each invocation, matching
+  // the 30s timeout the claude-code and codex hook entries use.
+  const HOOK_TIMEOUT_MS = 30_000
+  // A user message is reported at most twice (see reportUserPrompt): an optional
+  // early empty report, then an upgrade carrying the prompt text. Maps a message
+  // id to whether the report we already sent included the prompt text.
+  const promptReports = new Map<string, boolean>()
+  // message.* events don't carry the session id, so track it from events that do.
+  let currentSessionID: string | null = null
+  // The model of the most recent assistant message, forwarded for context.
+  let currentModel: string | null = null
+  const messageStore = new Map<string, any>()
+  // Bound messageStore so it can't grow unbounded within a session: `kilo run`
+  // flows that never deliver a text message.part.updated leave the user message
+  // entry undeleted, so without a cap the map would accumulate across many turns.
+  // Map preserves insertion order, so the first key is the oldest entry.
+  const MESSAGE_STORE_MAX = 256
+  function rememberMessage(id: string, msg: any) {
+    messageStore.set(id, msg)
+    while (messageStore.size > MESSAGE_STORE_MAX) {
+      const oldest = messageStore.keys().next().value
+      if (oldest === undefined) break
+      messageStore.delete(oldest)
+    }
+  }
+
+  // Wrap in `sh -c` with a guard so a missing `ao` binary is a silent no-op
+  // (exit 0) rather than a per-event error in the user's session.
+  function hookCmd(hookName: string): string[] {
+    return ["sh", "-c", `if ! command -v ao >/dev/null 2>&1; then exit 0; fi; exec ao hooks kilocode ${hookName}`]
+  }
+
+  // Report a hook failure through Kilo's structured logger. Best-effort: the
+  // log call must itself never throw or reject back into Kilo, hence the
+  // optional chaining + swallowed rejection.
+  function logHookFailure(hookName: string, detail: string) {
+    try {
+      void client?.app
+        ?.log?.({ body: { service: "ao-activity", level: "error", message: `hook ${hookName} failed: ${detail}` } })
+        ?.catch?.(() => {})
+    } catch {
+      // The logger itself is unavailable — nothing more we can safely do.
+    }
+  }
+
+  // All hooks are dispatched synchronously (Bun.spawnSync), for two reasons:
+  //   1. Ordering. An async hook yields the event loop; if Kilo does not await
+  //      the handler's promise, a later event (e.g. message.updated ->
+  //      user-prompt-submit) could complete before an in-flight async
+  //      session-start, so AO would see the prompt before the session is
+  //      registered. spawnSync blocks Kilo's single-threaded loop until the hook
+  //      returns, so events are reported strictly in dispatch order.
+  //   2. `kilo run` exits on the idle event, so an async stop hook would be
+  //      killed before completing.
+  //
+  // A non-zero exit (the guard makes a missing `ao` exit 0, so this is a real
+  // `ao hooks` failure) or a spawn exception is logged with its stderr and never
+  // rethrown, so reporting failures are diagnosable without crashing Kilo.
+  function callHookSync(hookName: string, payload: Record<string, unknown>) {
+    try {
+      const result = Bun.spawnSync(hookCmd(hookName), {
+        cwd: directory,
+        stdin: new TextEncoder().encode(JSON.stringify(payload) + "\n"),
+        stdout: "ignore",
+        stderr: "pipe",
+        timeout: HOOK_TIMEOUT_MS,
+      })
+      if (!result.success) {
+        const stderr = result.stderr ? new TextDecoder().decode(result.stderr).trim() : ""
+        logHookFailure(hookName, `exited ${result.exitCode}${stderr ? `: ${stderr}` : ""}`)
+      }
+    } catch (err) {
+      // The spawn itself failed (e.g. no `sh` on PATH). Never propagate.
+      logHookFailure(hookName, err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  function switchedSession(sessionID: string): boolean {
+    if (currentSessionID === sessionID) return false
+    promptReports.clear()
+    messageStore.clear()
+    currentModel = null
+    currentSessionID = sessionID
+    return true
+  }
+
+  // Report a user prompt, preferring the one that carries the prompt text.
+  // message.updated can arrive before message.part.updated with no text, so an
+  // early empty report must NOT dedup away the later text report — otherwise the
+  // prompt never reaches AO and title-from-prompt metadata breaks. Therefore: an
+  // empty report fires at most once (so run-mode flows that omit the text part
+  // still mark the session active), and a text report fires once and is terminal.
+  function reportUserPrompt(sessionID: string, messageID: string, prompt: string) {
+    const hasText = prompt.length > 0
+    const reportedWithText = promptReports.get(messageID)
+    if (reportedWithText) return // already reported with text — terminal
+    if (reportedWithText === false && !hasText) return // already reported empty; no new info
+    promptReports.set(messageID, hasText)
+    callHookSync("user-prompt-submit", { session_id: sessionID, prompt, model: currentModel ?? "" })
+  }
+
+  return {
+    // permission.ask fires when Kilo needs the user to approve a tool call. AO
+    // maps it to a sticky waiting_input state. The plugin only observes the
+    // request (it does not alter `output.status`), so Kilo's own approval flow
+    // is untouched.
+    "permission.ask": async (input: any) => {
+      try {
+        const sessionID = input?.sessionID ?? input?.sessionId ?? currentSessionID
+        if (!sessionID) return
+        callHookSync("permission-request", { session_id: sessionID, model: currentModel ?? "" })
+      } catch (err) {
+        logHookFailure("permission-request", err instanceof Error ? err.message : String(err))
+      }
+    },
+
+    event: async ({ event }) => {
+      try {
+        switch (event.type) {
+          case "session.created": {
+            const session = (event as any).properties?.info
+            if (!session?.id) break
+            if (switchedSession(session.id)) {
+              callHookSync("session-start", { session_id: session.id })
+            }
+            break
+          }
+
+          case "message.updated": {
+            const msg = (event as any).properties?.info
+            if (!msg) break
+            if (msg.sessionID && switchedSession(msg.sessionID)) {
+              callHookSync("session-start", { session_id: msg.sessionID })
+            }
+            if (msg.role === "assistant" && msg.modelID) currentModel = msg.modelID
+            // Fallback: some `kilo run` flows never deliver message.part.updated
+            // for the prompt, so start the turn from the user message itself.
+            if (msg.role === "user") {
+              rememberMessage(msg.id, msg)
+              const sessionID = msg.sessionID ?? currentSessionID
+              if (sessionID) reportUserPrompt(sessionID, msg.id, "")
+            }
+            break
+          }
+
+          case "message.part.updated": {
+            const part = (event as any).properties?.part
+            if (!part?.messageID) break
+            const msg = messageStore.get(part.messageID)
+            if (msg?.role === "user" && part.type === "text") {
+              const sessionID = msg.sessionID ?? currentSessionID
+              const prompt = part.text ?? ""
+              if (sessionID) reportUserPrompt(sessionID, msg.id, prompt)
+              if (prompt.length > 0) messageStore.delete(part.messageID)
+            }
+            break
+          }
+
+          case "session.status": {
+            // session.status fires in both TUI and `kilo run`; session.idle is
+            // deprecated and not reliably emitted in run mode.
+            // AO's "stop" hook means "the current turn is idle/finished", not
+            // "the whole native session has terminated", so multi-turn TUI
+            // sessions intentionally emit one stop per idle transition.
+            const props = (event as any).properties
+            if (props?.status?.type !== "idle") break
+            const sessionID = props?.sessionID ?? currentSessionID
+            if (!sessionID) break
+            callHookSync("stop", { session_id: sessionID, model: currentModel ?? "" })
+            break
+          }
+        }
+      } catch (err) {
+        // A malformed/unexpected event payload must never crash Kilo; log it
+        // (tagged with the event type) for diagnosis and move on.
+        logHookFailure(`event:${(event as any)?.type ?? "unknown"}`, err instanceof Error ? err.message : String(err))
+      }
+    },
+  }
+}

--- a/backend/internal/adapters/agent/kilocode/hooks.go
+++ b/backend/internal/adapters/agent/kilocode/hooks.go
@@ -1,0 +1,186 @@
+package kilocode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	_ "embed"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const (
+	// Kilo Code scans each config dir for `{plugin,plugins}/*.{ts,js}` (verified
+	// in the @kilocode/cli binary). Its config-dir suffixes are `.kilo`,
+	// `.kilocode`, and `.opencode` (it is an opencode fork). AO writes the
+	// branded `.kilocode/plugins/` so the AO plugin lands in Kilo's own dir and
+	// never collides with a sibling opencode adapter's `.opencode/` install.
+	kilocodePluginDirName = ".kilocode"
+	kilocodePluginSubDir  = "plugins"
+
+	// kilocodePluginFileName is the AO-owned plugin file. AO fully owns this
+	// filename: install overwrites it and uninstall deletes it (guarded by the
+	// sentinel), so user-authored plugins in other files are never touched.
+	// It is TypeScript (Kilo runs on Bun); the file's only import is a type-only
+	// import, which Bun erases at runtime.
+	kilocodePluginFileName = "ao-activity.ts"
+
+	// kilocodePluginSentinel marks the file as AO-managed. AreHooksInstalled and
+	// UninstallHooks key off it so AO never deletes a user file that happens to
+	// share the name. It must appear verbatim in the embedded plugin source.
+	kilocodePluginSentinel = "agent-orchestrator: managed kilocode activity plugin"
+
+	// kilocodeHookCommandPrefix identifies the hook commands AO owns. The
+	// embedded plugin shells `ao hooks kilocode <event>`; this prefix is the
+	// shared contract with the `ao hooks` CLI dispatcher and is asserted by tests
+	// so the plugin can't silently drift away from it.
+	kilocodeHookCommandPrefix = "ao hooks kilocode "
+)
+
+// kilocodePluginSource is the AO-managed Kilo Code plugin, embedded so it ships
+// inside the binary and is written verbatim into a session's worktree on hook
+// install. It is a real, lintable source file under assets/ rather than a Go
+// string literal because it is plugin source code, not a data structure AO
+// assembles (the way it builds Codex/Claude hook JSON).
+//
+//go:embed assets/ao-activity.ts
+var kilocodePluginSource string
+
+// kilocodeManagedEvents are the normalized activity events the embedded plugin
+// reports. They are defined here (not parsed from the file) so tests can assert
+// the plugin wires every one via the `ao hooks kilocode <event>` command, and
+// they mirror exactly the events kilocode.DeriveActivityState switches on.
+var kilocodeManagedEvents = []string{"session-start", "user-prompt-submit", "permission-request", "stop"}
+
+// GetAgentHooks installs AO's Kilo Code activity plugin into the worktree-local
+// .kilocode/plugins/ directory. Unlike Claude Code and Codex, Kilo Code has no
+// native command-hook config to merge into; its only lifecycle-extensibility
+// surface is a JS/TS plugin. AO therefore writes a dedicated, AO-owned plugin
+// file. The write is atomic and idempotent: re-installing overwrites AO's own
+// file with identical content. It refuses to overwrite a file that is NOT
+// AO-managed (no sentinel), so a user plugin that happens to occupy our path is
+// never silently destroyed — install fails loudly instead.
+func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(cfg.WorkspacePath) == "" {
+		return errors.New("kilocode.GetAgentHooks: WorkspacePath is required")
+	}
+
+	pluginPath := kilocodePluginPath(cfg.WorkspacePath)
+	// Guard against clobbering a user file at our path: overwrite only when the
+	// target is absent or already AO-managed. A foreign file is a loud error,
+	// not silent data loss (uninstall is sentinel-guarded the same way).
+	if _, err := os.Stat(pluginPath); err == nil {
+		managed, err := isAOManagedPlugin(pluginPath)
+		if err != nil {
+			return fmt.Errorf("kilocode.GetAgentHooks: %w", err)
+		}
+		if !managed {
+			return fmt.Errorf("kilocode.GetAgentHooks: refusing to overwrite non-AO file at %s — move it so AO can install its plugin", pluginPath)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("kilocode.GetAgentHooks: stat plugin: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(pluginPath), 0o750); err != nil {
+		return fmt.Errorf("kilocode.GetAgentHooks: create plugin dir: %w", err)
+	}
+	if err := atomicWriteFile(pluginPath, []byte(kilocodePluginSource), 0o600); err != nil {
+		return fmt.Errorf("kilocode.GetAgentHooks: write plugin: %w", err)
+	}
+	return nil
+}
+
+// UninstallHooks removes AO's Kilo Code plugin from the workspace-local
+// .kilocode/plugins/ directory. It deletes the file only when it carries the AO
+// sentinel, so a user file that happens to share the name is left in place. A
+// missing file is a no-op.
+func (p *Plugin) UninstallHooks(ctx context.Context, workspacePath string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(workspacePath) == "" {
+		return errors.New("kilocode.UninstallHooks: workspacePath is required")
+	}
+
+	pluginPath := kilocodePluginPath(workspacePath)
+	managed, err := isAOManagedPlugin(pluginPath)
+	if err != nil {
+		return fmt.Errorf("kilocode.UninstallHooks: %w", err)
+	}
+	if !managed {
+		return nil
+	}
+	if err := os.Remove(pluginPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("kilocode.UninstallHooks: remove plugin: %w", err)
+	}
+	return nil
+}
+
+// AreHooksInstalled reports whether AO's Kilo Code plugin is present in the
+// workspace-local plugin dir. A missing file, or a same-named file without the
+// AO sentinel, means none are installed.
+func (p *Plugin) AreHooksInstalled(ctx context.Context, workspacePath string) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(workspacePath) == "" {
+		return false, errors.New("kilocode.AreHooksInstalled: workspacePath is required")
+	}
+	managed, err := isAOManagedPlugin(kilocodePluginPath(workspacePath))
+	if err != nil {
+		return false, fmt.Errorf("kilocode.AreHooksInstalled: %w", err)
+	}
+	return managed, nil
+}
+
+func kilocodePluginPath(workspacePath string) string {
+	return filepath.Join(workspacePath, kilocodePluginDirName, kilocodePluginSubDir, kilocodePluginFileName)
+}
+
+// isAOManagedPlugin reports whether the file at path exists and carries the AO
+// sentinel. A missing file yields (false, nil).
+func isAOManagedPlugin(path string) (bool, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path built from caller-owned workspace dir
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+	return strings.Contains(string(data), kilocodePluginSentinel), nil
+}
+
+// atomicWriteFile writes data to path via a temp file + rename, so a crash mid-
+// write can't leave a truncated plugin file that Kilo then fails to import
+// (silently disabling activity reporting).
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".ao-tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op once renamed
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/backend/internal/adapters/agent/kilocode/kilocode.go
+++ b/backend/internal/adapters/agent/kilocode/kilocode.go
@@ -1,0 +1,315 @@
+// Package kilocode implements the Kilo Code CLI agent adapter: launching new
+// TUI sessions, resuming sessions by native id, installing a workspace-local
+// activity plugin, and reading plugin-derived session info.
+//
+// The Kilo Code CLI (binary "kilocode", also aliased "kilo"; npm package
+// @kilocode/cli) is a fork of sst/opencode and shares its CLI surface and
+// plugin runtime, so AO bridges it the same two ways it bridges opencode:
+//   - It has no native command-hook config (no settings.local.json / hooks.json
+//     equivalent). Its only lifecycle-extensibility surface is the @opencode-ai
+//     plugin SDK loaded from a config dir's `{plugin,plugins}/*.{ts,js}` glob,
+//     so GetAgentHooks installs an AO-owned plugin file (see hooks.go) into
+//     .kilocode/plugins/ instead of merging JSON.
+//   - Its interactive TUI exposes no permission flag (the --auto flag lives only
+//     on `kilo run`, not the default TUI command AO launches) and no
+//     system-prompt flag. AO's graduated permission modes are delivered via the
+//     KILO_CONFIG_CONTENT env var, which Kilo deep-merges as the
+//     highest-precedence inline config; the system prompt defers to Kilo's own
+//     config.
+//
+// AO-managed sessions derive native session identity and display metadata from
+// the Kilo plugin's reported events, mirroring the opencode and Codex adapters.
+package kilocode
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const (
+	// adapterID is the registry id and the value users pass to
+	// `ao spawn --agent`. It matches domain.HarnessKilocode.
+	adapterID = "kilocode"
+
+	// Normalized session-metadata keys the Kilo plugin persists into the AO
+	// session store and SessionInfo reads back. Shared vocabulary with the Codex
+	// and opencode adapters so the dashboard treats every agent uniformly. The
+	// agent-session-id key is the shared ports.MetadataKeyAgentSessionID.
+	kilocodeTitleMetadataKey   = "title"
+	kilocodeSummaryMetadataKey = "summary"
+)
+
+// Plugin is the Kilo Code agent adapter. It is safe for concurrent use; the
+// binary path is resolved once and cached under binaryMu.
+type Plugin struct {
+	binaryMu       sync.Mutex
+	resolvedBinary string
+}
+
+// New returns a ready-to-register Kilo Code adapter.
+func New() *Plugin {
+	return &Plugin{}
+}
+
+var _ adapters.Adapter = (*Plugin)(nil)
+var _ ports.Agent = (*Plugin)(nil)
+
+// Manifest returns the adapter's static self-description.
+func (p *Plugin) Manifest() adapters.Manifest {
+	return adapters.Manifest{
+		ID:          adapterID,
+		Name:        "Kilo Code",
+		Description: "Run Kilo Code worker sessions.",
+		Version:     "0.0.1",
+		Capabilities: []adapters.Capability{
+			adapters.CapabilityAgent,
+		},
+	}
+}
+
+// GetConfigSpec reports the agent-specific config keys. Kilo Code exposes none
+// yet: model and agent selection are read from Kilo's own config
+// (kilo.json / ~/.config/kilo), exactly as a normal launch.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{}, nil
+}
+
+// GetLaunchCommand builds the argv to start a new interactive Kilo Code session.
+// Shape:
+//
+//	[env KILO_CONFIG_CONTENT=<json>] kilocode [--prompt <prompt>]
+//
+// The session runs in the worktree (cwd is set by the runtime, as for opencode
+// and Codex). Kilo Code has no CLI flag to set a system prompt, so
+// cfg.SystemPrompt / SystemPromptFile are intentionally ignored here — Kilo
+// resolves instructions from its own config and AGENTS.md rules. The initial
+// task prompt is delivered via --prompt (its argument, so a leading "-" is not
+// read as a flag). Non-default permission modes prepend a KILO_CONFIG_CONTENT
+// env assignment rather than a flag (see kilocodePermissionEnvPrefix).
+func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
+	binary, err := p.kilocodeBinary(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd = append(kilocodePermissionEnvPrefix(cfg.Permissions), binary)
+	if cfg.Prompt != "" {
+		cmd = append(cmd, "--prompt", cfg.Prompt)
+	}
+	return cmd, nil
+}
+
+// GetPromptDeliveryStrategy reports that Kilo Code receives its prompt in the
+// launch command itself (via --prompt).
+func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, cfg ports.LaunchConfig) (ports.PromptDeliveryStrategy, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return ports.PromptDeliveryInCommand, nil
+}
+
+// GetRestoreCommand rebuilds the argv that continues an existing Kilo Code
+// session: `[env KILO_CONFIG_CONTENT=<json>] kilocode --session <agentSessionId>`.
+// It re-applies the permission env (resume otherwise reverts to the configured
+// default) but not the prompt, which the session already carries. ok is false
+// when the plugin-derived native session id has not landed yet, so callers fall
+// back to fresh launch behavior — mirroring the opencode adapter.
+func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	agentSessionID := strings.TrimSpace(cfg.Session.Metadata[ports.MetadataKeyAgentSessionID])
+	if agentSessionID == "" {
+		return nil, false, nil
+	}
+
+	binary, err := p.kilocodeBinary(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	cmd = append(kilocodePermissionEnvPrefix(cfg.Permissions), binary, "--session", agentSessionID)
+	return cmd, true, nil
+}
+
+// SessionInfo surfaces Kilo plugin-derived metadata. Metadata is intentionally
+// nil for Kilo Code: callers get the normalized fields directly, matching the
+// opencode and Codex adapters.
+func (p *Plugin) SessionInfo(ctx context.Context, session ports.SessionRef) (ports.SessionInfo, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.SessionInfo{}, false, err
+	}
+	info := ports.SessionInfo{
+		AgentSessionID: session.Metadata[ports.MetadataKeyAgentSessionID],
+		Title:          session.Metadata[kilocodeTitleMetadataKey],
+		Summary:        session.Metadata[kilocodeSummaryMetadataKey],
+	}
+	if info.AgentSessionID == "" && info.Title == "" && info.Summary == "" {
+		return ports.SessionInfo{}, false, nil
+	}
+	return info, true, nil
+}
+
+// kilocodePermissionEnvVar is the env var Kilo deep-merges as the
+// highest-precedence inline config (`KILO_CONFIG_CONTENT`, see the CLI's config
+// precedence: global -> KILO_CONFIG -> ./kilo.json -> .kilo/kilo.json ->
+// KILO_CONFIG_CONTENT -> managed; later wins). It is the permission-control
+// surface the interactive TUI honors: the --auto flag exists solely on
+// `kilo run`, not on the default TUI command AO launches, so passing any
+// permission flag would make Kilo reject the argv and the session fail to launch.
+const kilocodePermissionEnvVar = "KILO_CONFIG_CONTENT"
+
+// kilocodePermissionConfig maps an AO permission mode onto Kilo's permission
+// config (tool -> action, values "ask"/"allow"/"deny", verified via
+// `kilocode config check`). Tools left unset fall back to Kilo's own default
+// action ("ask"), so each mode only names the tools it relaxes:
+//   - default            → nil: no env; Kilo's config decides every prompt.
+//   - accept-edits       → edits ("write"/"edit"/"patch" gate on the "edit"
+//     key) auto-approved; bash and everything else still prompt.
+//   - auto               → edits + bash auto-approved; network/other still prompt.
+//     Kilo has no classifier/reviewer gate (unlike Claude Code's "auto"), so
+//     this is the closest analog its flat allow/ask/deny config can express.
+//   - bypass-permissions → "*" wildcard-allows every tool: nothing prompts.
+func kilocodePermissionConfig(mode ports.PermissionMode) map[string]string {
+	switch normalizePermissionMode(mode) {
+	case ports.PermissionModeAcceptEdits:
+		return map[string]string{"edit": "allow"}
+	case ports.PermissionModeAuto:
+		return map[string]string{"edit": "allow", "bash": "allow"}
+	case ports.PermissionModeBypassPermissions:
+		return map[string]string{"*": "allow"}
+	default:
+		return nil
+	}
+}
+
+// kilocodePermissionEnvPrefix renders mode's permission config as an
+// `env KILO_CONFIG_CONTENT=<json>` argv prefix, or nil for the default mode.
+//
+// The var must reach Kilo as a process env var, not an argv flag. The runtime
+// runs the argv through a shell, which execs `env`, which sets the var and execs
+// kilocode. A bare `KILO_CONFIG_CONTENT=...` argv element would not work: the
+// runtime shell-quotes every element, and a quoted token is run as a command
+// rather than read as an assignment — hence the explicit `env` wrapper.
+// POSIX-only, which matches the zellij runtime.
+func kilocodePermissionEnvPrefix(mode ports.PermissionMode) []string {
+	config := kilocodePermissionConfig(mode)
+	if len(config) == 0 {
+		return nil
+	}
+	// The inline config is the JSON object {"permission": {<tool>: <action>}}.
+	// Marshaling a map[string]string never errors and emits keys in sorted order,
+	// so the prefix is deterministic for tests and reproducible across launches.
+	blob, _ := json.Marshal(map[string]map[string]string{"permission": config})
+	return []string{"env", kilocodePermissionEnvVar + "=" + string(blob)}
+}
+
+func normalizePermissionMode(mode ports.PermissionMode) ports.PermissionMode {
+	switch mode {
+	case ports.PermissionModeDefault,
+		ports.PermissionModeAcceptEdits,
+		ports.PermissionModeAuto,
+		ports.PermissionModeBypassPermissions:
+		return mode
+	default:
+		// Empty or unrecognized: defer to Kilo's own config (no flag).
+		return ports.PermissionModeDefault
+	}
+}
+
+// ResolveKilocodeBinary returns the path to the kilocode binary on this machine,
+// searching PATH then a handful of well-known install locations (npm global
+// bin, Homebrew). Returns "kilocode" as a last-ditch fallback so callers see a
+// clear "command not found" rather than an empty argv.
+func ResolveKilocodeBinary(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	if runtime.GOOS == "windows" {
+		for _, name := range []string{"kilocode.cmd", "kilocode.exe", "kilocode"} {
+			if path, err := exec.LookPath(name); err == nil && path != "" {
+				return path, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+		}
+		candidates := []string{}
+		if appData := os.Getenv("APPDATA"); appData != "" {
+			candidates = append(candidates,
+				filepath.Join(appData, "npm", "kilocode.cmd"),
+				filepath.Join(appData, "npm", "kilocode.exe"),
+			)
+		}
+		for _, candidate := range candidates {
+			if fileExists(candidate) {
+				return candidate, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+		}
+		return "kilocode", nil
+	}
+
+	if path, err := exec.LookPath("kilocode"); err == nil && path != "" {
+		return path, nil
+	}
+
+	candidates := []string{
+		"/usr/local/bin/kilocode",
+		"/opt/homebrew/bin/kilocode",
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates,
+			filepath.Join(home, ".npm-global", "bin", "kilocode"),
+			filepath.Join(home, ".npm", "bin", "kilocode"),
+			filepath.Join(home, ".local", "bin", "kilocode"),
+		)
+	}
+
+	for _, candidate := range candidates {
+		if fileExists(candidate) {
+			return candidate, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+	}
+
+	return "kilocode", nil
+}
+
+func (p *Plugin) kilocodeBinary(ctx context.Context) (string, error) {
+	p.binaryMu.Lock()
+	defer p.binaryMu.Unlock()
+
+	if p.resolvedBinary != "" {
+		return p.resolvedBinary, nil
+	}
+
+	binary, err := ResolveKilocodeBinary(ctx)
+	if err != nil {
+		return "", err
+	}
+	p.resolvedBinary = binary
+	return binary, nil
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/backend/internal/adapters/agent/kilocode/kilocode_test.go
+++ b/backend/internal/adapters/agent/kilocode/kilocode_test.go
@@ -1,0 +1,449 @@
+package kilocode
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestManifestIDIsKilocode(t *testing.T) {
+	m := New().Manifest()
+	if m.ID != "kilocode" {
+		t.Fatalf("Manifest ID = %q, want kilocode", m.ID)
+	}
+	if m.Name != "Kilo Code" {
+		t.Fatalf("Manifest Name = %q, want Kilo Code", m.Name)
+	}
+}
+
+func TestGetLaunchCommandBuildsArgv(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kilocode"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Permissions:      ports.PermissionModeBypassPermissions,
+		Prompt:           "-fix this",
+		SystemPromptFile: filepath.Join("tmp", "prompt with spaces.md"),
+		SystemPrompt:     "ignored",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Kilo has no system-prompt flag, so SystemPrompt/SystemPromptFile are
+	// dropped; the prompt is delivered via --prompt. bypass-permissions prepends
+	// an `env KILO_CONFIG_CONTENT=...` assignment (the TUI has no permission flag).
+	want := []string{
+		"env", `KILO_CONFIG_CONTENT={"permission":{"*":"allow"}}`,
+		"kilocode",
+		"--prompt", "-fix this",
+	}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetLaunchCommandMapsPermissionModes(t *testing.T) {
+	tests := []struct {
+		name       string
+		permission ports.PermissionMode
+		// wantEnv is the expected KILO_CONFIG_CONTENT value, or "" when the mode
+		// emits no env prefix at all (defers entirely to Kilo's own config).
+		wantEnv string
+	}{
+		{name: "default", permission: ports.PermissionModeDefault, wantEnv: ""},
+		{name: "accept-edits", permission: ports.PermissionModeAcceptEdits, wantEnv: `{"permission":{"edit":"allow"}}`},
+		{name: "auto", permission: ports.PermissionModeAuto, wantEnv: `{"permission":{"bash":"allow","edit":"allow"}}`},
+		{name: "bypass-permissions", permission: ports.PermissionModeBypassPermissions, wantEnv: `{"permission":{"*":"allow"}}`},
+		{name: "empty", permission: "", wantEnv: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &Plugin{resolvedBinary: "kilocode"}
+			cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{Permissions: tt.permission})
+			if err != nil {
+				t.Fatal(err)
+			}
+			// A permission FLAG must never leak onto the interactive TUI launch;
+			// those exist only on `kilo run` (--auto).
+			if contains(cmd, "--auto") {
+				t.Fatalf("command %#v contains run-only --auto", cmd)
+			}
+			if tt.wantEnv == "" {
+				if len(cmd) == 0 || cmd[0] == "env" {
+					t.Fatalf("command %#v should have no env prefix", cmd)
+				}
+				return
+			}
+			// Non-default modes prepend `env KILO_CONFIG_CONTENT=<json>`.
+			want := "KILO_CONFIG_CONTENT=" + tt.wantEnv
+			if len(cmd) < 3 || cmd[0] != "env" || cmd[1] != want || cmd[2] != "kilocode" {
+				t.Fatalf("command %#v must be prefixed with `env %s`", cmd, want)
+			}
+		})
+	}
+}
+
+func TestGetPromptDeliveryStrategyIsInCommand(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kilocode"}
+
+	got, err := plugin.GetPromptDeliveryStrategy(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != ports.PromptDeliveryInCommand {
+		t.Fatalf("unexpected strategy: %q", got)
+	}
+}
+
+func TestGetConfigSpecHasNoCustomFieldsYet(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kilocode"}
+
+	spec, err := plugin.GetConfigSpec(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(spec.Fields) != 0 {
+		t.Fatalf("unexpected config fields: %#v", spec.Fields)
+	}
+}
+
+func TestGetAgentHooksInstallsPlugin(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kilocode"}
+	workspace := t.TempDir()
+
+	// A user's own plugin in the same dir must survive AO's install untouched.
+	pluginDir := filepath.Dir(kilocodePluginPath(workspace))
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	userPlugin := filepath.Join(pluginDir, "user.js")
+	userBody := []byte("export const userPlugin = async () => ({})\n")
+	if err := os.WriteFile(userPlugin, userBody, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	cfg := ports.WorkspaceHookConfig{DataDir: t.TempDir(), SessionID: "sess-1", WorkspacePath: workspace}
+	if err := plugin.GetAgentHooks(ctx, cfg); err != nil {
+		t.Fatal(err)
+	}
+	// A second install must be idempotent (overwrite with identical content).
+	if err := plugin.GetAgentHooks(ctx, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if installed, err := plugin.AreHooksInstalled(ctx, workspace); err != nil || !installed {
+		t.Fatalf("AreHooksInstalled after install = (%v, %v), want (true, nil)", installed, err)
+	}
+
+	data, err := os.ReadFile(kilocodePluginPath(workspace))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(data)
+	if !strings.Contains(body, kilocodePluginSentinel) {
+		t.Fatalf("installed plugin missing AO sentinel:\n%s", body)
+	}
+	// Every normalized activity event must be wired via `ao hooks kilocode <event>`.
+	for _, event := range kilocodeManagedEvents {
+		want := kilocodeHookCommandPrefix + event
+		if !strings.Contains(body, want) {
+			t.Fatalf("installed plugin missing hook command %q:\n%s", want, body)
+		}
+	}
+	// The Kilo-native lifecycle surfaces the plugin subscribes to. Stop maps to
+	// session.status(idle) — NOT the deprecated session.idle — the user prompt is
+	// detected from message.updated/message.part.updated, and permission requests
+	// from the permission.ask hook.
+	for _, marker := range []string{"session.created", "message.updated", "message.part.updated", "session.status", "permission.ask"} {
+		if !strings.Contains(body, marker) {
+			t.Fatalf("installed plugin missing Kilo event %q:\n%s", marker, body)
+		}
+	}
+	// Guard against regressing back to subscribing to the deprecated/unreliable
+	// session.idle event (the quoted event string is how a `case` would name it;
+	// the explanatory comment mentions it unquoted, which is fine).
+	if strings.Contains(body, `"session.idle"`) {
+		t.Fatalf("plugin subscribes to deprecated session.idle; use session.status(idle):\n%s", body)
+	}
+	// A hung `ao hooks` call must not block Kilo forever, so each spawn is
+	// time-boxed (parity with the claude/codex 30s hook timeout).
+	if !strings.Contains(body, "timeout:") {
+		t.Fatalf("plugin spawn has no timeout; a hung hook would block Kilo:\n%s", body)
+	}
+
+	// The user's plugin is untouched.
+	got, err := os.ReadFile(userPlugin)
+	if err != nil {
+		t.Fatalf("user plugin removed by install: %v", err)
+	}
+	if !reflect.DeepEqual(got, userBody) {
+		t.Fatalf("user plugin modified by install: %q", got)
+	}
+}
+
+func TestGetAgentHooksRefusesToClobberForeignFile(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kilocode"}
+	workspace := t.TempDir()
+	ctx := context.Background()
+
+	// A non-AO file occupying AO's exact path must NOT be silently overwritten.
+	pluginPath := kilocodePluginPath(workspace)
+	if err := os.MkdirAll(filepath.Dir(pluginPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	foreign := []byte("export const notOurs = async () => ({})\n")
+	if err := os.WriteFile(pluginPath, foreign, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := plugin.GetAgentHooks(ctx, ports.WorkspaceHookConfig{WorkspacePath: workspace})
+	if err == nil {
+		t.Fatal("GetAgentHooks overwrote a non-AO file; want a loud error")
+	}
+	got, readErr := os.ReadFile(pluginPath)
+	if readErr != nil {
+		t.Fatalf("foreign file removed by refused install: %v", readErr)
+	}
+	if !reflect.DeepEqual(got, foreign) {
+		t.Fatalf("foreign file modified by refused install: %q", got)
+	}
+}
+
+func TestUninstallHooksRemovesPlugin(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kilocode"}
+	workspace := t.TempDir()
+	ctx := context.Background()
+	cfg := ports.WorkspaceHookConfig{DataDir: t.TempDir(), SessionID: "sess-1", WorkspacePath: workspace}
+
+	// Pre-seed a user's own plugin; it must survive uninstall.
+	pluginDir := filepath.Dir(kilocodePluginPath(workspace))
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	userPlugin := filepath.Join(pluginDir, "user.js")
+	if err := os.WriteFile(userPlugin, []byte("export const userPlugin = async () => ({})\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := plugin.GetAgentHooks(ctx, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if installed, err := plugin.AreHooksInstalled(ctx, workspace); err != nil || !installed {
+		t.Fatalf("AreHooksInstalled after install = (%v, %v), want (true, nil)", installed, err)
+	}
+
+	if err := plugin.UninstallHooks(ctx, workspace); err != nil {
+		t.Fatal(err)
+	}
+	if installed, err := plugin.AreHooksInstalled(ctx, workspace); err != nil || installed {
+		t.Fatalf("AreHooksInstalled after uninstall = (%v, %v), want (false, nil)", installed, err)
+	}
+	if _, err := os.Stat(kilocodePluginPath(workspace)); !os.IsNotExist(err) {
+		t.Fatalf("AO plugin still present after uninstall: err=%v", err)
+	}
+	if _, err := os.Stat(userPlugin); err != nil {
+		t.Fatalf("user plugin removed by uninstall: %v", err)
+	}
+}
+
+func TestUninstallHooksLeavesForeignFile(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kilocode"}
+	workspace := t.TempDir()
+	ctx := context.Background()
+
+	// A non-AO file occupying AO's filename must NOT be deleted by uninstall.
+	pluginPath := kilocodePluginPath(workspace)
+	if err := os.MkdirAll(filepath.Dir(pluginPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	foreign := []byte("export const notOurs = async () => ({})\n")
+	if err := os.WriteFile(pluginPath, foreign, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if installed, err := plugin.AreHooksInstalled(ctx, workspace); err != nil || installed {
+		t.Fatalf("AreHooksInstalled on foreign file = (%v, %v), want (false, nil)", installed, err)
+	}
+	if err := plugin.UninstallHooks(ctx, workspace); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatalf("foreign file removed by uninstall: %v", err)
+	}
+	if !reflect.DeepEqual(got, foreign) {
+		t.Fatalf("foreign file modified by uninstall: %q", got)
+	}
+}
+
+func TestGetRestoreCommandReadsAgentSessionID(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kilocode"}
+
+	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Permissions: ports.PermissionModeBypassPermissions,
+		Session: ports.SessionRef{
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "ses_abc123"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	want := []string{
+		"env", `KILO_CONFIG_CONTENT={"permission":{"*":"allow"}}`,
+		"kilocode",
+		"--session", "ses_abc123",
+	}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("restore cmd\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetRestoreCommandFalseWithoutAgentSessionID(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kilocode"}
+
+	cases := []struct {
+		name string
+		ref  ports.SessionRef
+	}{
+		{"empty session ref", ports.SessionRef{}},
+		{"empty metadata", ports.SessionRef{Metadata: map[string]string{}}},
+		{"blank agent session metadata", ports.SessionRef{Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "   "}}},
+		{"workspace path only", ports.SessionRef{WorkspacePath: "/some/path"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+				Permissions: ports.PermissionModeDefault,
+				Session:     tc.ref,
+			})
+			if err != nil {
+				t.Fatalf("err = %v, want nil", err)
+			}
+			if ok {
+				t.Fatalf("ok = true, want false")
+			}
+			if cmd != nil {
+				t.Fatalf("cmd = %#v, want nil", cmd)
+			}
+		})
+	}
+}
+
+func TestSessionInfoReadsHookMetadata(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kilocode"}
+
+	info, ok, err := plugin.SessionInfo(context.Background(), ports.SessionRef{
+		WorkspacePath: "/some/path",
+		Metadata: map[string]string{
+			ports.MetadataKeyAgentSessionID: "ses_abc123",
+			kilocodeTitleMetadataKey:        "Fix login redirect",
+			kilocodeSummaryMetadataKey:      "Updated the auth callback and tests.",
+			"ignored":                       "not returned",
+		},
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !ok {
+		t.Fatalf("ok = false, want true")
+	}
+	if info.AgentSessionID != "ses_abc123" {
+		t.Fatalf("AgentSessionID = %q, want native id", info.AgentSessionID)
+	}
+	if info.Title != "Fix login redirect" {
+		t.Fatalf("Title = %q, want hook title", info.Title)
+	}
+	if info.Summary != "Updated the auth callback and tests." {
+		t.Fatalf("Summary = %q, want hook summary", info.Summary)
+	}
+	if info.Metadata != nil {
+		t.Fatalf("Metadata = %#v, want nil for kilocode", info.Metadata)
+	}
+}
+
+func TestSessionInfoFalseWhenNoHookMetadata(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "kilocode"}
+
+	info, ok, err := plugin.SessionInfo(context.Background(), ports.SessionRef{
+		WorkspacePath: "/some/path",
+		Metadata:      map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if ok {
+		t.Fatalf("ok = true, want false")
+	}
+	if !reflect.DeepEqual(info, ports.SessionInfo{}) {
+		t.Fatalf("info = %#v, want zero value", info)
+	}
+}
+
+func TestDeriveActivityState(t *testing.T) {
+	cases := []struct {
+		event     string
+		wantState domain.ActivityState
+		wantOK    bool
+	}{
+		{"session-start", domain.ActivityActive, true},
+		{"user-prompt-submit", domain.ActivityActive, true},
+		{"stop", domain.ActivityIdle, true},
+		{"permission-request", domain.ActivityWaitingInput, true},
+		{"unknown", "", false},
+		{"", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.event, func(t *testing.T) {
+			state, ok := DeriveActivityState(tc.event, nil)
+			if state != tc.wantState || ok != tc.wantOK {
+				t.Fatalf("DeriveActivityState(%q) = (%q, %v), want (%q, %v)", tc.event, state, ok, tc.wantState, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// These methods check ctx.Err() before doing any work, so a cancelled
+	// context surfaces as an error. (GetLaunchCommand resolves the binary first,
+	// whose own ctx check is short-circuited by the cached resolvedBinary, so it
+	// is intentionally not asserted here — matching the codex/opencode exemplars.)
+	plugin := &Plugin{resolvedBinary: "kilocode"}
+	if _, err := plugin.GetPromptDeliveryStrategy(ctx, ports.LaunchConfig{}); err == nil {
+		t.Fatal("GetPromptDeliveryStrategy: want ctx error, got nil")
+	}
+	if _, err := plugin.GetConfigSpec(ctx); err == nil {
+		t.Fatal("GetConfigSpec: want ctx error, got nil")
+	}
+	if _, _, err := plugin.GetRestoreCommand(ctx, ports.RestoreConfig{}); err == nil {
+		t.Fatal("GetRestoreCommand: want ctx error, got nil")
+	}
+	if _, _, err := plugin.SessionInfo(ctx, ports.SessionRef{}); err == nil {
+		t.Fatal("SessionInfo: want ctx error, got nil")
+	}
+	if err := plugin.GetAgentHooks(ctx, ports.WorkspaceHookConfig{WorkspacePath: "/tmp"}); err == nil {
+		t.Fatal("GetAgentHooks: want ctx error, got nil")
+	}
+}
+
+func contains(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/adapters/agent/registry/registry.go
+++ b/backend/internal/adapters/agent/registry/registry.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/droid"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/goose"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/grok"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kilocode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kimi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kiro"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/opencode"
@@ -55,6 +56,7 @@ func Constructors() []adapters.Adapter {
 		cline.New(),
 		kimi.New(),
 		kiro.New(),
+		kilocode.New(),
 	}
 }
 

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -109,6 +109,7 @@ func TestWiring_AgentResolverResolvesRealAdapters(t *testing.T) {
 		{domain.HarnessCline, "cline"},
 		{domain.HarnessKimi, "kimi"},
 		{domain.HarnessKiro, "kiro"},
+		{domain.HarnessKilocode, "kilocode"},
 		{"", config.DefaultAgent}, // empty harness falls back to the AO_AGENT default
 	} {
 		agent, ok := resolver.Agent(tc.harness)


### PR DESCRIPTION
Adds the **kilocode** harness, stacked on #119 (agent platform). Adapter package + `Constructors()` registration + resolver test. Includes its own activity deriver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #119
2. #120
3. #121
4. #122
5. #123
6. #124
7. #125
8. #126
9. #127
10. #128
11. #129
12. #130
13. #131
14. #132
15. #133
16. #134
17. #135
18. **#136** 👈 current
19. #137
20. #138
21. #139
<!-- stack:links:end -->