### PR TITLE
fix(frontend): set Electron app name

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "agent-orchestrator-frontend",
+	"productName": "Agent Orchestrator",
 	"version": "0.0.0",
 	"private": true,
 	"description": "Electron + TypeScript frontend for the agent-orchestrator rewrite",

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -12,6 +12,9 @@ import type { DaemonStatus } from "./shared/daemon-status";
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 declare const MAIN_WINDOW_VITE_NAME: string;
 
+// Must run before app ready so the About panel and default-menu role labels use it.
+app.setName("Agent Orchestrator");
+
 let mainWindow: BrowserWindow | null = null;
 let daemonProcess: ChildProcessWithoutNullStreams | null = null;
 let daemonStatus: DaemonStatus = { state: "stopped" };


### PR DESCRIPTION
## Summary
- Set `productName` for packaged Electron metadata.
- Call `app.setName("Agent Orchestrator")` before app ready so native labels use the product name.

## Test plan
- `npm run frontend:typecheck` (fails on current upstream main: Forge `notarize`/maker typings and `update-electron-app` import call signature)


Made with [Cursor](https://cursor.com)