### PR TITLE
docs: document Electron app dev quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,24 @@ go build -o /tmp/ao ./cmd/ao
 /tmp/ao session ls
 ```
 
+### Electron app (dev)
+
+The desktop supervisor lives under `frontend/` and is started separately:
+
+```bash
+cd frontend
+npm install
+npm run dev   # electron-forge start
+```
+
+Heads-up: `npm run dev` does **not** start the daemon for you. Start it first
+(`ao start`, see above) — the renderer attaches to the running daemon over
+loopback (`127.0.0.1:3001` by default, the `AO_PORT` from the table below).
+Without a daemon the app opens but shows its daemon-not-ready state.
+
+For renderer-only UI work without the Electron shell, use
+`npm run dev:web` (Vite in a regular browser).
+
 ## CLI surface
 
 The CLI is intentionally thin: every product command resolves to a daemon HTTP


### PR DESCRIPTION
## What

Adds an **"Electron app (dev)"** section to the README quick start: `npm install` + `npm run dev` under `frontend/`, plus `npm run dev:web` for renderer-only work in a regular browser.

## Why

The README's quick start covered only the daemon/CLI. People trying the desktop app also tend to expect `npm run dev` to bring the daemon up with it — it doesn't: `main.ts` has supervisor plumbing behind `AO_DAEMON_COMMAND`, but nothing invokes it yet, so the renderer attaches over loopback to a daemon started separately (`ao start`, port 3001 by default). The section states that explicitly so the daemon-not-ready state isn't a surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)