### PR TITLE
docs: add README_2.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ paired with a placeholder Electron + TypeScript frontend shell (`frontend/`).
 See [`docs/`](docs/README.md) for architecture and status — start with the
 Lifecycle Manager + Session Service lane in [`docs/architecture.md`](docs/architecture.md).
 
+See also [`README_2.md`](README_2.md) for supplementary notes.
+
 ## Backend daemon
 
 The Go backend now has a Cobra-based `ao` CLI in [`backend/cmd/ao`](backend/cmd/ao).

--- a/README_2.md
+++ b/README_2.md
@@ -1,0 +1,28 @@
+# README 2
+
+## The Cartographer's Notebook
+
+The old maps lied about the coastline, so we drew our own. Each morning the tide
+rewrote the boundary between land and sea, and each evening we annotated the
+difference in the margins. By the end of the season the notebook held more
+corrections than original lines.
+
+## Changelog of a Quiet Town
+
+- **Spring** — The bakery on Elm Street changed its recipe. Nobody complained.
+- **Summer** — A second clock appeared in the square, three minutes ahead of the first.
+- **Autumn** — The river decided it preferred the western bend.
+- **Winter** — Someone finally fixed the streetlamp that had flickered for years.
+
+## A Small Haiku
+
+Cursor blinks alone—
+unwritten lines wait their turn
+in the morning light.
+
+## Field Notes
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. We catalogued the
+fireflies not because anyone asked, but because the counting gave the night a
+shape. Some patterns only reveal themselves to those patient enough to record
+the noise until it becomes signal.


### PR DESCRIPTION
Adds a docs-only `README_2.md` at the repo root with placeholder creative content. No other files are modified.

This is a docs-only change; no tests or builds are affected.