### PR TITLE
fix(spawn): reject unknown harness with 400 instead of opaque 500

### DIFF
--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -318,6 +318,8 @@ func toAPIError(err error) error {
 		return apierr.Conflict("SESSION_INCOMPLETE_HANDLE", "Session is missing runtime or workspace handles", nil)
 	case errors.Is(err, sessionmanager.ErrProjectNotResolvable):
 		return apierr.Invalid("PROJECT_NOT_RESOLVABLE", "Project is not registered or has no repo — register it with `ao project add`", nil)
+	case errors.Is(err, sessionmanager.ErrUnknownHarness):
+		return apierr.Invalid("UNKNOWN_HARNESS", err.Error(), nil)
 	case errors.Is(err, ports.ErrWorkspaceBranchCheckedOutElsewhere):
 		return apierr.Conflict("BRANCH_CHECKED_OUT_ELSEWHERE", err.Error(), nil)
 	case errors.Is(err, ports.ErrWorkspaceBranchNotFetched):

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -245,6 +245,7 @@ func TestToAPIErrorMapsWorkspaceBranchSentinels(t *testing.T) {
 		{"checked out elsewhere", fmt.Errorf("spawn mer-1: workspace: %w: \"x\" is checked out at \"/tmp\"", ports.ErrWorkspaceBranchCheckedOutElsewhere), apierr.KindConflict, "BRANCH_CHECKED_OUT_ELSEWHERE"},
 		{"not fetched", fmt.Errorf("spawn mer-1: workspace: %w: \"x\" has no local head", ports.ErrWorkspaceBranchNotFetched), apierr.KindInvalid, "BRANCH_NOT_FETCHED"},
 		{"agent binary not found", fmt.Errorf("spawn mer-1: %w", ports.ErrAgentBinaryNotFound), apierr.KindInvalid, "AGENT_BINARY_NOT_FOUND"},
+		{"unknown harness", fmt.Errorf("spawn: %w: %q", sessionmanager.ErrUnknownHarness, "bogus"), apierr.KindInvalid, "UNKNOWN_HARNESS"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -28,6 +28,10 @@ var (
 	// ErrProjectNotResolvable means the spawn's project has no usable repo
 	// (unregistered, archived, or missing a path). The API maps it to a 400.
 	ErrProjectNotResolvable = errors.New("session: project repo not resolvable")
+	// ErrUnknownHarness means the requested agent harness has no registered
+	// adapter. The API maps it to a 400 so a typo'd `--harness` is a validation
+	// error, not an opaque 500.
+	ErrUnknownHarness = errors.New("session: unknown agent harness")
 )
 
 // Env vars a spawned process reads to learn who it is.
@@ -162,6 +166,13 @@ func (m *Manager) Spawn(ctx context.Context, cfg ports.SpawnConfig) (domain.Sess
 	// A per-project role override picks the harness when the spawn names none,
 	// so a project can default workers to one agent and orchestrators to another.
 	cfg.Harness = effectiveHarness(cfg.Harness, cfg.Kind, project.Config)
+
+	// Reject an unknown harness before any durable state is created. Doing this
+	// after CreateSession would leave a terminated orphan row and waste a
+	// worktree on a spawn that can never launch.
+	if _, ok := m.agents.Agent(cfg.Harness); !ok {
+		return domain.SessionRecord{}, fmt.Errorf("spawn: %w: %q", ErrUnknownHarness, cfg.Harness)
+	}
 
 	prompt, systemPrompt, err := m.buildSpawnTexts(ctx, cfg)
 	if err != nil {

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -175,6 +175,11 @@ type singleAgent struct{ agent ports.Agent }
 
 func (s singleAgent) Agent(domain.AgentHarness) (ports.Agent, bool) { return s.agent, true }
 
+// missingAgents resolves no harness, simulating a typo'd or unregistered agent.
+type missingAgents struct{}
+
+func (missingAgents) Agent(domain.AgentHarness) (ports.Agent, bool) { return nil, false }
+
 type fakeWorkspace struct {
 	createErr  error
 	destroyErr error
@@ -726,6 +731,29 @@ func TestSpawn_RejectsMissingAgentBinary(t *testing.T) {
 	}
 	if !st.sessions["mer-1"].IsTerminated {
 		t.Fatal("the orphan row should be marked terminated after the failed spawn")
+	}
+}
+
+func TestSpawn_RejectsUnknownHarness(t *testing.T) {
+	st := newFakeStore()
+	rt := &fakeRuntime{}
+	ws := &fakeWorkspace{}
+	m := New(Deps{Runtime: rt, Agents: missingAgents{}, Workspace: ws, Store: st, Messenger: &fakeMessenger{}, Lifecycle: &fakeLCM{store: st}, LookPath: func(string) (string, error) { return "/bin/true", nil }})
+
+	_, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker, Harness: "bogus"})
+	if !errors.Is(err, ErrUnknownHarness) {
+		t.Fatalf("err = %v, want ErrUnknownHarness", err)
+	}
+	// The harness is rejected before any durable state is created — no seed row,
+	// no worktree — so an unknown harness never leaves an orphan behind.
+	if len(st.sessions) != 0 {
+		t.Fatalf("no session row should be created, got %d", len(st.sessions))
+	}
+	if ws.lastCfg.SessionID != "" || ws.destroyed != 0 {
+		t.Fatal("workspace must not be created for an unknown harness")
+	}
+	if rt.created != 0 {
+		t.Fatal("runtime must not be created for an unknown harness")
 	}
 }
 


### PR DESCRIPTION
Closes #210.

## Problem

`ao spawn --harness <unknown>` returned an opaque `INTERNAL_ERROR` 500. The harness was only resolved at `m.agents.Agent(cfg.Harness)` deep inside `Manager.Spawn` — **after** the seed row, worktree, and provisioning. On a miss it returned a plain (untyped) error, so `toAPIError` fell through to its `default` and the envelope collapsed it to 500. The late failure also left a terminated **orphan row** and a wasted worktree (the "create row before validating preconditions" pattern from #152).

This is the unknown-*harness-name* sibling of #152 Bug 6 (unknown *binary on PATH* → `AGENT_BINARY_NOT_FOUND`); that fix doesn't cover a harness with no registered adapter.

## Change

- New sentinel `ErrUnknownHarness`, mapped in `toAPIError` → `apierr.Invalid("UNKNOWN_HARNESS", ...)` (400).
- Validate the harness against the registry **immediately after `effectiveHarness`**, before `CreateSession`. No durable state is created for a doomed spawn — no orphan row, no worktree.

## Test

- `TestSpawn_RejectsUnknownHarness`: returns `ErrUnknownHarness`, and asserts **no** session row, workspace, or runtime is created.
- `TestToAPIErrorMapsWorkspaceBranchSentinels`: adds the `UNKNOWN_HARNESS` mapping case.
- `go build ./...` and full `go test ./...` pass.
- End-to-end against a live daemon: `--harness bogus-agent` now returns `unknown agent harness: "bogus-agent" (UNKNOWN_HARNESS)` (exit 1) instead of `Internal server error`; a valid `--harness codex` still spawns.
