### PR TITLE
docs: add README_1.md

### DIFF
--- a/README_1.md
+++ b/README_1.md
@@ -1,0 +1,23 @@
+# README_1
+
+A placeholder document, drifting in from nowhere in particular.
+
+## Changelog of a fictional machine
+
+- **v0.3.0** — Taught the kettle to whistle in three keys. Removed the fourth; it was rude.
+- **v0.2.1** — Patched a leak where Tuesdays would occasionally spill into Wednesday.
+- **v0.1.0** — First light. The gears turned, blinked, and asked for coffee.
+
+## A small haiku
+
+Cursor blinks softly —
+a thousand unwritten lines
+wait behind the glass.
+
+## Field notes
+
+The lighthouse keeper logged nothing unusual, which was itself unusual. Somewhere
+between the second and third paragraph, the fog forgot how to be a metaphor and
+simply became weather. We left it there, content to be ordinary.
+
+That is all. Carry on.


### PR DESCRIPTION
Adds a docs-only `README_1.md` at the repo root containing placeholder creative text (a fictional changelog, a haiku, and some field notes). No other files are modified and no build/test changes are involved.