### PR TITLE
feat(agents): add autohand adapter

### DIFF
--- a/backend/internal/adapters/agent/activitydispatch/dispatch.go
+++ b/backend/internal/adapters/agent/activitydispatch/dispatch.go
@@ -10,6 +10,7 @@ package activitydispatch
 
 import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/agy"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/autohand"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/claudecode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/cline"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
@@ -51,6 +52,7 @@ var Derivers = map[string]DeriveFunc{
 	"cline":       cline.DeriveActivityState,
 	"kiro":        kiro.DeriveActivityState,
 	"kilocode":    kilocode.DeriveActivityState,
+	"autohand":    autohand.DeriveActivityState,
 }
 
 // Derive looks up the deriver for an agent token and applies it. ok=false when

--- a/backend/internal/adapters/agent/autohand/activity.go
+++ b/backend/internal/adapters/agent/autohand/activity.go
@@ -1,0 +1,26 @@
+package autohand
+
+import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
+
+// DeriveActivityState maps an Autohand hook event onto an AO activity state. The
+// bool is false when the event carries no activity signal.
+//
+// event is the AO hook sub-command name installed in autohandManagedHooks
+// ("session-start", "user-prompt-submit", "permission-request", "stop"), routed
+// from Autohand's native lifecycle events. Autohand has no SessionEnd/process-
+// exit hook wired into the adapter, so runtime exit still falls back to the
+// lifecycle reaper.
+func DeriveActivityState(event string, _ []byte) (domain.ActivityState, bool) {
+	switch event {
+	case "session-start":
+		return domain.ActivityActive, true
+	case "user-prompt-submit":
+		return domain.ActivityActive, true
+	case "stop":
+		return domain.ActivityIdle, true
+	case "permission-request":
+		return domain.ActivityWaitingInput, true
+	default:
+		return "", false
+	}
+}

--- a/backend/internal/adapters/agent/autohand/autohand.go
+++ b/backend/internal/adapters/agent/autohand/autohand.go
@@ -1,0 +1,283 @@
+// Package autohand implements the Autohand Code agent adapter: launching new
+// command-mode sessions, resuming native sessions by id, installing AO's
+// lifecycle hooks into Autohand's config, and reading hook-derived session info.
+//
+// Autohand ("autohand") is an autonomous coding agent with a non-interactive
+// command mode (`autohand -p <prompt>` / positional prompt), native session
+// resume (`autohand resume <sessionId>`), and a native hook/lifecycle system
+// whose events (session-start, stop, permission-request, ...) AO maps onto
+// activity states. See hooks.go for hook installation and activity.go for the
+// event→state mapping.
+package autohand
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const (
+	adapterID = "autohand"
+
+	autohandTitleMetadataKey   = "title"
+	autohandSummaryMetadataKey = "summary"
+)
+
+// Plugin is the Autohand agent adapter. It is safe for concurrent use; the
+// binary path is resolved once and cached under binaryMu.
+type Plugin struct {
+	binaryMu       sync.Mutex
+	resolvedBinary string
+}
+
+// New returns a ready-to-register Autohand adapter.
+func New() *Plugin {
+	return &Plugin{}
+}
+
+var _ adapters.Adapter = (*Plugin)(nil)
+var _ ports.Agent = (*Plugin)(nil)
+
+// Manifest returns the adapter's static self-description.
+func (p *Plugin) Manifest() adapters.Manifest {
+	return adapters.Manifest{
+		ID:          adapterID,
+		Name:        "Autohand",
+		Description: "Run Autohand worker sessions.",
+		Version:     "0.0.1",
+		Capabilities: []adapters.Capability{
+			adapters.CapabilityAgent,
+		},
+	}
+}
+
+// GetConfigSpec reports the agent-specific config keys. Autohand exposes none yet.
+func (p *Plugin) GetConfigSpec(ctx context.Context) (ports.ConfigSpec, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ConfigSpec{}, err
+	}
+	return ports.ConfigSpec{}, nil
+}
+
+// GetLaunchCommand builds the argv to start a new Autohand command-mode session,
+// scoping the run to the workspace, applying the approval-mode flags and optional
+// system-prompt override, and passing the initial prompt as a positional argument
+// after `--` so a prompt beginning with "-" is not read as a flag.
+//
+//	autohand [--path <workspace>] [<approval flags>] [--sys-prompt <value>] [-- <prompt>]
+func (p *Plugin) GetLaunchCommand(ctx context.Context, cfg ports.LaunchConfig) (cmd []string, err error) {
+	binary, err := p.autohandBinary(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd = []string{binary}
+	appendWorkspaceFlag(&cmd, cfg.WorkspacePath)
+	appendApprovalFlags(&cmd, cfg.Permissions)
+
+	// Autohand's --sys-prompt accepts either an inline string or a file path,
+	// auto-detected by the CLI; prefer the file form when AO provides one.
+	if cfg.SystemPromptFile != "" {
+		cmd = append(cmd, "--sys-prompt", cfg.SystemPromptFile)
+	} else if cfg.SystemPrompt != "" {
+		cmd = append(cmd, "--sys-prompt", cfg.SystemPrompt)
+	}
+
+	if cfg.Prompt != "" {
+		cmd = append(cmd, "--", cfg.Prompt)
+	}
+
+	return cmd, nil
+}
+
+// GetPromptDeliveryStrategy reports that Autohand receives its prompt in the
+// launch command itself.
+func (p *Plugin) GetPromptDeliveryStrategy(ctx context.Context, cfg ports.LaunchConfig) (ports.PromptDeliveryStrategy, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	return ports.PromptDeliveryInCommand, nil
+}
+
+// GetRestoreCommand rebuilds the argv that continues an existing Autohand
+// session: `autohand resume [--path <workspace>] <sessionId>`. ok is false when
+// the hook-derived native session id has not landed yet, so callers can fall
+// back to fresh launch behavior. Autohand's resume sub-command does not accept
+// approval flags, so none are appended here.
+func (p *Plugin) GetRestoreCommand(ctx context.Context, cfg ports.RestoreConfig) (cmd []string, ok bool, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	agentSessionID := strings.TrimSpace(cfg.Session.Metadata[ports.MetadataKeyAgentSessionID])
+	if agentSessionID == "" {
+		return nil, false, nil
+	}
+
+	binary, err := p.autohandBinary(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	cmd = make([]string, 0, 5)
+	cmd = append(cmd, binary, "resume")
+	appendWorkspaceFlag(&cmd, cfg.Session.WorkspacePath)
+	cmd = append(cmd, agentSessionID)
+	return cmd, true, nil
+}
+
+// SessionInfo surfaces Autohand hook-derived metadata. Metadata is intentionally
+// nil: callers get the normalized fields directly.
+func (p *Plugin) SessionInfo(ctx context.Context, session ports.SessionRef) (ports.SessionInfo, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.SessionInfo{}, false, err
+	}
+	info := ports.SessionInfo{
+		AgentSessionID: session.Metadata[ports.MetadataKeyAgentSessionID],
+		Title:          session.Metadata[autohandTitleMetadataKey],
+		Summary:        session.Metadata[autohandSummaryMetadataKey],
+	}
+	if info.AgentSessionID == "" && info.Title == "" && info.Summary == "" {
+		return ports.SessionInfo{}, false, nil
+	}
+	return info, true, nil
+}
+
+// appendWorkspaceFlag scopes the run to the given workspace path via --path.
+func appendWorkspaceFlag(cmd *[]string, workspacePath string) {
+	if strings.TrimSpace(workspacePath) != "" {
+		*cmd = append(*cmd, "--path", workspacePath)
+	}
+}
+
+// appendApprovalFlags maps AO's four permission modes onto Autohand's approval
+// flags. Default emits no flag so Autohand resolves its starting mode from the
+// user's own config (permissions.mode). Autohand has no distinct "accept-edits"
+// mode, so it maps to --yes (auto-confirm risky actions) — the least-privileged
+// non-interactive option — while auto/bypass map to --unrestricted.
+func appendApprovalFlags(cmd *[]string, permissions ports.PermissionMode) {
+	switch normalizePermissionMode(permissions) {
+	case ports.PermissionModeDefault:
+		// No flag: defer to the user's Autohand config/default behavior.
+	case ports.PermissionModeAcceptEdits:
+		*cmd = append(*cmd, "--yes")
+	case ports.PermissionModeAuto:
+		*cmd = append(*cmd, "--unrestricted")
+	case ports.PermissionModeBypassPermissions:
+		*cmd = append(*cmd, "--unrestricted")
+	}
+}
+
+func normalizePermissionMode(mode ports.PermissionMode) ports.PermissionMode {
+	switch mode {
+	case ports.PermissionModeDefault,
+		ports.PermissionModeAcceptEdits,
+		ports.PermissionModeAuto,
+		ports.PermissionModeBypassPermissions:
+		return mode
+	default:
+		return ports.PermissionModeDefault
+	}
+}
+
+// ResolveAutohandBinary returns the path to the autohand binary on this machine,
+// searching PATH then a handful of well-known install locations (Homebrew, the
+// official ~/.local/bin installer, npm global). Returns "autohand" as a
+// last-ditch fallback so callers see a clear "command not found" rather than an
+// empty argv.
+func ResolveAutohandBinary(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	if runtime.GOOS == "windows" {
+		for _, name := range []string{"autohand.cmd", "autohand.exe", "autohand"} {
+			if path, err := exec.LookPath(name); err == nil && path != "" {
+				return path, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+		}
+
+		candidates := []string{}
+		if appData := os.Getenv("APPDATA"); appData != "" {
+			candidates = append(candidates,
+				filepath.Join(appData, "npm", "autohand.cmd"),
+				filepath.Join(appData, "npm", "autohand.exe"),
+			)
+		}
+		if home, err := os.UserHomeDir(); err == nil {
+			candidates = append(candidates, filepath.Join(home, ".local", "bin", "autohand.exe"))
+		}
+		for _, candidate := range candidates {
+			if fileExists(candidate) {
+				return candidate, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return "", err
+			}
+		}
+
+		return "autohand", nil
+	}
+
+	if path, err := exec.LookPath("autohand"); err == nil && path != "" {
+		return path, nil
+	}
+
+	candidates := []string{
+		"/usr/local/bin/autohand",
+		"/opt/homebrew/bin/autohand",
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates,
+			filepath.Join(home, ".local", "bin", "autohand"),
+			filepath.Join(home, ".npm", "bin", "autohand"),
+		)
+	}
+
+	for _, candidate := range candidates {
+		if fileExists(candidate) {
+			return candidate, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+	}
+
+	return "autohand", nil
+}
+
+func (p *Plugin) autohandBinary(ctx context.Context) (string, error) {
+	// Honor cancellation even on the cached path, where ResolveAutohandBinary
+	// (which has its own ctx.Err() guard) is never reached.
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	p.binaryMu.Lock()
+	defer p.binaryMu.Unlock()
+
+	if p.resolvedBinary != "" {
+		return p.resolvedBinary, nil
+	}
+
+	binary, err := ResolveAutohandBinary(ctx)
+	if err != nil {
+		return "", err
+	}
+	p.resolvedBinary = binary
+	return binary, nil
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/backend/internal/adapters/agent/autohand/autohand_test.go
+++ b/backend/internal/adapters/agent/autohand/autohand_test.go
@@ -1,0 +1,539 @@
+package autohand
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/domain"
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+func TestManifestIDMatchesHarness(t *testing.T) {
+	m := (&Plugin{}).Manifest()
+	if m.ID != "autohand" {
+		t.Fatalf("Manifest ID = %q, want %q", m.ID, "autohand")
+	}
+	if adapterID != "autohand" {
+		t.Fatalf("adapterID = %q, want %q", adapterID, "autohand")
+	}
+	if len(m.Capabilities) != 1 || m.Capabilities[0] != "agent" {
+		t.Fatalf("Capabilities = %#v, want [agent]", m.Capabilities)
+	}
+}
+
+func TestGetLaunchCommandBuildsArgv(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "autohand"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		Permissions:      ports.PermissionModeBypassPermissions,
+		Prompt:           "-fix this",
+		WorkspacePath:    "/work/space",
+		SystemPromptFile: filepath.Join("tmp", "prompt with spaces.md"),
+		SystemPrompt:     "ignored",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"autohand",
+		"--path", "/work/space",
+		"--unrestricted",
+		"--sys-prompt", filepath.Join("tmp", "prompt with spaces.md"),
+		"--", "-fix this",
+	}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetLaunchCommandInlineSystemPrompt(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "autohand"}
+
+	cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+		SystemPrompt: "be terse",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"autohand", "--sys-prompt", "be terse"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("unexpected command\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetLaunchCommandMapsApprovalModes(t *testing.T) {
+	tests := []struct {
+		name        string
+		permission  ports.PermissionMode
+		want        []string
+		notExpected []string
+	}{
+		{
+			name:        "default",
+			permission:  ports.PermissionModeDefault,
+			notExpected: []string{"--unrestricted", "--yes", "--restricted"},
+		},
+		{
+			name:        "accept-edits",
+			permission:  ports.PermissionModeAcceptEdits,
+			want:        []string{"--yes"},
+			notExpected: []string{"--unrestricted"},
+		},
+		{
+			name:       "auto",
+			permission: ports.PermissionModeAuto,
+			want:       []string{"--unrestricted"},
+		},
+		{
+			name:       "bypass-permissions",
+			permission: ports.PermissionModeBypassPermissions,
+			want:       []string{"--unrestricted"},
+		},
+		{
+			name:        "unknown falls back to default",
+			permission:  "frobnicate",
+			notExpected: []string{"--unrestricted", "--yes", "--restricted"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &Plugin{resolvedBinary: "autohand"}
+			cmd, err := plugin.GetLaunchCommand(context.Background(), ports.LaunchConfig{
+				Permissions: tt.permission,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, want := range tt.want {
+				if !contains(cmd, want) {
+					t.Fatalf("command %#v missing %q", cmd, want)
+				}
+			}
+			for _, missing := range tt.notExpected {
+				if contains(cmd, missing) {
+					t.Fatalf("command %#v contains %q", cmd, missing)
+				}
+			}
+		})
+	}
+}
+
+func TestGetPromptDeliveryStrategyIsInCommand(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "autohand"}
+
+	got, err := plugin.GetPromptDeliveryStrategy(context.Background(), ports.LaunchConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != ports.PromptDeliveryInCommand {
+		t.Fatalf("unexpected strategy: %q", got)
+	}
+}
+
+func TestGetConfigSpecHasNoCustomFieldsYet(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "autohand"}
+
+	spec, err := plugin.GetConfigSpec(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(spec.Fields) != 0 {
+		t.Fatalf("unexpected config fields: %#v", spec.Fields)
+	}
+}
+
+func TestGetRestoreCommandReadsAgentSessionID(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "autohand"}
+
+	cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+		Permissions: ports.PermissionModeAuto,
+		Session: ports.SessionRef{
+			WorkspacePath: "/work/space",
+			Metadata:      map[string]string{ports.MetadataKeyAgentSessionID: "sess-123"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	want := []string{"autohand", "resume", "--path", "/work/space", "sess-123"}
+	if !reflect.DeepEqual(cmd, want) {
+		t.Fatalf("restore cmd\nwant: %#v\n got: %#v", want, cmd)
+	}
+}
+
+func TestGetRestoreCommandFalseWithoutAgentSessionID(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "autohand"}
+
+	cases := []struct {
+		name string
+		ref  ports.SessionRef
+	}{
+		{"empty session ref", ports.SessionRef{}},
+		{"empty metadata", ports.SessionRef{Metadata: map[string]string{}}},
+		{"blank agent session metadata", ports.SessionRef{Metadata: map[string]string{ports.MetadataKeyAgentSessionID: "   "}}},
+		{"workspace path only", ports.SessionRef{WorkspacePath: "/some/path"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, ok, err := plugin.GetRestoreCommand(context.Background(), ports.RestoreConfig{
+				Permissions: ports.PermissionModeAuto,
+				Session:     tc.ref,
+			})
+			if err != nil {
+				t.Fatalf("err = %v, want nil", err)
+			}
+			if ok {
+				t.Fatalf("ok = true, want false")
+			}
+			if cmd != nil {
+				t.Fatalf("cmd = %#v, want nil", cmd)
+			}
+		})
+	}
+}
+
+func TestSessionInfoReadsHookMetadata(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "autohand"}
+
+	info, ok, err := plugin.SessionInfo(context.Background(), ports.SessionRef{
+		WorkspacePath: "/some/path",
+		Metadata: map[string]string{
+			ports.MetadataKeyAgentSessionID: "sess-123",
+			autohandTitleMetadataKey:        "Fix login redirect",
+			autohandSummaryMetadataKey:      "Updated the auth callback and tests.",
+			"ignored":                       "not returned",
+		},
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !ok {
+		t.Fatalf("ok = false, want true")
+	}
+	if info.AgentSessionID != "sess-123" {
+		t.Fatalf("AgentSessionID = %q, want native id", info.AgentSessionID)
+	}
+	if info.Title != "Fix login redirect" {
+		t.Fatalf("Title = %q, want hook title", info.Title)
+	}
+	if info.Summary != "Updated the auth callback and tests." {
+		t.Fatalf("Summary = %q, want hook summary", info.Summary)
+	}
+	if info.Metadata != nil {
+		t.Fatalf("Metadata = %#v, want nil", info.Metadata)
+	}
+}
+
+func TestSessionInfoFalseWhenNoHookMetadata(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "autohand"}
+
+	info, ok, err := plugin.SessionInfo(context.Background(), ports.SessionRef{
+		WorkspacePath: "/some/path",
+		Metadata:      map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if ok {
+		t.Fatalf("ok = true, want false")
+	}
+	if !reflect.DeepEqual(info, ports.SessionInfo{}) {
+		t.Fatalf("info = %#v, want zero value", info)
+	}
+}
+
+func TestContextCancellationIsRespected(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "autohand"}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := plugin.GetConfigSpec(ctx); err == nil {
+		t.Fatal("GetConfigSpec: want context error")
+	}
+	if _, err := plugin.GetPromptDeliveryStrategy(ctx, ports.LaunchConfig{}); err == nil {
+		t.Fatal("GetPromptDeliveryStrategy: want context error")
+	}
+	if _, _, err := plugin.GetRestoreCommand(ctx, ports.RestoreConfig{}); err == nil {
+		t.Fatal("GetRestoreCommand: want context error")
+	}
+	if _, _, err := plugin.SessionInfo(ctx, ports.SessionRef{}); err == nil {
+		t.Fatal("SessionInfo: want context error")
+	}
+	if err := plugin.GetAgentHooks(ctx, ports.WorkspaceHookConfig{}); err == nil {
+		t.Fatal("GetAgentHooks: want context error")
+	}
+	// resolvedBinary is set, so this exercises the cached-binary path, which
+	// must still honor cancellation.
+	if _, err := plugin.GetLaunchCommand(ctx, ports.LaunchConfig{}); err == nil {
+		t.Fatal("GetLaunchCommand: want context error")
+	}
+}
+
+// TestGetAgentHooksPreservesUnknownEntryFields locks the round-trip behavior:
+// keys AO does not model on a user hook entry (here "async") must survive a
+// GetAgentHooks rewrite instead of being silently dropped.
+func TestGetAgentHooksPreservesUnknownEntryFields(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "autohand"}
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("AUTOHAND_CONFIG", configPath)
+
+	existing := `{
+  "hooks": {
+    "enabled": false,
+    "hooks": [
+      {"event": "stop", "command": "~/.autohand/hooks/sound-alert.sh", "description": "user hook", "enabled": true, "async": true, "filter": {"glob": "*.go"}}
+    ]
+  }
+}`
+	if err := os.WriteFile(configPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := plugin.GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: t.TempDir()}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var top struct {
+		Hooks struct {
+			Hooks []map[string]json.RawMessage `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &top); err != nil {
+		t.Fatal(err)
+	}
+
+	var userEntry map[string]json.RawMessage
+	for _, entry := range top.Hooks.Hooks {
+		if string(entry["command"]) == `"~/.autohand/hooks/sound-alert.sh"` {
+			userEntry = entry
+			break
+		}
+	}
+	if userEntry == nil {
+		t.Fatalf("user hook entry not found in %s", data)
+	}
+	if string(userEntry["async"]) != "true" {
+		t.Fatalf("unknown field async dropped: %s", data)
+	}
+	filterRaw, ok := userEntry["filter"]
+	if !ok {
+		t.Fatalf("unknown field filter dropped: %s", data)
+	}
+	var filter map[string]string
+	if err := json.Unmarshal(filterRaw, &filter); err != nil {
+		t.Fatalf("filter not valid json: %v (%s)", err, filterRaw)
+	}
+	if filter["glob"] != "*.go" {
+		t.Fatalf("unknown field filter not preserved: got %v in %s", filter, data)
+	}
+}
+
+func TestDeriveActivityState(t *testing.T) {
+	tests := []struct {
+		name   string
+		event  string
+		want   domain.ActivityState
+		wantOK bool
+	}{
+		{"session start -> active", "session-start", domain.ActivityActive, true},
+		{"user prompt -> active", "user-prompt-submit", domain.ActivityActive, true},
+		{"stop -> idle", "stop", domain.ActivityIdle, true},
+		{"permission request -> waiting input", "permission-request", domain.ActivityWaitingInput, true},
+		{"unknown event -> no signal", "frobnicate", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := DeriveActivityState(tt.event, []byte(`{}`))
+			if got != tt.want || ok != tt.wantOK {
+				t.Fatalf("DeriveActivityState(%q) = (%q, %v), want (%q, %v)",
+					tt.event, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestGetAgentHooksInstallsAndPreservesConfig(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "autohand"}
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("AUTOHAND_CONFIG", configPath)
+
+	// Seed a config with unrelated keys plus a user hook; both must survive.
+	existing := `{
+  "provider": "openai",
+  "auth": {"token": "keep-me"},
+  "hooks": {
+    "enabled": false,
+    "hooks": [
+      {"event": "stop", "command": "~/.autohand/hooks/sound-alert.sh", "description": "user hook", "enabled": true, "async": true}
+    ]
+  }
+}`
+	if err := os.WriteFile(configPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := ports.WorkspaceHookConfig{
+		DataDir:       t.TempDir(),
+		SessionID:     "sess-1",
+		WorkspacePath: t.TempDir(),
+	}
+	if err := plugin.GetAgentHooks(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+	// A second install must not duplicate AO hook commands.
+	if err := plugin.GetAgentHooks(context.Background(), cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Unrelated top-level config keys are preserved.
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(data, &top); err != nil {
+		t.Fatal(err)
+	}
+	if string(top["provider"]) != `"openai"` {
+		t.Fatalf("provider not preserved: %s", top["provider"])
+	}
+	if _, ok := top["auth"]; !ok {
+		t.Fatalf("auth block dropped: %s", data)
+	}
+
+	_, hooksSection, entries := mustReadHooks(t, configPath)
+	if string(hooksSection["enabled"]) != "true" {
+		t.Fatalf("hooks.enabled = %s, want true", hooksSection["enabled"])
+	}
+
+	for _, spec := range autohandManagedHooks {
+		command := autohandHookCommandPrefix + spec.Subcommand
+		if got := countCommand(entries, command); got != 1 {
+			t.Fatalf("command %q count = %d, want 1 in %#v", command, got, entries)
+		}
+	}
+	if countCommand(entries, "~/.autohand/hooks/sound-alert.sh") != 1 {
+		t.Fatalf("user hook not preserved: %#v", entries)
+	}
+
+	if installed, err := plugin.AreHooksInstalled(context.Background(), ""); err != nil || !installed {
+		t.Fatalf("AreHooksInstalled after install = (%v, %v), want (true, nil)", installed, err)
+	}
+}
+
+func TestUninstallHooksRemovesOnlyAOHooks(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "autohand"}
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	t.Setenv("AUTOHAND_CONFIG", configPath)
+
+	existing := `{
+  "hooks": {
+    "enabled": false,
+    "hooks": [
+      {"event": "stop", "command": "~/.autohand/hooks/sound-alert.sh", "description": "user hook", "enabled": true}
+    ]
+  }
+}`
+	if err := os.WriteFile(configPath, []byte(existing), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	cfg := ports.WorkspaceHookConfig{DataDir: t.TempDir(), SessionID: "sess-1", WorkspacePath: t.TempDir()}
+	if err := plugin.GetAgentHooks(ctx, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if installed, err := plugin.AreHooksInstalled(ctx, ""); err != nil || !installed {
+		t.Fatalf("AreHooksInstalled after install = (%v, %v), want (true, nil)", installed, err)
+	}
+
+	if err := plugin.UninstallHooks(ctx, ""); err != nil {
+		t.Fatal(err)
+	}
+	if installed, err := plugin.AreHooksInstalled(ctx, ""); err != nil || installed {
+		t.Fatalf("AreHooksInstalled after uninstall = (%v, %v), want (false, nil)", installed, err)
+	}
+
+	_, _, entries := mustReadHooks(t, configPath)
+	for _, spec := range autohandManagedHooks {
+		command := autohandHookCommandPrefix + spec.Subcommand
+		if got := countCommand(entries, command); got != 0 {
+			t.Fatalf("command %q count = %d after uninstall, want 0", command, got)
+		}
+	}
+	if countCommand(entries, "~/.autohand/hooks/sound-alert.sh") != 1 {
+		t.Fatalf("user hook not preserved after uninstall: %#v", entries)
+	}
+}
+
+func TestUninstallHooksMissingFileIsNoOp(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "autohand"}
+	configPath := filepath.Join(t.TempDir(), "missing", "config.json")
+	t.Setenv("AUTOHAND_CONFIG", configPath)
+
+	if err := plugin.UninstallHooks(context.Background(), ""); err != nil {
+		t.Fatalf("UninstallHooks on missing file = %v, want nil", err)
+	}
+	if installed, err := plugin.AreHooksInstalled(context.Background(), ""); err != nil || installed {
+		t.Fatalf("AreHooksInstalled on missing file = (%v, %v), want (false, nil)", installed, err)
+	}
+}
+
+func TestGetAgentHooksCreatesConfigWhenAbsent(t *testing.T) {
+	plugin := &Plugin{resolvedBinary: "autohand"}
+	configPath := filepath.Join(t.TempDir(), "nested", "config.json")
+	t.Setenv("AUTOHAND_CONFIG", configPath)
+
+	if err := plugin.GetAgentHooks(context.Background(), ports.WorkspaceHookConfig{WorkspacePath: t.TempDir()}); err != nil {
+		t.Fatal(err)
+	}
+	_, hooksSection, entries := mustReadHooks(t, configPath)
+	if string(hooksSection["enabled"]) != "true" {
+		t.Fatalf("hooks.enabled = %s, want true", hooksSection["enabled"])
+	}
+	if len(entries) != len(autohandManagedHooks) {
+		t.Fatalf("entry count = %d, want %d", len(entries), len(autohandManagedHooks))
+	}
+}
+
+func mustReadHooks(t *testing.T, configPath string) (map[string]json.RawMessage, map[string]json.RawMessage, []autohandHookEntry) {
+	t.Helper()
+	top, section, entries, err := readAutohandHooks(configPath)
+	if err != nil {
+		t.Fatalf("readAutohandHooks: %v", err)
+	}
+	return top, section, entries
+}
+
+func countCommand(entries []autohandHookEntry, command string) int {
+	count := 0
+	for _, entry := range entries {
+		if entry.Command == command {
+			count++
+		}
+	}
+	return count
+}
+
+func contains(values []string, needle string) bool {
+	for _, v := range values {
+		if v == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/adapters/agent/autohand/hooks.go
+++ b/backend/internal/adapters/agent/autohand/hooks.go
@@ -1,0 +1,337 @@
+package autohand
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aoagents/agent-orchestrator/backend/internal/ports"
+)
+
+const (
+	autohandConfigDirName  = ".autohand"
+	autohandConfigFileName = "config.json"
+
+	// autohandHookCommandPrefix identifies the hook commands AO owns, so
+	// install skips duplicates and uninstall recognizes AO entries by prefix
+	// without an embedded template to diff against.
+	autohandHookCommandPrefix = "ao hooks autohand "
+	autohandHookTimeout       = 30
+)
+
+// autohandManagedHookKeys are the entry keys AO owns. On marshal they are
+// written from the typed fields below; any other key the user set is preserved
+// from Extra. Keep in sync with the json tags on autohandHookEntry.
+var autohandManagedHookKeys = []string{"event", "command", "description", "enabled", "timeout"}
+
+// autohandHookEntry is the on-disk shape of one entry in the config's
+// hooks.hooks array. AO owns the five typed fields; any other key the user set
+// on an entry (matcher, filter, async, ...) is captured in Extra so a rewrite
+// preserves fields AO does not own instead of silently dropping them.
+type autohandHookEntry struct {
+	Event       string `json:"event"`
+	Command     string `json:"command"`
+	Description string `json:"description,omitempty"`
+	Enabled     bool   `json:"enabled"`
+	Timeout     int    `json:"timeout,omitempty"`
+
+	// Extra holds keys AO does not manage, captured on unmarshal and written
+	// back on marshal so they round-trip. encoding/json does not support
+	// `json:",inline"`, so the round-trip is implemented via the custom
+	// UnmarshalJSON/MarshalJSON below.
+	Extra map[string]json.RawMessage `json:"-"`
+}
+
+// UnmarshalJSON decodes the entry's typed fields and captures every key AO does
+// not manage into Extra, so a later MarshalJSON can write them back verbatim.
+func (e *autohandHookEntry) UnmarshalJSON(data []byte) error {
+	raw := map[string]json.RawMessage{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	// Decode the managed fields via a type alias to avoid recursing into this
+	// method, then drop the managed keys so Extra holds only unknown ones.
+	type managedAlias autohandHookEntry
+	var managed managedAlias
+	if err := json.Unmarshal(data, &managed); err != nil {
+		return err
+	}
+	*e = autohandHookEntry(managed)
+
+	for _, key := range autohandManagedHookKeys {
+		delete(raw, key)
+	}
+	if len(raw) > 0 {
+		e.Extra = raw
+	} else {
+		e.Extra = nil
+	}
+	return nil
+}
+
+// MarshalJSON writes AO's managed fields merged with any preserved unknown keys
+// from Extra. Managed fields win on key collision so AO's values stay
+// authoritative.
+func (e autohandHookEntry) MarshalJSON() ([]byte, error) {
+	out := make(map[string]json.RawMessage, len(e.Extra)+len(autohandManagedHookKeys))
+	for key, val := range e.Extra {
+		out[key] = val
+	}
+
+	type managedAlias autohandHookEntry
+	managedJSON, err := json.Marshal(managedAlias(e))
+	if err != nil {
+		return nil, err
+	}
+	var managed map[string]json.RawMessage
+	if err := json.Unmarshal(managedJSON, &managed); err != nil {
+		return nil, err
+	}
+	for key, val := range managed {
+		out[key] = val
+	}
+	return json.Marshal(out)
+}
+
+// autohandHookSpec describes one hook AO installs. Event is Autohand's native
+// lifecycle event name; Subcommand is the AO hook sub-command appended after the
+// command prefix (and the value DeriveActivityState switches on).
+type autohandHookSpec struct {
+	Event      string
+	Subcommand string
+}
+
+// autohandManagedHooks is the source of truth for the hooks AO installs. Each
+// native Autohand event is routed to the AO sub-command DeriveActivityState
+// understands. Autohand's pre-prompt event is the user-prompt-submit signal.
+var autohandManagedHooks = []autohandHookSpec{
+	{Event: "session-start", Subcommand: "session-start"},
+	{Event: "pre-prompt", Subcommand: "user-prompt-submit"},
+	{Event: "permission-request", Subcommand: "permission-request"},
+	{Event: "stop", Subcommand: "stop"},
+}
+
+// GetAgentHooks installs AO's Autohand hooks into the Autohand config's
+// hooks.hooks array. Existing user hooks are preserved and duplicate AO commands
+// are not appended. The rest of the config (auth, provider, ...) is preserved
+// byte-for-byte because only the hooks section is decoded and rewritten.
+//
+// Autohand loads hooks from a single config file (default ~/.autohand/config.json,
+// overridable via AUTOHAND_CONFIG); it does not merge a workspace-local file at
+// runtime, so AO installs into that config rather than a per-workspace file. The
+// AUTOHAND_CONFIG env var, when set, takes precedence so AO and the agent agree
+// on the target.
+func (p *Plugin) GetAgentHooks(ctx context.Context, cfg ports.WorkspaceHookConfig) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	configPath := autohandConfigPath()
+	topLevel, hooksSection, entries, err := readAutohandHooks(configPath)
+	if err != nil {
+		return fmt.Errorf("autohand.GetAgentHooks: %w", err)
+	}
+
+	for _, spec := range autohandManagedHooks {
+		command := autohandHookCommandPrefix + spec.Subcommand
+		if autohandHookCommandExists(entries, command) {
+			continue
+		}
+		entries = append(entries, autohandHookEntry{
+			Event:       spec.Event,
+			Command:     command,
+			Description: "AO activity hook",
+			Enabled:     true,
+			Timeout:     autohandHookTimeout,
+		})
+	}
+
+	// Autohand only fires hooks when the hooks section is enabled.
+	hooksSection["enabled"] = json.RawMessage(`true`)
+
+	if err := writeAutohandHooks(configPath, topLevel, hooksSection, entries); err != nil {
+		return fmt.Errorf("autohand.GetAgentHooks: %w", err)
+	}
+	return nil
+}
+
+// UninstallHooks removes AO's Autohand hooks from the config's hooks.hooks
+// array, leaving user-defined hooks and the rest of the config untouched. A
+// missing file is a no-op. The hooks.enabled flag is left in place because it
+// enables every Autohand hook, not just AO's.
+func (p *Plugin) UninstallHooks(ctx context.Context, _ string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	configPath := autohandConfigPath()
+	if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	topLevel, hooksSection, entries, err := readAutohandHooks(configPath)
+	if err != nil {
+		return fmt.Errorf("autohand.UninstallHooks: %w", err)
+	}
+
+	kept := make([]autohandHookEntry, 0, len(entries))
+	for _, entry := range entries {
+		if !isAutohandManagedHook(entry.Command) {
+			kept = append(kept, entry)
+		}
+	}
+
+	if err := writeAutohandHooks(configPath, topLevel, hooksSection, kept); err != nil {
+		return fmt.Errorf("autohand.UninstallHooks: %w", err)
+	}
+	return nil
+}
+
+// AreHooksInstalled reports whether any AO Autohand hook is present in the
+// config. A missing file means none are installed.
+func (p *Plugin) AreHooksInstalled(ctx context.Context, _ string) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
+	configPath := autohandConfigPath()
+	if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	_, _, entries, err := readAutohandHooks(configPath)
+	if err != nil {
+		return false, fmt.Errorf("autohand.AreHooksInstalled: %w", err)
+	}
+	for _, entry := range entries {
+		if isAutohandManagedHook(entry.Command) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// autohandConfigPath returns the config file Autohand loads hooks from: the
+// AUTOHAND_CONFIG override if set, else ~/.autohand/config.json.
+func autohandConfigPath() string {
+	if env := strings.TrimSpace(os.Getenv("AUTOHAND_CONFIG")); env != "" {
+		return env
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		// Fall back to a relative path; callers surface the resulting error.
+		return filepath.Join(autohandConfigDirName, autohandConfigFileName)
+	}
+	return filepath.Join(home, autohandConfigDirName, autohandConfigFileName)
+}
+
+// readAutohandHooks loads the config into a top-level raw map, the decoded
+// "hooks" section (preserving keys AO doesn't manage such as "enabled"), and the
+// decoded hooks array. A missing or empty file yields empty maps and a nil
+// slice.
+func readAutohandHooks(configPath string) (topLevel, hooksSection map[string]json.RawMessage, entries []autohandHookEntry, err error) {
+	topLevel = map[string]json.RawMessage{}
+	hooksSection = map[string]json.RawMessage{}
+
+	data, err := os.ReadFile(configPath) //nolint:gosec // path is the user's own Autohand config
+	if errors.Is(err, os.ErrNotExist) {
+		return topLevel, hooksSection, nil, nil
+	}
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("read %s: %w", configPath, err)
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return topLevel, hooksSection, nil, nil
+	}
+	if err := json.Unmarshal(data, &topLevel); err != nil {
+		return nil, nil, nil, fmt.Errorf("parse %s: %w", configPath, err)
+	}
+	if hooksRaw, ok := topLevel["hooks"]; ok {
+		if err := json.Unmarshal(hooksRaw, &hooksSection); err != nil {
+			return nil, nil, nil, fmt.Errorf("parse hooks in %s: %w", configPath, err)
+		}
+	}
+	if arrRaw, ok := hooksSection["hooks"]; ok {
+		if err := json.Unmarshal(arrRaw, &entries); err != nil {
+			return nil, nil, nil, fmt.Errorf("parse hooks array in %s: %w", configPath, err)
+		}
+	}
+	return topLevel, hooksSection, entries, nil
+}
+
+// writeAutohandHooks folds the entries back into the hooks section, the hooks
+// section back into topLevel, and writes the file atomically. An empty entries
+// slice drops the "hooks" array key.
+func writeAutohandHooks(configPath string, topLevel, hooksSection map[string]json.RawMessage, entries []autohandHookEntry) error {
+	if len(entries) == 0 {
+		delete(hooksSection, "hooks")
+	} else {
+		arrJSON, err := json.Marshal(entries)
+		if err != nil {
+			return fmt.Errorf("encode hooks array: %w", err)
+		}
+		hooksSection["hooks"] = arrJSON
+	}
+
+	if len(hooksSection) == 0 {
+		delete(topLevel, "hooks")
+	} else {
+		hooksJSON, err := json.Marshal(hooksSection)
+		if err != nil {
+			return fmt.Errorf("encode hooks section: %w", err)
+		}
+		topLevel["hooks"] = hooksJSON
+	}
+
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o750); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+	data, err := json.MarshalIndent(topLevel, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode %s: %w", configPath, err)
+	}
+	data = append(data, '\n')
+	if err := atomicWriteFile(configPath, data, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", configPath, err)
+	}
+	return nil
+}
+
+// atomicWriteFile writes data to path via a temp file + rename, so a crash mid-
+// write can't leave a truncated/empty config that Autohand then fails to parse.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".ao-tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+func isAutohandManagedHook(command string) bool {
+	return strings.HasPrefix(command, autohandHookCommandPrefix)
+}
+
+func autohandHookCommandExists(entries []autohandHookEntry, command string) bool {
+	for _, entry := range entries {
+		if entry.Command == command {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/adapters/agent/registry/registry.go
+++ b/backend/internal/adapters/agent/registry/registry.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/aider"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/amp"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/auggie"
+	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/autohand"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/claudecode"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/cline"
 	"github.com/aoagents/agent-orchestrator/backend/internal/adapters/agent/codex"
@@ -61,6 +62,7 @@ func Constructors() []adapters.Adapter {
 		kilocode.New(),
 		vibe.New(),
 		pi.New(),
+		autohand.New(),
 	}
 }
 

--- a/backend/internal/daemon/wiring_test.go
+++ b/backend/internal/daemon/wiring_test.go
@@ -112,6 +112,7 @@ func TestWiring_AgentResolverResolvesRealAdapters(t *testing.T) {
 		{domain.HarnessKilocode, "kilocode"},
 		{domain.HarnessVibe, "vibe"},
 		{domain.HarnessPi, "pi"},
+		{domain.HarnessAutohand, "autohand"},
 		{"", config.DefaultAgent}, // empty harness falls back to the AO_AGENT default
 	} {
 		agent, ok := resolver.Agent(tc.harness)


### PR DESCRIPTION
Adds the **autohand** harness, stacked on #119 (agent platform). Adapter package + `Constructors()` registration + resolver test. Includes its own activity deriver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #119
2. #120
3. #121
4. #122
5. #123
6. #124
7. #125
8. #126
9. #127
10. #128
11. #129
12. #130
13. #131
14. #132
15. #133
16. #134
17. #135
18. #136
19. #137
20. #138
21. **#139** 👈 current
<!-- stack:links:end -->