### PR TITLE
fix(session): stamp spawn timestamps in UTC

### DIFF
--- a/backend/internal/lifecycle/manager.go
+++ b/backend/internal/lifecycle/manager.go
@@ -52,7 +52,12 @@ type Manager struct {
 
 // New builds a Lifecycle Manager over the session store it writes and the messenger it uses for agent nudges.
 func New(store sessionStore, messenger ports.AgentMessenger, opts ...Option) *Manager {
-	m := &Manager{store: store, messenger: messenger, window: defaultRecentActivityWindow, clock: time.Now, react: newReactionState()}
+	// UTC so activity-driven LastActivityAt/UpdatedAt match spawn-stamped
+	// timestamps (the session manager clock is UTC too); a local clock here left
+	// `ao session get` showing created in UTC but updated in local time. A
+	// WithClock option may still override this in tests.
+	clock := func() time.Time { return time.Now().UTC() }
+	m := &Manager{store: store, messenger: messenger, window: defaultRecentActivityWindow, clock: clock, react: newReactionState()}
 	for _, opt := range opts {
 		opt(m)
 	}

--- a/backend/internal/lifecycle/manager_test.go
+++ b/backend/internal/lifecycle/manager_test.go
@@ -146,6 +146,21 @@ func TestMarkSpawnedStoresRuntimeMetadata(t *testing.T) {
 	}
 }
 
+// TestMarkSpawned_StampsUTCActivity locks the lifecycle clock to UTC so
+// activity-driven timestamps match the session manager's spawn timestamps. A
+// local clock here left `ao session get` showing created in UTC but updated in
+// local time.
+func TestMarkSpawned_StampsUTCActivity(t *testing.T) {
+	m, st, _ := newManager()
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer", IsTerminated: true}
+	if err := m.MarkSpawned(ctx, "mer-1", domain.SessionMetadata{RuntimeHandleID: "h1"}); err != nil {
+		t.Fatal(err)
+	}
+	if loc := st.sessions["mer-1"].Activity.LastActivityAt.Location(); loc != time.UTC {
+		t.Fatalf("LastActivityAt location = %v, want UTC", loc)
+	}
+}
+
 func TestPRObservation_CIFailingNudgesAgentWithLogs(t *testing.T) {
 	m, st, msg := newManager()
 	st.sessions["mer-1"] = working("mer-1")

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -146,7 +146,10 @@ func New(d Deps) *Manager {
 		logger:         d.Logger,
 	}
 	if m.clock == nil {
-		m.clock = time.Now
+		// UTC so spawn-stamped CreatedAt/UpdatedAt match every other session
+		// write (rename, activity) — all of which use time.Now().UTC(). A local
+		// default produced mixed-timezone timestamps in `ao session get`.
+		m.clock = func() time.Time { return time.Now().UTC() }
 	}
 	if m.lookPath == nil {
 		m.lookPath = exec.LookPath

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -326,6 +326,25 @@ func TestSpawn_AssignsIDAndGoesIdle(t *testing.T) {
 		t.Fatal("handle not folded")
 	}
 }
+
+// TestSpawn_StampsUTCTimestamps locks the default clock to UTC so spawn-stamped
+// CreatedAt/UpdatedAt match every other session write (rename, activity), which
+// all use time.Now().UTC(). A local default produced mixed-timezone timestamps
+// in `ao session get` (created in local time, updated in UTC).
+func TestSpawn_StampsUTCTimestamps(t *testing.T) {
+	m, st, _, _ := newManager()
+	if _, err := m.Spawn(ctx, ports.SpawnConfig{ProjectID: "mer", Kind: domain.KindWorker}); err != nil {
+		t.Fatal(err)
+	}
+	rec := st.sessions["mer-1"]
+	if loc := rec.CreatedAt.Location(); loc != time.UTC {
+		t.Fatalf("CreatedAt location = %v, want UTC", loc)
+	}
+	if loc := rec.UpdatedAt.Location(); loc != time.UTC {
+		t.Fatalf("UpdatedAt location = %v, want UTC", loc)
+	}
+}
+
 func TestSpawn_RollsBackOnRuntimeFailure(t *testing.T) {
 	m, st, _, ws := newManager()
 	m.runtime = &fakeRuntime{createErr: errors.New("boom")}


### PR DESCRIPTION
Closes #214.

## Problem

`ao session get` showed `created` and `updated` in different timezones. **Two** clocks defaulted to local `time.Now` while the rest of the codebase writes UTC:

- the **session manager** clock → spawn-stamped `CreatedAt`/`UpdatedAt`
- the **lifecycle manager** clock → activity-driven `LastActivityAt`/`UpdatedAt`

A real spawn made the second one visible: after the first fix `createdAt` came back UTC, but `updatedAt`/`lastActivityAt` were still local (`+05:30`) the moment the agent reported activity.

## Change

Default both clocks to UTC, matching the codebase convention.

## Test

- `TestSpawn_StampsUTCTimestamps` (session manager): spawn-stamped `CreatedAt`/`UpdatedAt` are UTC.
- `TestMarkSpawned_StampsUTCActivity` (lifecycle): activity-driven `LastActivityAt` is UTC.
- `go build ./...`, full `go test ./...`, `gofmt`, and `golangci-lint` all clean.
- End-to-end: after spawn + activity, `ao session get` shows `created` and `updated` both ending in `Z`.
