### PR TITLE
fix(spawn): keep worker modal open on errors

### DIFF
--- a/frontend/src/renderer/components/SpawnWorkerModal.test.tsx
+++ b/frontend/src/renderer/components/SpawnWorkerModal.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { SpawnWorkerModal } from "./SpawnWorkerModal";
+import { TooltipProvider } from "./ui/tooltip";
+import type { WorkspaceSummary } from "../types/workspace";
+
+const workspaces: WorkspaceSummary[] = [{ id: "proj-1", name: "my-app", path: "/p", type: "main", sessions: [] }];
+
+function renderModal(onCreateTask = vi.fn().mockResolvedValue(undefined), onOpenChange = () => undefined) {
+	render(
+		<TooltipProvider>
+			<SpawnWorkerModal
+				open
+				onOpenChange={onOpenChange}
+				workspaces={workspaces}
+				defaultProjectId="proj-1"
+				onCreateTask={onCreateTask}
+			/>
+		</TooltipProvider>,
+	);
+	return onCreateTask;
+}
+
+describe("SpawnWorkerModal", () => {
+	it("requires a non-empty prompt before it can spawn", () => {
+		const onCreateTask = renderModal();
+		expect(screen.getByRole("button", { name: /Spawn worker/ })).toBeDisabled();
+		expect(onCreateTask).not.toHaveBeenCalled();
+	});
+
+	it("keeps the modal open and shows the daemon error when the spawn fails", async () => {
+		const user = userEvent.setup();
+		const onOpenChange = vi.fn();
+		let rejectSpawn!: (reason: Error) => void;
+		const onCreateTask = vi.fn(
+			() =>
+				new Promise<void>((_, reject) => {
+					rejectSpawn = reject;
+				}),
+		);
+		renderModal(onCreateTask, onOpenChange);
+
+		await user.type(await screen.findByLabelText("Prompt"), "do the thing");
+		await user.click(screen.getByRole("button", { name: /Spawn worker/ }));
+		expect(screen.getByRole("button", { name: /Spawn worker/ })).toBeDisabled();
+
+		rejectSpawn(new Error("branch already checked out at ~/Projects/skills"));
+
+		expect(await screen.findByRole("alert")).toHaveTextContent("branch already checked out at ~/Projects/skills");
+		expect(onOpenChange).not.toHaveBeenCalled();
+		expect(screen.getByLabelText("Prompt")).toHaveValue("do the thing");
+
+		onCreateTask.mockResolvedValueOnce(undefined);
+		await user.click(screen.getByRole("button", { name: /Spawn worker/ }));
+		await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+		expect(onCreateTask).toHaveBeenCalledTimes(2);
+	});
+});

--- a/frontend/src/renderer/components/SpawnWorkerModal.tsx
+++ b/frontend/src/renderer/components/SpawnWorkerModal.tsx
@@ -202,7 +202,11 @@ export function SpawnWorkerModal({
 							)}
 						</div>
 
-						{error && <p className="text-[12px] text-error">{error}</p>}
+						{error && (
+							<p className="text-[12px] text-error" role="alert">
+								{error}
+							</p>
+						)}
 
 						<div className="-mx-[18px] -mb-[18px] flex justify-end border-t border-border bg-surface px-3.5 py-3">
 							<Button disabled={!canSubmit} type="submit" variant="primary">


### PR DESCRIPTION
## Summary
- Keep the spawn modal open when the daemon rejects a worker spawn.
- Surface the daemon error as an inline alert while preserving the user's prompt for retry.

## Test plan
- `npm --prefix frontend run test -- src/renderer/components/SpawnWorkerModal.test.tsx`


Made with [Cursor](https://cursor.com)