### PR TITLE
docs: add README_3.md

### DIFF
--- a/README_3.md
+++ b/README_3.md
@@ -1,0 +1,19 @@
+# README 3
+
+## Changelog of an Imaginary Machine
+
+### v0.3.0 — The Quiet Release
+We taught the orchestrator to dream in parallel. Sessions now braid together like rivers
+finding the same sea, each one carrying its own small cargo of intent. Nothing broke, which
+is its own kind of miracle.
+
+### v0.2.0 — Lanterns
+Added soft logging. Where before there was silence, now there are lanterns strung along the
+event stream, blinking gently whenever a worker wakes. We removed three bugs and apologized
+to a fourth, which had been doing useful work all along.
+
+### v0.1.0 — First Light
+The first commit landed at dawn. A single function, hopeful and untested, reached out into
+the dark and returned exactly what it was given. We called it good and went to make coffee.
+
+> "Build small, ship often, and leave the campsite cleaner than you found it."


### PR DESCRIPTION
Adds a docs-only `README_3.md` at the repo root containing creative placeholder content (a fictional changelog). No other files are modified.

This is a documentation-only change; no tests or builds are affected.