### PR TITLE
fix(sessions): remove agentRules spawn path

### DIFF
--- a/backend/internal/cli/spawn.go
+++ b/backend/internal/cli/spawn.go
@@ -17,7 +17,6 @@ type spawnOptions struct {
 	branch     string
 	prompt     string
 	issue      string
-	rules      string
 	claimPR    string
 	noTakeover bool
 }
@@ -25,12 +24,11 @@ type spawnOptions struct {
 // spawnRequest mirrors the daemon's SpawnSessionRequest body for
 // POST /api/v1/sessions. The CLI keeps its own copy so it need not import httpd.
 type spawnRequest struct {
-	ProjectID  string `json:"projectId"`
-	IssueID    string `json:"issueId,omitempty"`
-	Harness    string `json:"harness,omitempty"`
-	Branch     string `json:"branch,omitempty"`
-	Prompt     string `json:"prompt,omitempty"`
-	AgentRules string `json:"agentRules,omitempty"`
+	ProjectID string `json:"projectId"`
+	IssueID   string `json:"issueId,omitempty"`
+	Harness   string `json:"harness,omitempty"`
+	Branch    string `json:"branch,omitempty"`
+	Prompt    string `json:"prompt,omitempty"`
 }
 
 type spawnResult struct {
@@ -68,12 +66,11 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 				}
 			}
 			req := spawnRequest{
-				ProjectID:  opts.project,
-				IssueID:    opts.issue,
-				Harness:    opts.harness,
-				Branch:     opts.branch,
-				Prompt:     opts.prompt,
-				AgentRules: opts.rules,
+				ProjectID: opts.project,
+				IssueID:   opts.issue,
+				Harness:   opts.harness,
+				Branch:    opts.branch,
+				Prompt:    opts.prompt,
 			}
 			var res spawnResult
 			if err := ctx.postJSON(cmd.Context(), "sessions", req, &res); err != nil {
@@ -127,7 +124,6 @@ func newSpawnCommand(ctx *commandContext) *cobra.Command {
 	f.StringVar(&opts.branch, "branch", "", "Branch for the session worktree (default: ao/<session-id>)")
 	f.StringVar(&opts.prompt, "prompt", "", "Initial prompt for the agent")
 	f.StringVar(&opts.issue, "issue", "", "Issue id to associate with the session")
-	f.StringVar(&opts.rules, "rules", "", "Agent rules appended to the prompt")
 	f.StringVar(&opts.claimPR, "claim-pr", "", "Immediately claim an existing PR for the spawned session")
 	f.BoolVar(&opts.noTakeover, "no-takeover", false, "Refuse if another active session owns the claimed PR (requires --claim-pr)")
 	return cmd

--- a/backend/internal/httpd/apispec/openapi.yaml
+++ b/backend/internal/httpd/apispec/openapi.yaml
@@ -1376,8 +1376,6 @@ components:
       type: object
     SpawnSessionRequest:
       properties:
-        agentRules:
-          type: string
         branch:
           type: string
         harness:

--- a/backend/internal/httpd/controllers/dto.go
+++ b/backend/internal/httpd/controllers/dto.go
@@ -118,13 +118,12 @@ type ListSessionsResponse struct {
 
 // SpawnSessionRequest is the body of POST /api/v1/sessions.
 type SpawnSessionRequest struct {
-	ProjectID  domain.ProjectID    `json:"projectId"`
-	IssueID    domain.IssueID      `json:"issueId,omitempty"`
-	Kind       domain.SessionKind  `json:"kind,omitempty" enum:"worker,orchestrator"`
-	Harness    domain.AgentHarness `json:"harness,omitempty" enum:"claude-code,codex,aider,opencode,grok,droid,amp,agy,crush,cursor,qwen,copilot,goose,auggie,continue,devin,cline,kimi,kiro,kilocode,vibe,pi,autohand"`
-	Branch     string              `json:"branch,omitempty"`
-	Prompt     string              `json:"prompt,omitempty" maxLength:"4096"`
-	AgentRules string              `json:"agentRules,omitempty"`
+	ProjectID domain.ProjectID    `json:"projectId"`
+	IssueID   domain.IssueID      `json:"issueId,omitempty"`
+	Kind      domain.SessionKind  `json:"kind,omitempty" enum:"worker,orchestrator"`
+	Harness   domain.AgentHarness `json:"harness,omitempty" enum:"claude-code,codex,aider,opencode,grok,droid,amp,agy,crush,cursor,qwen,copilot,goose,auggie,continue,devin,cline,kimi,kiro,kilocode,vibe,pi,autohand"`
+	Branch    string              `json:"branch,omitempty"`
+	Prompt    string              `json:"prompt,omitempty" maxLength:"4096"`
 }
 
 // SessionResponse is the { session } body shared by session create/get.

--- a/backend/internal/httpd/controllers/sessions.go
+++ b/backend/internal/httpd/controllers/sessions.go
@@ -112,7 +112,7 @@ func (c *SessionsController) spawn(w http.ResponseWriter, r *http.Request) {
 	if in.Kind == "" {
 		in.Kind = domain.KindWorker
 	}
-	sess, err := c.Svc.Spawn(r.Context(), ports.SpawnConfig{ProjectID: in.ProjectID, IssueID: in.IssueID, Kind: in.Kind, Harness: in.Harness, Branch: in.Branch, Prompt: in.Prompt, AgentRules: in.AgentRules})
+	sess, err := c.Svc.Spawn(r.Context(), ports.SpawnConfig{ProjectID: in.ProjectID, IssueID: in.IssueID, Kind: in.Kind, Harness: in.Harness, Branch: in.Branch, Prompt: in.Prompt})
 	if err != nil {
 		envelope.WriteError(w, r, err)
 		return

--- a/backend/internal/ports/session.go
+++ b/backend/internal/ports/session.go
@@ -3,13 +3,12 @@ package ports
 import "github.com/aoagents/agent-orchestrator/backend/internal/domain"
 
 // SpawnConfig is the request to start a new session: which project/issue, which
-// agent harness, and the branch/prompt/rules the agent launches with.
+// agent harness, and the branch/prompt the agent launches with.
 type SpawnConfig struct {
-	ProjectID  domain.ProjectID
-	IssueID    domain.IssueID
-	Kind       domain.SessionKind
-	Harness    domain.AgentHarness
-	Branch     string
-	Prompt     string
-	AgentRules string
+	ProjectID domain.ProjectID
+	IssueID   domain.IssueID
+	Kind      domain.SessionKind
+	Harness   domain.AgentHarness
+	Branch    string
+	Prompt    string
 }

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -388,17 +388,8 @@ func seedRecord(cfg ports.SpawnConfig, now time.Time) domain.SessionRecord {
 	}
 }
 
-// buildPrompt assembles the spawn prompt from the explicit config (the full
-// 3-layer assembly lands later).
 func buildPrompt(cfg ports.SpawnConfig) string {
-	switch {
-	case cfg.AgentRules == "":
-		return cfg.Prompt
-	case cfg.Prompt == "":
-		return cfg.AgentRules
-	default:
-		return cfg.Prompt + "\n\n" + cfg.AgentRules
-	}
+	return cfg.Prompt
 }
 
 func (m *Manager) buildSpawnPrompt(ctx context.Context, cfg ports.SpawnConfig) (string, error) {

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -492,7 +492,6 @@ export interface components {
             orchestrator: components["schemas"]["OrchestratorResponse"];
         };
         SpawnSessionRequest: {
-            agentRules?: string;
             branch?: string;
             /** @enum {string} */
             harness?: "claude-code" | "codex" | "aider" | "opencode" | "grok" | "droid" | "amp" | "agy" | "crush" | "cursor" | "qwen" | "copilot" | "goose" | "auggie" | "continue" | "devin" | "cline" | "kimi" | "kiro" | "kilocode" | "vibe" | "pi" | "autohand";


### PR DESCRIPTION
## Summary

- remove the existing per-spawn `agentRules` / `--rules` path from CLI, API DTOs, and session manager prompt assembly
- regenerate OpenAPI and frontend API schema so `SpawnSessionRequest.agentRules` is no longer advertised

## Why

Persistent or ad-hoc project instructions should flow through the system prompt / repo-local `AGENTS.md` model rather than a separate `agentRules` prompt-concatenation path.

## Tests

- `cd backend && go test ./internal/session_manager ./internal/httpd/controllers ./internal/httpd/apispec ./internal/cli`
- `cd backend && go test ./...`

## Notes

- `npm run api` could not complete locally because dependencies are not installed (`openapi-typescript` missing from local node_modules), so I regenerated the TS schema with `npx openapi-typescript@7.4.4 backend/internal/httpd/apispec/openapi.yaml -o frontend/src/api/schema.ts`.
- Worker session `aa-77` is updating PR #154 to remove the new project-config rules fields and future-only config fields; I sent it conflict-avoidance notes for this branch.
