### PR TITLE
fix(config): migrate pre-#233 state from the old config dir to ~/.ao

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -5,7 +5,9 @@
 package config
 
 import (
+	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -153,6 +155,20 @@ func Load() (Config, error) {
 		cfg.AllowedOrigins = origins
 	}
 
+	// One-time migration of pre-#233 state from the old os.UserConfigDir()
+	// location to the canonical ~/.ao home. Only attempted in the fully-default
+	// case: an explicit AO_DATA_DIR or AO_RUN_FILE means the operator is directing
+	// paths, so we must not move data out from under them.
+	if os.Getenv("AO_DATA_DIR") == "" && os.Getenv("AO_RUN_FILE") == "" {
+		if legacy, err := migrateLegacyStateDir(); err != nil {
+			slog.Warn("config: could not migrate pre-#233 state to ~/.ao; your previous "+
+				"projects and sessions remain at the old location and must be moved by hand",
+				"legacy", legacy, "err", err)
+		} else if legacy != "" {
+			slog.Info("config: migrated pre-#233 state dir to ~/.ao", "from", legacy)
+		}
+	}
+
 	runFile, err := resolveRunFilePath()
 	if err != nil {
 		return Config{}, err
@@ -216,4 +232,51 @@ func defaultStateDir() (string, error) {
 		return "", fmt.Errorf("resolve state dir: %w", err)
 	}
 	return filepath.Join(homeDir, ".ao"), nil
+}
+
+// legacyStateDirName is the directory the daemon used under os.UserConfigDir()
+// before #233 moved the canonical state home to ~/.ao (e.g.
+// ~/.config/agent-orchestrator on Linux, ~/Library/Application Support/
+// agent-orchestrator on macOS). Its internal layout (data/, running.json) is
+// identical to the new home, so a whole-directory move preserves everything.
+const legacyStateDirName = "agent-orchestrator"
+
+// migrateLegacyStateDir performs a one-time, best-effort move of pre-#233 state
+// into the canonical ~/.ao home. It runs only when the canonical home does not
+// yet exist and the legacy directory does, so an upgrading user keeps their
+// projects/sessions instead of silently booting against an empty database.
+//
+// It never overwrites an existing ~/.ao, and on any failure it leaves the legacy
+// data untouched (and therefore still recoverable). The returned string is the
+// legacy path that was moved, or "" when there was nothing to migrate.
+func migrateLegacyStateDir() (string, error) {
+	stateDir, err := defaultStateDir()
+	if err != nil {
+		return "", err
+	}
+	switch _, statErr := os.Stat(stateDir); {
+	case statErr == nil:
+		return "", nil // canonical home already exists — never clobber it
+	case !errors.Is(statErr, os.ErrNotExist):
+		return "", fmt.Errorf("stat %s: %w", stateDir, statErr)
+	}
+
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		//nolint:nilerr // no resolvable config dir simply means no legacy state to migrate
+		return "", nil
+	}
+	legacy := filepath.Join(configDir, legacyStateDirName)
+	if info, statErr := os.Stat(legacy); statErr != nil || !info.IsDir() {
+		//nolint:nilerr // an absent/unreadable legacy dir is not a Load failure — nothing to migrate
+		return "", nil
+	}
+
+	// Atomic when both live on one filesystem, which is the common case (both
+	// under $HOME). A cross-device legacy location fails here and surfaces as a
+	// warning rather than a silent, partial copy.
+	if err := os.Rename(legacy, stateDir); err != nil {
+		return legacy, fmt.Errorf("move %s to %s: %w", legacy, stateDir, err)
+	}
+	return legacy, nil
 }

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -104,6 +105,116 @@ func TestLoadInvalid(t *testing.T) {
 			}
 		})
 	}
+}
+
+// seedLegacyState lays down a fake pre-#233 state dir under the resolved
+// os.UserConfigDir() and returns the legacy root plus the marker DB path.
+func seedLegacyState(t *testing.T) (legacyRoot, dbPath string) {
+	t.Helper()
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir: %v", err)
+	}
+	legacyRoot = filepath.Join(configDir, legacyStateDirName)
+	dbPath = filepath.Join(legacyRoot, "data", "ao.db")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o750); err != nil {
+		t.Fatalf("seed legacy data dir: %v", err)
+	}
+	if err := os.WriteFile(dbPath, []byte("legacy-db-marker"), 0o600); err != nil {
+		t.Fatalf("seed legacy db: %v", err)
+	}
+	return legacyRoot, dbPath
+}
+
+func TestLegacyStateDirMigration(t *testing.T) {
+	// Isolate HOME and XDG_CONFIG_HOME so UserHomeDir/UserConfigDir resolve into
+	// the temp dir, and clear path overrides so Load takes the default branch.
+	t.Run("migrates pre-#233 state when ~/.ao is absent", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)                                         // UserHomeDir on unix
+		t.Setenv("USERPROFILE", home)                                  // UserHomeDir on Windows
+		t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))    // UserConfigDir on Linux
+		t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming")) // UserConfigDir on Windows
+		t.Setenv("AO_DATA_DIR", "")
+		t.Setenv("AO_RUN_FILE", "")
+
+		legacyRoot, _ := seedLegacyState(t)
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		// The marker DB now lives under the canonical home...
+		migrated := filepath.Join(cfg.DataDir, "ao.db")
+		got, err := os.ReadFile(migrated)
+		if err != nil {
+			t.Fatalf("read migrated db at %s: %v", migrated, err)
+		}
+		if string(got) != "legacy-db-marker" {
+			t.Errorf("migrated db = %q, want legacy-db-marker", got)
+		}
+		// ...and the legacy directory is gone (it was moved, not copied).
+		if _, err := os.Stat(legacyRoot); !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("legacy dir still present after migration: stat err = %v", err)
+		}
+	})
+
+	t.Run("does not clobber an existing ~/.ao", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)                                         // UserHomeDir on unix
+		t.Setenv("USERPROFILE", home)                                  // UserHomeDir on Windows
+		t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))    // UserConfigDir on Linux
+		t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming")) // UserConfigDir on Windows
+		t.Setenv("AO_DATA_DIR", "")
+		t.Setenv("AO_RUN_FILE", "")
+
+		// Canonical home already exists with its own DB.
+		canonicalDB := filepath.Join(home, ".ao", "data", "ao.db")
+		if err := os.MkdirAll(filepath.Dir(canonicalDB), 0o750); err != nil {
+			t.Fatalf("seed canonical: %v", err)
+		}
+		if err := os.WriteFile(canonicalDB, []byte("canonical-db"), 0o600); err != nil {
+			t.Fatalf("seed canonical db: %v", err)
+		}
+		legacyRoot, legacyDB := seedLegacyState(t)
+
+		if _, err := Load(); err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		// Canonical untouched, legacy left in place (recoverable).
+		got, _ := os.ReadFile(canonicalDB)
+		if string(got) != "canonical-db" {
+			t.Errorf("canonical db = %q, want canonical-db (must not be overwritten)", got)
+		}
+		if _, err := os.Stat(legacyDB); err != nil {
+			t.Errorf("legacy db should be left untouched, stat err = %v", err)
+		}
+		_ = legacyRoot
+	})
+
+	t.Run("explicit AO_DATA_DIR disables migration", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)                                         // UserHomeDir on unix
+		t.Setenv("USERPROFILE", home)                                  // UserHomeDir on Windows
+		t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))    // UserConfigDir on Linux
+		t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming")) // UserConfigDir on Windows
+		t.Setenv("AO_DATA_DIR", filepath.Join(home, "explicit-data"))
+		t.Setenv("AO_RUN_FILE", "")
+
+		legacyRoot, legacyDB := seedLegacyState(t)
+
+		if _, err := Load(); err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		// Operator-directed paths: legacy data must be left exactly where it is.
+		if _, err := os.Stat(legacyDB); err != nil {
+			t.Errorf("legacy db moved despite explicit AO_DATA_DIR: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(home, ".ao")); !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("~/.ao created despite explicit AO_DATA_DIR: stat err = %v", err)
+		}
+		_ = legacyRoot
+	})
 }
 
 func TestLoadAllowedOrigins(t *testing.T) {


### PR DESCRIPTION
Closes #238.

## Problem

[#233](https://github.com/aoagents/ReverbCode/pull/233) moved the canonical state home from `os.UserConfigDir()/agent-orchestrator` to `~/.ao` but shipped **no migration**. Any user upgrading from a pre-#233 build boots the daemon against a fresh empty `~/.ao/data/ao.db` and silently loses every project, session, PR record, review run, and notification (the old DB is orphaned, not deleted).

## Fix

A one-time, best-effort migration in `config.Load()`:

- Runs only when `~/.ao` does **not** yet exist but the legacy dir does.
- Moves the legacy directory into place with an **atomic `os.Rename`** — the internal layout (`data/`, `running.json`) is identical between the two homes, so a whole-directory move preserves everything.
- Only in the **fully-default path**: an explicit `AO_DATA_DIR` or `AO_RUN_FILE` means the operator is directing paths, so nothing is moved.
- **Never overwrites** an existing `~/.ao`, and **never fails `Load`**: on any error (e.g. a cross-device legacy location where rename can't be atomic) the legacy data is left untouched — and therefore recoverable — and a warning logs the old location.

## Known limitation

Worktree paths stored as absolute strings in the DB still point at the old parent after the move; live pre-upgrade worktrees are generally dead anyway, and project/session/PR history (the valuable state) is fully preserved. Rewriting stored worktree paths is out of scope for this fix.

## Test

`internal/config/config_test.go` adds `TestLegacyStateDirMigration` covering three cases:
1. migrates pre-#233 state when `~/.ao` is absent (marker DB lands under `~/.ao`, legacy dir gone);
2. does **not** clobber an existing `~/.ao` (canonical DB preserved, legacy left in place);
3. an explicit `AO_DATA_DIR` disables migration entirely.

Gate: `go build ./...`, `gofmt -l`, `golangci-lint run ./internal/config/...` (0 issues), full `go test ./...` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)