### PR TITLE
fix(session): remove orchestrator kickoff auto-prompt on spawn

### DIFF
--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -851,7 +851,7 @@ func restoreArgv(ctx context.Context, agent ports.Agent, id domain.SessionID, wo
 		WorkspacePath: workspacePath,
 		Metadata:      map[string]string{ports.MetadataKeyAgentSessionID: meta.AgentSessionID},
 	}
-	cmd, ok, err := agent.GetRestoreCommand(ctx, ports.RestoreConfig{Session: ref, Config: agentConfig, Permissions: agentConfig.Permissions})
+	cmd, ok, err := agent.GetRestoreCommand(ctx, ports.RestoreConfig{Session: ref, SystemPrompt: systemPrompt, Config: agentConfig, Permissions: agentConfig.Permissions})
 	if err != nil {
 		return nil, fmt.Errorf("restore command: %w", err)
 	}

--- a/backend/internal/session_manager/manager.go
+++ b/backend/internal/session_manager/manager.go
@@ -594,24 +594,17 @@ func buildPrompt(cfg ports.SpawnConfig) string {
 	return cfg.Prompt
 }
 
-// orchestratorKickoffPrompt is the default first turn for an orchestrator
-// spawned without an explicit prompt. The role definition rides the system
-// prompt, and an interactive agent launched with only a system prompt sits at
-// an empty input box; this gives it a turn to act on.
-const orchestratorKickoffPrompt = "Get oriented: review the current repo state and any active worker sessions, then report your status and wait for direction."
-
 // buildSpawnTexts returns the user-facing prompt and the system prompt to
 // deliver separately to the agent. Orchestrator role instructions and worker
 // coordination hints are placed in the system prompt so they are treated as
-// standing instructions rather than part of the human's task request.
+// standing instructions rather than part of the human's task request. A
+// promptless spawn delivers no user prompt at all: the agent simply lands at an
+// empty input box rather than receiving an auto-generated kickoff turn.
 func (m *Manager) buildSpawnTexts(ctx context.Context, cfg ports.SpawnConfig) (prompt, systemPrompt string, err error) {
 	prompt = buildPrompt(cfg)
 	systemPrompt, err = m.buildSystemPrompt(ctx, cfg.Kind, cfg.ProjectID)
 	if err != nil {
 		return "", "", err
-	}
-	if cfg.Kind == domain.KindOrchestrator && prompt == "" {
-		prompt = orchestratorKickoffPrompt
 	}
 	return prompt, systemPrompt, nil
 }

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -168,6 +168,11 @@ func (a *recordingAgent) GetLaunchCommand(_ context.Context, cfg ports.LaunchCon
 func (a *recordingAgent) GetRestoreCommand(_ context.Context, cfg ports.RestoreConfig) ([]string, bool, error) {
 	a.lastConfig = cfg.Config
 	a.lastRestore = cfg
+	// Mirror real adapters: with no native agent-session id to resume, signal
+	// "cannot restore" so the manager falls back to a fresh launch.
+	if cfg.Session.Metadata[ports.MetadataKeyAgentSessionID] == "" {
+		return nil, false, nil
+	}
 	return []string{"resume"}, true, nil
 }
 

--- a/backend/internal/session_manager/manager_test.go
+++ b/backend/internal/session_manager/manager_test.go
@@ -635,10 +635,10 @@ func TestSpawnOrchestrator_UsesCoordinatorPrompt(t *testing.T) {
 		t.Fatalf("coordinator role must not be in the user prompt:\n%s", agent.lastLaunch.Prompt)
 	}
 
-	// A promptless orchestrator still needs a first turn: with the role in the
-	// system prompt only, an interactive agent would idle at an empty input box.
-	if agent.lastLaunch.Prompt != orchestratorKickoffPrompt {
-		t.Fatalf("prompt = %q, want kick-off prompt", agent.lastLaunch.Prompt)
+	// A promptless orchestrator gets no auto-generated kickoff turn: spawning
+	// must deliver nothing to the agent, leaving it idle at an empty input box.
+	if agent.lastLaunch.Prompt != "" {
+		t.Fatalf("prompt = %q, want empty (no kickoff turn)", agent.lastLaunch.Prompt)
 	}
 }
 


### PR DESCRIPTION
## What

Two fixes:

### 1. Remove orchestrator kickoff auto-prompt on spawn (issue #226)
Spawning a session without an explicit prompt injected a `"Get oriented: review the current repo state..."` kickoff turn for orchestrators, surfacing as an unsolicited message delivered on spawn. Removed the `orchestratorKickoffPrompt` auto-injection in `buildSpawnTexts`, so a promptless spawn now delivers **nothing** to the agent (it lands at an empty input box). The coordinator role still rides the system prompt, unchanged.

### 2. Re-apply derived system prompt on agent resume (pre-existing main breakage)
While running the gate, the three `TestRestore_*` cases in `session_manager` were red — and they were **already red on `main`** (the Go CI job on the latest main push is failing). Root cause: `restoreArgv` re-derives the standing system prompt but only handed it to the fresh-launch fallback, not the native `GetRestoreCommand` path, so a resumed orchestrator/worker lost its role instructions. Now `SystemPrompt` is passed through to the restore command too, matching adapters that re-append it on resume (cf. `TestGetRestoreCommandReappendsSystemPrompt` in claudecode).

The `recordingAgent` test double also returned `ok=true` unconditionally, so the fallback-launch path was never exercised; it now returns `ok=false` without an agent-session id, mirroring every real adapter.

## Changes

- `backend/internal/session_manager/manager.go`: drop `orchestratorKickoffPrompt` + its injection; pass `SystemPrompt` into the `GetRestoreCommand` `RestoreConfig`.
- `backend/internal/session_manager/manager_test.go`: `TestSpawnOrchestrator_UsesCoordinatorPrompt` asserts an empty launch prompt; `recordingAgent.GetRestoreCommand` returns `ok=false` without an agent-session id.

## Testing

`cd backend && go build ./... && go test -race ./...` → **1294 passed, 0 failed** (63 packages).

Closes #226