### PR TITLE
chore: change default data/config dir from ~/Library/Application Support to ~/.ao

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -189,23 +189,22 @@ func resolveRunFilePath() (string, error) {
 	if p, ok := os.LookupEnv("AO_RUN_FILE"); ok && p != "" {
 		return p, nil
 	}
-	dir, err := os.UserConfigDir()
+	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve state dir: %w", err)
 	}
-	return filepath.Join(dir, "agent-orchestrator", "running.json"), nil
+	return filepath.Join(home, ".ao", "running.json"), nil
 }
 
 // resolveDataDir picks where durable state (the SQLite DB) lives. An explicit
-// AO_DATA_DIR wins; otherwise it sits under the per-user config directory
-// alongside running.json.
+// AO_DATA_DIR wins; otherwise it defaults to ~/.ao/data/.
 func resolveDataDir() (string, error) {
 	if p, ok := os.LookupEnv("AO_DATA_DIR"); ok && p != "" {
 		return p, nil
 	}
-	dir, err := os.UserConfigDir()
+	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve state dir: %w", err)
 	}
-	return filepath.Join(dir, "agent-orchestrator", "data"), nil
+	return filepath.Join(home, ".ao", "data"), nil
 }

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -33,14 +33,14 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.RunFilePath == "" {
 		t.Error("RunFilePath is empty, want a resolved default path")
 	}
-	if !strings.HasSuffix(cfg.RunFilePath, filepath.Join("agent-orchestrator", "running.json")) {
-		t.Errorf("RunFilePath = %q, want agent-orchestrator/running.json suffix", cfg.RunFilePath)
+	if !strings.HasSuffix(cfg.RunFilePath, filepath.Join(".ao", "running.json")) {
+		t.Errorf("RunFilePath = %q, want .ao/running.json suffix", cfg.RunFilePath)
 	}
 	if cfg.DataDir == "" {
 		t.Error("DataDir is empty, want a resolved default path")
 	}
-	if !strings.HasSuffix(cfg.DataDir, filepath.Join("agent-orchestrator", "data")) {
-		t.Errorf("DataDir = %q, want agent-orchestrator/data suffix", cfg.DataDir)
+	if !strings.HasSuffix(cfg.DataDir, filepath.Join(".ao", "data")) {
+		t.Errorf("DataDir = %q, want .ao/data suffix", cfg.DataDir)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace `os.UserConfigDir()` + `"agent-orchestrator/..."` fallback with `os.UserHomeDir()` + `".ao/..."` in `resolveRunFilePath()` and `resolveDataDir()` (`backend/internal/config/config.go`)
- Default layout is now `~/.ao/running.json` and `~/.ao/data/`
- `AO_RUN_FILE` and `AO_DATA_DIR` env overrides unchanged
- Updated `TestLoadDefaults` to assert the new `.ao/` suffix

> **Note for release:** existing installs will lose their data on upgrade unless `AO_DATA_DIR` is set explicitly or state is migrated manually from `~/Library/Application Support/agent-orchestrator/`.

Closes #183

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./...` passes (1264 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)