### PR TITLE
fix(project): detect the repo's default branch on add

### DIFF
--- a/backend/internal/httpd/controllers/projects_test.go
+++ b/backend/internal/httpd/controllers/projects_test.go
@@ -509,7 +509,7 @@ func gitRepo(t *testing.T, name string) string {
 
 	}
 
-	if out, err := exec.Command("git", "init", dir).CombinedOutput(); err != nil {
+	if out, err := exec.Command("git", "init", "-b", "main", dir).CombinedOutput(); err != nil {
 
 		t.Fatalf("git init fixture: %v\n%s", err, out)
 

--- a/backend/internal/service/project/service.go
+++ b/backend/internal/service/project/service.go
@@ -194,6 +194,16 @@ func (m *Service) Add(ctx context.Context, in AddInput) (Project, error) {
 	if !isGitRepo(path) {
 		return Project{}, apierr.Invalid("NOT_A_GIT_REPO", "Repository path must point to a git repository", nil)
 	}
+	// Record the repo's actual checked-out branch as the project default so
+	// session worktrees base off a branch that exists. Without this a repo on
+	// `master` (or any non-`main` default) falls back to DefaultBranchName and
+	// every spawn fails BRANCH_NOT_FETCHED. Only persist when it diverges from
+	// the default, so the common `main` repo keeps an empty (NULL) config.
+	if row.Config.DefaultBranch == "" {
+		if branch := resolveDefaultBranch(path); branch != "" && branch != domain.DefaultBranchName {
+			row.Config.DefaultBranch = branch
+		}
+	}
 	row.RepoOriginURL = resolveGitOriginURL(path)
 	if err := m.store.UpsertProject(ctx, row); err != nil {
 		return Project{}, apierr.Internal("PROJECT_ADD_FAILED", "Failed to register project")
@@ -230,6 +240,19 @@ func (m *Service) SetConfig(ctx context.Context, id domain.ProjectID, in SetConf
 // because no origin is configured (the SCM observer skips such projects).
 func resolveGitOriginURL(path string) string {
 	out, err := exec.Command("git", "-C", path, "remote", "get-url", "origin").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// resolveDefaultBranch returns the repo's currently checked-out branch via
+// `git -C path symbolic-ref --short HEAD`. A detached HEAD, missing repo, or any
+// other git error returns an empty string — `project add` must not fail just
+// because the branch can't be resolved (the caller falls back to
+// DefaultBranchName).
+func resolveDefaultBranch(path string) string {
+	out, err := exec.Command("git", "-C", path, "symbolic-ref", "--short", "HEAD").Output()
 	if err != nil {
 		return ""
 	}

--- a/backend/internal/service/project/service_test.go
+++ b/backend/internal/service/project/service_test.go
@@ -28,11 +28,24 @@ func newManager(t *testing.T) project.Manager {
 	return project.New(store)
 }
 
-// gitRepo creates a real git repository in a fresh temp dir and returns its path.
+// gitRepo creates a real git repository in a fresh temp dir and returns its
+// path. It pins the initial branch to `main` so default-branch detection is
+// deterministic regardless of the host's init.defaultBranch.
 func gitRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	if out, err := exec.Command("git", "init", dir).CombinedOutput(); err != nil {
+	if out, err := exec.Command("git", "init", "-b", "main", dir).CombinedOutput(); err != nil {
+		t.Fatalf("git unavailable: %v (%s)", err, out)
+	}
+	return dir
+}
+
+// gitRepoOnBranch creates a real git repository whose initial branch is
+// `branch`, used to exercise default-branch detection for non-`main` repos.
+func gitRepoOnBranch(t *testing.T, branch string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if out, err := exec.Command("git", "init", "-b", branch, dir).CombinedOutput(); err != nil {
 		t.Fatalf("git unavailable: %v (%s)", err, out)
 	}
 	return dir
@@ -184,6 +197,45 @@ func TestManager_DefaultsWhenUnconfigured(t *testing.T) {
 	}
 	if list[0].SessionPrefix != "ao" {
 		t.Fatalf("default session prefix = %q, want derived 'ao'", list[0].SessionPrefix)
+	}
+}
+
+func TestManager_AddDetectsNonMainDefaultBranch(t *testing.T) {
+	ctx := context.Background()
+	m := newManager(t)
+	repo := gitRepoOnBranch(t, "master")
+
+	proj, err := m.Add(ctx, project.AddInput{Path: repo, ProjectID: ptr("ao")})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	// A repo whose checked-out branch is not `main` must record that branch so
+	// session worktrees base off a ref that exists (otherwise spawn fails
+	// BRANCH_NOT_FETCHED).
+	if proj.DefaultBranch != "master" {
+		t.Fatalf("DefaultBranch = %q, want master", proj.DefaultBranch)
+	}
+
+	got, err := m.Get(ctx, "ao")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Project == nil || got.Project.DefaultBranch != "master" {
+		t.Fatalf("Get DefaultBranch = %#v, want master", got.Project)
+	}
+
+	// An explicit config wins over detection.
+	mainRepo := gitRepoOnBranch(t, "trunk")
+	proj2, err := m.Add(ctx, project.AddInput{
+		Path:      mainRepo,
+		ProjectID: ptr("ao2"),
+		Config:    &domain.ProjectConfig{DefaultBranch: "release"},
+	})
+	if err != nil {
+		t.Fatalf("Add with config: %v", err)
+	}
+	if proj2.DefaultBranch != "release" {
+		t.Fatalf("explicit DefaultBranch = %q, want release", proj2.DefaultBranch)
 	}
 }
 


### PR DESCRIPTION
Closes #208.

## Problem

`ao project add` never inspected the repo's branch, so `Config.DefaultBranch` stayed empty and `WithDefaults()` forced it to `main`. Any repo whose default branch isn't `main` (`master`, `develop`, `trunk`, …) then failed **every** `ao spawn` with a misleading `BRANCH_NOT_FETCHED` — and `project add` has no `--branch` flag, so there was no CLI workaround. This breaks the README quickstart (`project add` → `spawn`) for a large class of repos.

## Change

- Add `resolveDefaultBranch` (mirrors `resolveGitOriginURL`: best-effort `git symbolic-ref --short HEAD`, never fails `add`).
- In `Service.Add` (single-repo path), record the detected branch as `DefaultBranch` **only** when the user set none and it diverges from `main` — so the common `main` repo keeps an empty (NULL) config and behavior is unchanged there. A detached HEAD or git error falls back to the existing `main` default.

## Test

- `TestManager_AddDetectsNonMainDefaultBranch`: a `master` repo records `master`; an explicit config still wins.
- Pinned the `gitRepo` test helpers to `git init -b main` so detection is deterministic regardless of the host's `init.defaultBranch` (this is also why two existing fixtures changed).
- `go build ./...`, `go vet ./...`, and the full `go test ./...` suite pass.
- Verified end-to-end against a live daemon: a fresh `master` repo now reports `default branch: master` on `project add` and `ao spawn` succeeds (`idle` session in zellij) where it previously failed `BRANCH_NOT_FETCHED`.

## Scope note

Surgical to the single-repo path. Workspace-root projects already `git init -b main`, so they are unaffected. The misleading "run `git fetch`" wording in the `BRANCH_NOT_FETCHED` message is left as-is — with correct detection it no longer fires for this case.
