### PR TITLE
fix(renderer): stabilize onResize ref to prevent rrp constraint race

### DIFF
--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { PanelImperativeHandle, PanelSize } from "react-resizable-panels";
 import { CenterPane } from "./CenterPane";
 import { SessionInspector } from "./SessionInspector";
@@ -116,16 +116,23 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	// data-separator="active" only during a pointer drag — the same hook the
 	// transition-suppressing CSS keys on, so drag writes are never transition
 	// frames.
-	const handleInspectorResize = (size: PanelSize) => {
-		if (inspectorSeparatorRef.current?.getAttribute("data-separator") !== "active") return;
-		const open = useUiStore.getState().isInspectorOpen;
-		if (size.asPercentage > 0) {
-			window.localStorage?.setItem(inspectorSplitStorageKey, String(size.asPercentage));
-			if (!open) toggleInspector();
-		} else if (open) {
-			toggleInspector();
-		}
-	};
+	// Also wrapped in useCallback: rrp v4's panel registration useLayoutEffect
+	// includes onResize in its dep array, so an unstable reference would
+	// de-register/re-register the inspector panel on every render and race
+	// with the expand()/collapse() effect above.
+	const handleInspectorResize = useCallback(
+		(size: PanelSize) => {
+			if (inspectorSeparatorRef.current?.getAttribute("data-separator") !== "active") return;
+			const open = useUiStore.getState().isInspectorOpen;
+			if (size.asPercentage > 0) {
+				window.localStorage?.setItem(inspectorSplitStorageKey, String(size.asPercentage));
+				if (!open) toggleInspector();
+			} else if (open) {
+				toggleInspector();
+			}
+		},
+		[toggleInspector],
+	);
 
 	if (!session && !workspaceQuery.isLoading) {
 		return (


### PR DESCRIPTION
## Summary

- Wraps `handleInspectorResize` in `useCallback([toggleInspector])` in `SessionView.tsx`
- Stabilises the `onResize` reference across renders so rrp v4's panel registration `useLayoutEffect` stops de-registering/re-registering the inspector panel on every re-render
- Eliminates the "Panel constraints not found for Panel inspector" crash that tore down the session view on every sidebar click

## Root Cause (full RCA at #185)

rrp v4's `ResizablePanel` includes the `onResize` callback in its `useLayoutEffect` dependency array. `handleInspectorResize` was defined without `useCallback`, so every re-render of `SessionView` (workspace query update, daemon status change, etc.) produced a new function reference → rrp ran cleanup (removed "inspector" from its constraints map) then re-ran the effect (re-added it). With React 19's automatic batching, this cleanup window reliably overlapped with the `expand()`/`collapse()` `useEffect` on initial sidebar click, producing the rrp throw.

## Test plan

- [ ] `pnpm --filter frontend test` passes (vitest; inspector split tests cover the affected path)
- [ ] Launch Electron app, click sessions in the sidebar — no error overlay
- [ ] Toggle inspector open/close with ⌘⇧B — no error

Closes #185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)