### PR TITLE
fix(frontend): clean shell/sidebar refs after spawn modal removal

### DIFF
--- a/frontend/src/renderer/components/SessionsBoard.tsx
+++ b/frontend/src/renderer/components/SessionsBoard.tsx
@@ -99,7 +99,7 @@ export function SessionsBoard({ projectId }: SessionsBoardProps) {
 
 	return (
 		<div className="flex h-full min-h-0 flex-col bg-background text-foreground">
-			<DashboardSubhead title="Board" subtitle="Live agent sessions flowing from work → review → merge." />
+			<DashboardSubhead title={boardTitle} subtitle="Live agent sessions flowing from work → review → merge." />
 
 			<div className="min-h-0 flex-1 overflow-hidden p-[18px]">
 				{workspaceQuery.isError ? (


### PR DESCRIPTION
## Summary\n- remove undefined symbol refs left from the merged refactor\n- align Sidebar and Sidebar tests with current API (no onRemoveProject/removeProject code path)\n- keep createProject-only shell context usage\n\n## Follow-up\nThis follows up the merged #222 and fixes compile blockers introduced by refactor merge remnants.