### PR TITLE
feat(agents): add pi adapter

### DIFF
--- a/backend/internal/adapters/agent/pi/pi.go
+++ b/backend/internal/adapters/agent/pi/pi.go
@@ -1,0 +1,243 @@
+// Package pi implements the Pi agent adapter: launching new headless Pi
+// sessions and resuming sessions when a native Pi session id is known.
+//
+// Pi (badlogic / "@earendil-works/pi-coding-agent", binary "pi") is a minimal
+// terminal coding harness. AO drives it non-interactively with `-p` / `--print`
+// ("process prompt and exit"). The initial prompt is delivered in-command as a
+// trailing positional message; Pi's argument parser does not honor a `--`
+// options terminator, so AO relies on prompts not beginning with a literal "-".
+//
+// System prompts are appended to Pi's default coding-assistant prompt via
+// `--append-system-prompt <text>`. Pi's flag takes inline text only (no file
+// variant), so a system-prompt file is read from disk and its contents are
+// inlined into the flag; a read failure aborts the launch.
+//
+// Permissions: Pi has no permission/approval CLI flags ("No permission popups" —
+// confirmation flows are built via TypeScript extensions), so AO emits no
+// permission flag and defers to Pi's own behavior.
+//
+// Restore: Pi persists sessions to ~/.pi/agent/sessions/ and resumes by id with
+// `--session <id>` (partial UUIDs accepted). The native session id is emitted on
+// the first line of `--mode json` output as {"type":"session","id":"<uuid>",...}
+// and is captured into session metadata out-of-band; GetRestoreCommand reads it
+// back from metadata. ok=false when no native id is known (manager falls back to
+// a fresh launch).
+//
+// Hooks/activity: Pi exposes lifecycle hooks only through in-process TypeScript
+// extensions (pi.on("session_start", ...), etc.), not a config file AO can
+// install, and it has no Claude Code hook compatibility. There is therefore no
+// Tier A native hook installer nor a Tier B Claude-compat delegation; hook
+// installation and SessionInfo are intentionally no-ops until a Pi-specific
+// extension exists.
+package pi
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const adapterID = "pi"
+
+// Plugin is the Pi agent adapter. It is safe for concurrent use; the binary
+// path is resolved once and cached under binaryMu.
+type Plugin struct {
+	binaryMu       sync.Mutex
+	resolvedBinary string
+}
+
+// New returns a ready-to-register Pi adapter.
+func New() *Plugin {
+	return &Plugin{}
+}
+
+var _ adapters.Adapter = (*Plugin)(nil)
+var _ ports.Agent = (*Plugin)(nil)
+
+// Manifest returns the adapter's static self-description.
+func (p *Plugin) Manifest() adapters.Manifest {
+	return adapters.Manifest{
+		ID:          adapterID,
+		Name:        "Pi",
+		Description: "Run Pi worker sessions.",
+		Version:     "0.0.1",
+		Capabilities: []adapters.Capability{
+			adapters.CapabilityAgent,
+		},
+	}
+}
+
+// GetConfigSpec reports no agent-specific config keys yet.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{}, nil
+}
+
+// GetLaunchCommand builds the argv to start a new headless Pi session:
+//
+//	pi --print [--append-system-prompt <system prompt>] [<prompt>]
+//
+// The prompt is delivered in-command as a trailing positional message. Pi does
+// not honor a `--` options terminator, so the prompt must not begin with "-".
+// Pi has no permission flags, so none are emitted.
+func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
+	binary, err := p.piBinary(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd = []string{binary, "--print"}
+	if cfg.SystemPromptFile != "" {
+		data, err := os.ReadFile(cfg.SystemPromptFile) //nolint:gosec // path is AO-owned launch config
+		if err != nil {
+			return nil, err
+		}
+		cmd = append(cmd, "--append-system-prompt", string(data))
+	} else if cfg.SystemPrompt != "" {
+		cmd = append(cmd, "--append-system-prompt", cfg.SystemPrompt)
+	}
+	if cfg.Prompt != "" {
+		cmd = append(cmd, cfg.Prompt)
+	}
+	return cmd, nil
+}
+
+// GetPromptDeliveryStrategy reports that Pi receives its prompt in the launch
+// command itself.
+func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, cfg ports.LaunchConfig) (ports.PromptDeliveryStrategy, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return ports.PromptDeliveryInCommand, nil
+}
+
+// GetAgentHooks is intentionally a no-op: Pi's lifecycle hooks are only
+// reachable through in-process TypeScript extensions, not a config file AO can
+// install, and Pi has no Claude Code hook compatibility.
+func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
+	return ctx.Err()
+}
+
+// GetRestoreCommand rebuilds the argv that continues an existing Pi session when
+// a native session id is available in metadata. Pi resumes by id with
+// `--session <id>` (partial UUIDs accepted). Until that id exists, ok is false
+// and callers fall back to fresh launch behavior.
+func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	agentSessionID := strings.TrimSpace(cfg.Session.Metadata[ports.MetadataKeyAgentSessionID])
+	if agentSessionID == "" {
+		return nil, false, nil
+	}
+
+	binary, err := p.piBinary(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	cmd = []string{binary, "--print", "--session", agentSessionID}
+	return cmd, true, nil
+}
+
+// SessionInfo is intentionally a no-op until a Pi-specific extension persists
+// session metadata (title/summary). The native session id, when known, is read
+// directly from metadata by GetRestoreCommand.
+func (p *Plugin) SessionInfo(ctx context.Context, session ports.SessionRef) (ports.SessionInfo, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.SessionInfo{}, false, err
+	}
+	return ports.SessionInfo{}, false, nil
+}
+
+// ResolvePiBinary finds the `pi` binary, searching PATH then common install
+// locations. It returns "pi" as a last resort so callers get the shell's normal
+// command-not-found behavior if Pi is absent.
+func ResolvePiBinary(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	if runtime.GOOS == "windows" {
+		for _, name := range []string{"pi.cmd", "pi.exe", "pi"} {
+			if path, err := exec.LookPath(name); err == nil && path != "" {
+				return path, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+		}
+		candidates := []string{}
+		if appData := os.Getenv("APPDATA"); appData != "" {
+			candidates = append(candidates,
+				filepath.Join(appData, "npm", "pi.cmd"),
+				filepath.Join(appData, "npm", "pi.exe"),
+			)
+		}
+		for _, candidate := range candidates {
+			if fileExists(candidate) {
+				return candidate, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+		}
+		return "pi", nil
+	}
+
+	if path, err := exec.LookPath("pi"); err == nil && path != "" {
+		return path, nil
+	}
+
+	candidates := []string{
+		"/usr/local/bin/pi",
+		"/opt/homebrew/bin/pi",
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates,
+			filepath.Join(home, ".npm-global", "bin", "pi"),
+			filepath.Join(home, ".local", "bin", "pi"),
+			filepath.Join(home, ".pi", "bin", "pi"),
+		)
+	}
+
+	for _, candidate := range candidates {
+		if fileExists(candidate) {
+			return candidate, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+	}
+
+	return "pi", nil
+}
+
+func (p *Plugin) piBinary(ctx context.Context) (string, error) {
+	p.binaryMu.Lock()
+	defer p.binaryMu.Unlock()
+
+	if p.resolvedBinary != "" {
+		return p.resolvedBinary, nil
+	}
+
+	binary, err := ResolvePiBinary(ctx)
+	if err != nil {
+		return "", err
+	}
+	p.resolvedBinary = binary
+	return binary, nil
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/backend/internal/adapters/agent/pi/pi_test.go
+++ b/backend/internal/adapters/agent/pi/pi_test.go
@@ -1,0 +1,231 @@
+package pi
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestManifest(t *testing.T) {
+	m := (&Plugin{}).Manifest()
+	if m.ID != "pi" {
+		t.Fatalf("ID = %q, want pi", m.ID)
+	}
+	if m.Name != "Pi" {
+		t.Fatalf("Name = %q, want Pi", m.Name)
+	}
+	hasAgent := false
+	for _, c := range m.Capabilities {
+		if c == adapters.CapabilityAgent {
+			hasAgent = true
+		}
+	}
+	if !hasAgent {
+		t.Fatal("missing CapabilityAgent")
+	}
+}
+
+func TestGetConfigSpecEmpty(t *testing.T) {
+	spec, err := (&Plugin{}).GetConfigSpec(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(spec.Fields) != 0 {
+		t.Fatalf("expected no fields, got %d", len(spec.Fields))
+	}
+}
+
+func TestGetPromptDeliveryStrategy(t *testing.T) {
+	s, err := (&Plugin{}).GetPromptDeliveryStrategy(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if s != ports.PromptDeliveryInCommand {
+		t.Fatalf("strategy = %q, want %q", s, ports.PromptDeliveryInCommand)
+	}
+}
+
+func TestGetLaunchCommandWithPrompt(t *testing.T) {
+	p := &Plugin{resolvedBinary: "pi"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Prompt: "add a health check",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"pi", "--print", "add a health check"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetLaunchCommandEmitsNoPermissionFlag(t *testing.T) {
+	// Pi has no permission CLI surface; every mode must produce the same argv
+	// and never emit a permission flag.
+	modes := []ports.PermissionMode{
+		ports.PermissionModeDefault,
+		"",
+		ports.PermissionModeAcceptEdits,
+		ports.PermissionModeAuto,
+		ports.PermissionModeBypassPermissions,
+	}
+
+	for _, mode := range modes {
+		t.Run(string(mode), func(t *testing.T) {
+			p := &Plugin{resolvedBinary: "pi"}
+			cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{Permissions: mode})
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := []string{"pi", "--print"}
+			if !reflect.DeepEqual(cmd, want) {
+				t.Fatalf("cmd = %#v, want %#v", cmd, want)
+			}
+			for _, arg := range cmd {
+				if arg == "--permission-mode" {
+					t.Fatalf("cmd = %#v unexpectedly contains a permission flag", cmd)
+				}
+			}
+		})
+	}
+}
+
+func TestGetLaunchCommandAppendsSystemPrompt(t *testing.T) {
+	p := &Plugin{resolvedBinary: "pi"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		SystemPrompt: "follow repo rules",
+		Prompt:       "do the thing",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"pi", "--print", "--append-system-prompt", "follow repo rules", "do the thing"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandInlinesSystemPromptFileContents(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "system.md")
+	if err := os.WriteFile(file, []byte("file contents win"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &Plugin{resolvedBinary: "pi"}
+	cmd, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		SystemPromptFile: file,
+		SystemPrompt:     "inline ignored",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"pi", "--print", "--append-system-prompt", "file contents win"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetLaunchCommandSystemPromptFileReadError(t *testing.T) {
+	p := &Plugin{resolvedBinary: "pi"}
+	_, err := p.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		SystemPromptFile: filepath.Join(t.TempDir(), "missing.md"),
+		SystemPrompt:     "inline ignored",
+	})
+	if err == nil {
+		t.Fatal("expected error for unreadable system-prompt file, got nil")
+	}
+}
+
+func TestGetRestoreCommand(t *testing.T) {
+	p := &Plugin{resolvedBinary: "pi"}
+	cmd, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Session: ports.SessionRef{
+			Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "019e950e-52e0-7411-961b-d380ca7e610f"},
+		},
+		Permissions: ports.PermissionModeBypassPermissions,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want true")
+	}
+
+	want := []string{"pi", "--print", "--session", "019e950e-52e0-7411-961b-d380ca7e610f"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("cmd = %#v, want %#v", cmd, want)
+	}
+}
+
+func TestGetRestoreCommandNoID(t *testing.T) {
+	p := &Plugin{resolvedBinary: "pi"}
+	_, ok, err := p.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Session: ports.SessionRef{Metadata: map[string]string{}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("ok=true with no agentSessionId, want false")
+	}
+}
+
+func TestGetAgentHooksNoOp(t *testing.T) {
+	if err := (&Plugin{}).GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: t.TempDir()}); err != nil {
+		t.Fatalf("GetAgentHooks err = %v, want nil", err)
+	}
+}
+
+func TestSessionInfoNoOp(t *testing.T) {
+	info, ok, err := (&Plugin{}).SessionInfo(context.Background(), ports.SessionRef{
+		Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "019e950e-52e0-7411-961b-d380ca7e610f"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatalf("ok=true with info %#v, want no-op false", info)
+	}
+	if !reflect.DeepEqual(info, ports.SessionInfo{}) {
+		t.Fatalf("info = %#v, want zero", info)
+	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := (&Plugin{}).GetConfigSpec(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetConfigSpec err = %v, want context.Canceled", err)
+	}
+	if _, err := (&Plugin{}).GetPromptDeliveryStrategy(ctx, ports.LaunchConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetPromptDeliveryStrategy err = %v, want context.Canceled", err)
+	}
+	if err := (&Plugin{}).GetAgentHooks(ctx, ports.WorkspaceHookConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetAgentHooks err = %v, want context.Canceled", err)
+	}
+	if _, _, err := (&Plugin{}).GetRestoreCommand(ctx, ports.RestoreConfig{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetRestoreCommand err = %v, want context.Canceled", err)
+	}
+	if _, _, err := (&Plugin{}).SessionInfo(ctx, ports.SessionRef{}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("SessionInfo err = %v, want context.Canceled", err)
+	}
+}
+
+func TestResolvePiBinaryContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := ResolvePiBinary(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("ResolvePiBinary err = %v, want context.Canceled", err)
+	}
+}

--- a/backend/internal/adapters/agent/registry/registry.go
+++ b/backend/internal/adapters/agent/registry/registry.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kimi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/kiro"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/opencode"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/pi"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/qwen"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/vibe"
 	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
@@ -59,6 +60,7 @@ func Constructors() []adapters.Adapter {
 		kiro.New(),
 		kilocode.New(),
 		vibe.New(),
+		pi.New(),
 	}
 }
 

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -111,6 +111,7 @@ func TestWiring_AgentResolverResolvesRealAdapters(t *testing.T) {
 		{domain.HarnessKiro, "kiro"},
 		{domain.HarnessKilocode, "kilocode"},
 		{domain.HarnessVibe, "vibe"},
+		{domain.HarnessPi, "pi"},
 		{"", config.DefaultAgent}, // empty harness falls back to the AO_AGENT default
 	} {
 		agent, ok := resolver.Agent(tc.harness)


### PR DESCRIPTION
Adds the **pi** harness, stacked on #119 (agent platform). Adapter package + `Constructors()` registration + resolver test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #119
2. #120
3. #121
4. #122
5. #123
6. #124
7. #125
8. #126
9. #127
10. #128
11. #129
12. #130
13. #131
14. #132
15. #133
16. #134
17. #135
18. #136
19. #137
20. **#138** 👈 current
21. #139
<!-- stack:links:end -->