### PR TITLE
fix(frontend): exclude nested node_modules from the vitest run

### DIFF
--- a/frontend/vite.renderer.config.ts
+++ b/frontend/vite.renderer.config.ts
@@ -74,7 +74,11 @@ export default defineConfig({
 	],
 	test: {
 		environment: "jsdom",
-		exclude: ["node_modules/**", "dist/**", "dist-electron/**", "e2e/**"],
+		// Anchor node_modules at any depth: a bare "node_modules/**" replaces
+		// vitest's default "**/node_modules/**" and only matches the root, so the
+		// tracked src/landing preview app's nested node_modules would otherwise
+		// have its vendored third-party test suites collected and run.
+		exclude: ["**/node_modules/**", "dist/**", "dist-electron/**", "e2e/**"],
 		globals: true,
 		setupFiles: "./src/renderer/test/setup.ts",
 	},


### PR DESCRIPTION
Closes #216.

## Problem

`frontend/vite.renderer.config.ts` set `test.exclude` to `["node_modules/**", ...]`. Providing `exclude` *replaces* vitest's default `**/node_modules/**` (it doesn't merge), and the root-anchored `node_modules/**` doesn't match nested `node_modules`. `src/landing` is a tracked, self-contained Next.js preview app with its own deps, so once those are installed, `npm test` collected and ran vendored third-party suites (zod, next, react-medium-image-zoom, style-to-js) → 20+ failures from code that isn't ours.

## Change

`"node_modules/**"` → `"**/node_modules/**"` so nested `node_modules` are excluded at any depth.

## Test

- Before: `npm test` collected 185 files / 2033 tests with 8 failed files / 20 failed tests, all under `src/landing/node_modules/**`.
- After: `npm test` collects only the renderer's **10 files / 121 tests, all passing**, with zero `src/landing/node_modules` references — and runs in ~6s instead of ~50s.
