### PR TITLE
feat(frontend): show reviewer worker controls

### DIFF
--- a/frontend/src/renderer/components/CenterPane.tsx
+++ b/frontend/src/renderer/components/CenterPane.tsx
@@ -1,4 +1,6 @@
+import { ChevronLeft, Shield } from "lucide-react";
 import type { Theme } from "../stores/ui-store";
+import type { TerminalTarget } from "../types/terminal";
 import type { WorkspaceSession } from "../types/workspace";
 import { TerminalPane } from "./TerminalPane";
 
@@ -6,13 +8,35 @@ type CenterPaneProps = {
 	session?: WorkspaceSession;
 	theme: Theme;
 	daemonReady: boolean;
+	terminalTarget?: TerminalTarget;
+	onSelectWorkerTerminal?: () => void;
 };
 
-export function CenterPane({ session, theme, daemonReady }: CenterPaneProps) {
+export function CenterPane({ session, theme, daemonReady, terminalTarget, onSelectWorkerTerminal }: CenterPaneProps) {
+	const target = terminalTarget ?? { kind: "worker" };
+
 	return (
 		<div className="flex h-full min-h-0 min-w-0 flex-col bg-background">
+			{target.kind === "reviewer" ? (
+				<div className="reviewer-terminal-header">
+					<button
+						aria-label="Back to agent terminal"
+						className="reviewer-terminal-header__back"
+						onClick={onSelectWorkerTerminal}
+						type="button"
+					>
+						<ChevronLeft aria-hidden="true" />
+						<span>agent</span>
+					</button>
+					<span className="reviewer-terminal-header__role">
+						<Shield aria-hidden="true" />
+						Reviewer
+					</span>
+					<span className="reviewer-terminal-header__harness">{target.harness}</span>
+				</div>
+			) : null}
 			<div className="min-h-0 flex-1">
-				<TerminalPane session={session} theme={theme} daemonReady={daemonReady} />
+				<TerminalPane daemonReady={daemonReady} session={session} terminalTarget={target} theme={theme} />
 			</div>
 		</div>
 	);

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -51,96 +51,92 @@ beforeEach(() => {
 });
 
 describe("ProjectSettingsForm", () => {
-	it(
-		"loads the current project settings and saves the exposed fields without dropping hidden config",
-		async () => {
-			getMock.mockResolvedValue({
-				data: {
-					status: "ok",
-					project: {
-						id: "proj-1",
-						name: "Project One",
-						kind: "single_repo",
-						path: "/repo/project-one",
-						repo: "git@github.com:acme/project-one.git",
-						defaultBranch: "main",
-						config: {
-							defaultBranch: "develop",
-							sessionPrefix: "po",
-							env: { FOO: "bar" },
-							symlinks: [".env"],
-							postCreate: ["npm install"],
-							worker: {
-								agent: "codex",
-								agentConfig: { model: "worker-model" },
-							},
-							orchestrator: { agent: "claude-code" },
-							agentConfig: {
-								model: "claude-opus-4-5",
-								permissions: "auto",
-							},
-							reviewers: [{ harness: "claude-code" }],
-						},
-					},
-				},
-				error: undefined,
-			});
-
-			renderSettings();
-
-			expect(await screen.findByText("git@github.com:acme/project-one.git")).toBeInTheDocument();
-			expect(screen.getByLabelText("Default branch")).toHaveValue("develop");
-			expect(screen.getByLabelText("Session prefix")).toHaveValue("po");
-			expect(screen.getByLabelText("Model override")).toHaveValue("claude-opus-4-5");
-
-			const workerAgent = screen.getByRole("combobox", { name: "Default worker agent" });
-			const orchestratorAgent = screen.getByRole("combobox", { name: "Default orchestrator agent" });
-			const permissionMode = screen.getByRole("combobox", { name: "Permission mode" });
-			const reviewerAgent = screen.getByRole("combobox", { name: "Default reviewer agent" });
-			expect(workerAgent).toHaveTextContent("codex");
-			expect(orchestratorAgent).toHaveTextContent("claude-code");
-			expect(permissionMode).toHaveTextContent("Auto");
-			expect(reviewerAgent).toHaveTextContent("claude-code");
-
-			await userEvent.clear(screen.getByLabelText("Default branch"));
-			await userEvent.type(screen.getByLabelText("Default branch"), "release");
-			await userEvent.clear(screen.getByLabelText("Session prefix"));
-			await userEvent.type(screen.getByLabelText("Session prefix"), "rel");
-			await userEvent.clear(screen.getByLabelText("Model override"));
-			await userEvent.type(screen.getByLabelText("Model override"), "gpt-5-codex");
-			await chooseOption(workerAgent, "opencode");
-			await chooseOption(orchestratorAgent, "goose");
-			await chooseOption(permissionMode, "Bypass permissions");
-
-			await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
-
-			await waitFor(() => expect(putMock).toHaveBeenCalledTimes(1));
-			expect(putMock).toHaveBeenCalledWith("/api/v1/projects/{id}/config", {
-				params: { path: { id: "proj-1" } },
-				body: {
+	it("loads the current project settings and saves the exposed fields without dropping hidden config", async () => {
+		getMock.mockResolvedValue({
+			data: {
+				status: "ok",
+				project: {
+					id: "proj-1",
+					name: "Project One",
+					kind: "single_repo",
+					path: "/repo/project-one",
+					repo: "git@github.com:acme/project-one.git",
+					defaultBranch: "main",
 					config: {
-						defaultBranch: "release",
-						sessionPrefix: "rel",
+						defaultBranch: "develop",
+						sessionPrefix: "po",
 						env: { FOO: "bar" },
 						symlinks: [".env"],
 						postCreate: ["npm install"],
 						worker: {
-							agent: "opencode",
+							agent: "codex",
 							agentConfig: { model: "worker-model" },
 						},
-						orchestrator: { agent: "goose" },
+						orchestrator: { agent: "claude-code" },
 						agentConfig: {
-							model: "gpt-5-codex",
-							permissions: "bypass-permissions",
+							model: "claude-opus-4-5",
+							permissions: "auto",
 						},
 						reviewers: [{ harness: "claude-code" }],
 					},
 				},
-			});
-			expect(await screen.findByText("Saved.")).toBeInTheDocument();
-		},
-		10_000,
-	);
+			},
+			error: undefined,
+		});
+
+		renderSettings();
+
+		expect(await screen.findByText("git@github.com:acme/project-one.git")).toBeInTheDocument();
+		expect(screen.getByLabelText("Default branch")).toHaveValue("develop");
+		expect(screen.getByLabelText("Session prefix")).toHaveValue("po");
+		expect(screen.getByLabelText("Model override")).toHaveValue("claude-opus-4-5");
+
+		const workerAgent = screen.getByRole("combobox", { name: "Default worker agent" });
+		const orchestratorAgent = screen.getByRole("combobox", { name: "Default orchestrator agent" });
+		const permissionMode = screen.getByRole("combobox", { name: "Permission mode" });
+		const reviewerAgent = screen.getByRole("combobox", { name: "Default reviewer agent" });
+		expect(workerAgent).toHaveTextContent("codex");
+		expect(orchestratorAgent).toHaveTextContent("claude-code");
+		expect(permissionMode).toHaveTextContent("Auto");
+		expect(reviewerAgent).toHaveTextContent("claude-code");
+
+		await userEvent.clear(screen.getByLabelText("Default branch"));
+		await userEvent.type(screen.getByLabelText("Default branch"), "release");
+		await userEvent.clear(screen.getByLabelText("Session prefix"));
+		await userEvent.type(screen.getByLabelText("Session prefix"), "rel");
+		await userEvent.clear(screen.getByLabelText("Model override"));
+		await userEvent.type(screen.getByLabelText("Model override"), "gpt-5-codex");
+		await chooseOption(workerAgent, "opencode");
+		await chooseOption(orchestratorAgent, "goose");
+		await chooseOption(permissionMode, "Bypass permissions");
+
+		await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+		await waitFor(() => expect(putMock).toHaveBeenCalledTimes(1));
+		expect(putMock).toHaveBeenCalledWith("/api/v1/projects/{id}/config", {
+			params: { path: { id: "proj-1" } },
+			body: {
+				config: {
+					defaultBranch: "release",
+					sessionPrefix: "rel",
+					env: { FOO: "bar" },
+					symlinks: [".env"],
+					postCreate: ["npm install"],
+					worker: {
+						agent: "opencode",
+						agentConfig: { model: "worker-model" },
+					},
+					orchestrator: { agent: "goose" },
+					agentConfig: {
+						model: "gpt-5-codex",
+						permissions: "bypass-permissions",
+					},
+					reviewers: [{ harness: "claude-code" }],
+				},
+			},
+		});
+		expect(await screen.findByText("Saved.")).toBeInTheDocument();
+	}, 10_000);
 
 	it("shows the daemon validation message when save fails", async () => {
 		getMock.mockResolvedValue({

--- a/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.test.tsx
@@ -51,88 +51,96 @@ beforeEach(() => {
 });
 
 describe("ProjectSettingsForm", () => {
-	it("loads the current project settings and saves the exposed fields without dropping hidden config", async () => {
-		getMock.mockResolvedValue({
-			data: {
-				status: "ok",
-				project: {
-					id: "proj-1",
-					name: "Project One",
-					kind: "single_repo",
-					path: "/repo/project-one",
-					repo: "git@github.com:acme/project-one.git",
-					defaultBranch: "main",
+	it(
+		"loads the current project settings and saves the exposed fields without dropping hidden config",
+		async () => {
+			getMock.mockResolvedValue({
+				data: {
+					status: "ok",
+					project: {
+						id: "proj-1",
+						name: "Project One",
+						kind: "single_repo",
+						path: "/repo/project-one",
+						repo: "git@github.com:acme/project-one.git",
+						defaultBranch: "main",
+						config: {
+							defaultBranch: "develop",
+							sessionPrefix: "po",
+							env: { FOO: "bar" },
+							symlinks: [".env"],
+							postCreate: ["npm install"],
+							worker: {
+								agent: "codex",
+								agentConfig: { model: "worker-model" },
+							},
+							orchestrator: { agent: "claude-code" },
+							agentConfig: {
+								model: "claude-opus-4-5",
+								permissions: "auto",
+							},
+							reviewers: [{ harness: "claude-code" }],
+						},
+					},
+				},
+				error: undefined,
+			});
+
+			renderSettings();
+
+			expect(await screen.findByText("git@github.com:acme/project-one.git")).toBeInTheDocument();
+			expect(screen.getByLabelText("Default branch")).toHaveValue("develop");
+			expect(screen.getByLabelText("Session prefix")).toHaveValue("po");
+			expect(screen.getByLabelText("Model override")).toHaveValue("claude-opus-4-5");
+
+			const workerAgent = screen.getByRole("combobox", { name: "Default worker agent" });
+			const orchestratorAgent = screen.getByRole("combobox", { name: "Default orchestrator agent" });
+			const permissionMode = screen.getByRole("combobox", { name: "Permission mode" });
+			const reviewerAgent = screen.getByRole("combobox", { name: "Default reviewer agent" });
+			expect(workerAgent).toHaveTextContent("codex");
+			expect(orchestratorAgent).toHaveTextContent("claude-code");
+			expect(permissionMode).toHaveTextContent("Auto");
+			expect(reviewerAgent).toHaveTextContent("claude-code");
+
+			await userEvent.clear(screen.getByLabelText("Default branch"));
+			await userEvent.type(screen.getByLabelText("Default branch"), "release");
+			await userEvent.clear(screen.getByLabelText("Session prefix"));
+			await userEvent.type(screen.getByLabelText("Session prefix"), "rel");
+			await userEvent.clear(screen.getByLabelText("Model override"));
+			await userEvent.type(screen.getByLabelText("Model override"), "gpt-5-codex");
+			await chooseOption(workerAgent, "opencode");
+			await chooseOption(orchestratorAgent, "goose");
+			await chooseOption(permissionMode, "Bypass permissions");
+
+			await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+			await waitFor(() => expect(putMock).toHaveBeenCalledTimes(1));
+			expect(putMock).toHaveBeenCalledWith("/api/v1/projects/{id}/config", {
+				params: { path: { id: "proj-1" } },
+				body: {
 					config: {
-						defaultBranch: "develop",
-						sessionPrefix: "po",
+						defaultBranch: "release",
+						sessionPrefix: "rel",
 						env: { FOO: "bar" },
 						symlinks: [".env"],
 						postCreate: ["npm install"],
 						worker: {
-							agent: "codex",
+							agent: "opencode",
 							agentConfig: { model: "worker-model" },
 						},
-						orchestrator: { agent: "claude-code" },
+						orchestrator: { agent: "goose" },
 						agentConfig: {
-							model: "claude-opus-4-5",
-							permissions: "auto",
+							model: "gpt-5-codex",
+							permissions: "bypass-permissions",
 						},
+						reviewers: [{ harness: "claude-code" }],
 					},
 				},
-			},
-			error: undefined,
-		});
-
-		renderSettings();
-
-		expect(await screen.findByText("git@github.com:acme/project-one.git")).toBeInTheDocument();
-		expect(screen.getByLabelText("Default branch")).toHaveValue("develop");
-		expect(screen.getByLabelText("Session prefix")).toHaveValue("po");
-		expect(screen.getByLabelText("Model override")).toHaveValue("claude-opus-4-5");
-
-		const workerAgent = screen.getByRole("combobox", { name: "Default worker agent" });
-		const orchestratorAgent = screen.getByRole("combobox", { name: "Default orchestrator agent" });
-		const permissionMode = screen.getByRole("combobox", { name: "Permission mode" });
-		expect(workerAgent).toHaveTextContent("codex");
-		expect(orchestratorAgent).toHaveTextContent("claude-code");
-		expect(permissionMode).toHaveTextContent("Auto");
-
-		await userEvent.clear(screen.getByLabelText("Default branch"));
-		await userEvent.type(screen.getByLabelText("Default branch"), "release");
-		await userEvent.clear(screen.getByLabelText("Session prefix"));
-		await userEvent.type(screen.getByLabelText("Session prefix"), "rel");
-		await userEvent.clear(screen.getByLabelText("Model override"));
-		await userEvent.type(screen.getByLabelText("Model override"), "gpt-5-codex");
-		await chooseOption(workerAgent, "opencode");
-		await chooseOption(orchestratorAgent, "goose");
-		await chooseOption(permissionMode, "Bypass permissions");
-
-		await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
-
-		await waitFor(() => expect(putMock).toHaveBeenCalledTimes(1));
-		expect(putMock).toHaveBeenCalledWith("/api/v1/projects/{id}/config", {
-			params: { path: { id: "proj-1" } },
-			body: {
-				config: {
-					defaultBranch: "release",
-					sessionPrefix: "rel",
-					env: { FOO: "bar" },
-					symlinks: [".env"],
-					postCreate: ["npm install"],
-					worker: {
-						agent: "opencode",
-						agentConfig: { model: "worker-model" },
-					},
-					orchestrator: { agent: "goose" },
-					agentConfig: {
-						model: "gpt-5-codex",
-						permissions: "bypass-permissions",
-					},
-				},
-			},
-		});
-		expect(await screen.findByText("Saved.")).toBeInTheDocument();
-	});
+			});
+			expect(await screen.findByText("Saved.")).toBeInTheDocument();
+		},
+		10_000,
+	);
 
 	it("shows the daemon validation message when save fails", async () => {
 		getMock.mockResolvedValue({

--- a/frontend/src/renderer/components/ProjectSettingsForm.tsx
+++ b/frontend/src/renderer/components/ProjectSettingsForm.tsx
@@ -22,6 +22,8 @@ const PERMISSION_MODE_OPTIONS = [
 	{ value: "bypass-permissions", label: "Bypass permissions" },
 ] as const;
 
+const REVIEWER_OPTIONS = ["claude-code"] as const;
+
 const projectQueryKey = (id: string) => ["project", id] as const;
 
 export function ProjectSettingsForm({ projectId }: { projectId: string }) {
@@ -73,6 +75,7 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 		orchestratorAgent: config.orchestrator?.agent ?? "",
 		model: config.agentConfig?.model ?? "",
 		permissions: config.agentConfig?.permissions ?? "",
+		reviewerHarness: config.reviewers?.[0]?.harness ?? "",
 	});
 	const [savedAt, setSavedAt] = useState<number | null>(null);
 
@@ -91,6 +94,7 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 					model: form.model || undefined,
 					permissions: form.permissions || undefined,
 				}),
+				reviewers: form.reviewerHarness ? [{ harness: form.reviewerHarness }] : undefined,
 			};
 			const { error } = await apiClient.PUT("/api/v1/projects/{id}/config", {
 				params: { path: { id: projectId } },
@@ -188,6 +192,21 @@ function SettingsBody({ project, projectId, onSaved }: { project: Project; proje
 				</CardContent>
 			</Card>
 
+			<Card>
+				<CardHeader>
+					<CardTitle className="text-[13px]">Reviewers</CardTitle>
+				</CardHeader>
+				<CardContent className="flex flex-col gap-4">
+					<Field label="Default reviewer agent" htmlFor="reviewerHarness">
+						<ReviewerSelect
+							id="reviewerHarness"
+							value={form.reviewerHarness}
+							onChange={(v) => setForm((f) => ({ ...f, reviewerHarness: v }))}
+						/>
+					</Field>
+				</CardContent>
+			</Card>
+
 			<div className="flex items-center gap-3">
 				<Button type="submit" variant="primary" disabled={mutation.isPending}>
 					{mutation.isPending ? "Saving…" : "Save changes"}
@@ -243,6 +262,24 @@ function AgentSelect({ id, value, onChange }: { id: string; value: string; onCha
 				{AGENT_OPTIONS.map((agent) => (
 					<SelectItem key={agent} value={agent}>
 						{agent}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}
+
+function ReviewerSelect({ id, value, onChange }: { id: string; value: string; onChange: (value: string) => void }) {
+	return (
+		<Select value={value || "__default__"} onValueChange={(v) => onChange(v === "__default__" ? "" : v)}>
+			<SelectTrigger id={id} className="h-8 w-full text-[13px]">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				<SelectItem value="__default__">Project default</SelectItem>
+				{REVIEWER_OPTIONS.map((reviewer) => (
+					<SelectItem key={reviewer} value={reviewer}>
+						{reviewer}
 					</SelectItem>
 				))}
 			</SelectContent>

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -12,8 +12,7 @@ const api = vi.hoisted(() => ({
 
 vi.mock("../lib/api-client", () => ({
 	apiClient: api,
-	apiErrorMessage: (error: unknown, fallback = "Request failed") =>
-		error instanceof Error ? error.message : fallback,
+	apiErrorMessage: (error: unknown, fallback = "Request failed") => (error instanceof Error ? error.message : fallback),
 }));
 
 const session = {

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -48,7 +48,10 @@ const reviewSession = {
 	pullRequest: { number: 3, state: "open" },
 } satisfies WorkspaceSession;
 
-function renderInspector(session: WorkspaceSession = worker, onOpenReviewerTerminal?: Parameters<typeof SessionInspector>[0]["onOpenReviewerTerminal"]) {
+function renderInspector(
+	session: WorkspaceSession = worker,
+	onOpenReviewerTerminal?: Parameters<typeof SessionInspector>[0]["onOpenReviewerTerminal"],
+) {
 	const queryClient = new QueryClient({
 		defaultOptions: {
 			queries: { retry: false },

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -1,0 +1,150 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionInspector } from "./SessionInspector";
+import type { WorkspaceSession } from "../types/workspace";
+
+const api = vi.hoisted(() => ({
+	GET: vi.fn(),
+	POST: vi.fn(),
+}));
+
+vi.mock("../lib/api-client", () => ({
+	apiClient: api,
+	apiErrorMessage: (error: unknown, fallback = "Request failed") =>
+		error instanceof Error ? error.message : fallback,
+}));
+
+const session = {
+	id: "sess-1",
+	terminalHandleId: "worker-pane",
+	workspaceId: "proj-1",
+	workspaceName: "my-app",
+	title: "review me",
+	provider: "codex",
+	kind: "worker",
+	branch: "session/sess-1",
+	status: "working",
+	createdAt: "2026-06-16T10:00:00Z",
+	updatedAt: "2026-06-16T10:05:00Z",
+	pullRequest: { number: 3, state: "open" },
+} satisfies WorkspaceSession;
+
+function renderWithQuery(children: ReactNode) {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return render(<QueryClientProvider client={client}>{children}</QueryClientProvider>);
+}
+
+function mockCommonGets(reviews: unknown[] = [], reviewerHandleId = "") {
+	api.GET.mockImplementation(async (path: string) => {
+		if (path === "/api/v1/sessions/{sessionId}/pr") {
+			return {
+				data: {
+					prs: [
+						{
+							url: "https://github.com/aoagents/reverbcode/pull/3",
+							number: 3,
+							state: "open",
+							ci: "passing",
+							review: "required",
+							mergeability: "mergeable",
+							reviewComments: false,
+							updatedAt: "2026-06-16T10:05:00Z",
+						},
+					],
+				},
+			};
+		}
+		if (path === "/api/v1/sessions/{sessionId}/reviews") {
+			return { data: { reviewerHandleId, reviews } };
+		}
+		if (path === "/api/v1/projects/{id}") {
+			return {
+				data: {
+					status: "ok",
+					project: {
+						id: "proj-1",
+						kind: "git",
+						name: "my-app",
+						path: "/repo",
+						repo: "my-app",
+						defaultBranch: "main",
+						config: { reviewers: [{ harness: "codex" }] },
+					},
+				},
+			};
+		}
+		return { data: undefined };
+	});
+}
+
+describe("SessionInspector reviews", () => {
+	beforeEach(() => {
+		api.GET.mockReset();
+		api.POST.mockReset();
+	});
+
+	it("triggers a review and opens the returned reviewer terminal", async () => {
+		mockCommonGets();
+		api.POST.mockResolvedValue({
+			data: {
+				reviewerHandleId: "reviewer-pane",
+				review: {
+					id: "run-1",
+					reviewId: "review-1",
+					sessionId: "sess-1",
+					harness: "codex",
+					status: "running",
+					verdict: "",
+					body: "",
+					prUrl: "https://github.com/aoagents/reverbcode/pull/3",
+					targetSha: "abc123",
+					createdAt: "2026-06-16T10:06:00Z",
+				},
+			},
+		});
+		const onOpenReviewerTerminal = vi.fn();
+
+		renderWithQuery(<SessionInspector onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} />);
+
+		fireEvent.click(await screen.findByRole("button", { name: /run review/i }));
+
+		await waitFor(() =>
+			expect(api.POST).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/reviews/trigger", {
+				params: { path: { sessionId: "sess-1" } },
+			}),
+		);
+		expect(onOpenReviewerTerminal).toHaveBeenCalledWith({ handleId: "reviewer-pane", harness: "codex" });
+	});
+
+	it("shows an approved review and opens its terminal", async () => {
+		mockCommonGets(
+			[
+				{
+					id: "run-1",
+					reviewId: "review-1",
+					sessionId: "sess-1",
+					harness: "codex",
+					status: "complete",
+					verdict: "approved",
+					body: "Looks good.",
+					prUrl: "https://github.com/aoagents/reverbcode/pull/3",
+					targetSha: "abc123",
+					createdAt: "2026-06-16T10:06:00Z",
+				},
+			],
+			"reviewer-pane",
+		);
+		const onOpenReviewerTerminal = vi.fn();
+
+		renderWithQuery(<SessionInspector onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} />);
+
+		await waitFor(() => expect(screen.getAllByText("Approved").length).toBeGreaterThan(0));
+		fireEvent.click(screen.getByRole("button", { name: /open terminal/i }));
+
+		expect(onOpenReviewerTerminal).toHaveBeenCalledWith({ handleId: "reviewer-pane", harness: "codex" });
+	});
+});

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -119,6 +119,52 @@ describe("SessionInspector reviews", () => {
 		expect(onOpenReviewerTerminal).toHaveBeenCalledWith({ handleId: "reviewer-pane", harness: "codex" });
 	});
 
+	it("shows an up-to-date notice instead of opening the terminal when the backend reuses a run", async () => {
+		mockCommonGets(
+			[
+				{
+					id: "run-1",
+					reviewId: "review-1",
+					sessionId: "sess-1",
+					harness: "codex",
+					status: "complete",
+					verdict: "approved",
+					body: "Looks good.",
+					prUrl: "https://github.com/aoagents/reverbcode/pull/3",
+					targetSha: "abc123",
+					createdAt: "2026-06-16T10:06:00Z",
+				},
+			],
+			"reviewer-pane",
+		);
+		api.POST.mockResolvedValue({
+			response: { status: 200 },
+			data: {
+				reviewerHandleId: "reviewer-pane",
+				review: {
+					id: "run-1",
+					reviewId: "review-1",
+					sessionId: "sess-1",
+					harness: "codex",
+					status: "complete",
+					verdict: "approved",
+					body: "Looks good.",
+					prUrl: "https://github.com/aoagents/reverbcode/pull/3",
+					targetSha: "abc123",
+					createdAt: "2026-06-16T10:06:00Z",
+				},
+			},
+		});
+		const onOpenReviewerTerminal = vi.fn();
+
+		renderWithQuery(<SessionInspector onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} />);
+
+		fireEvent.click(await screen.findByRole("button", { name: /re-run review/i }));
+
+		expect(await screen.findByText("Review is already up to date for this commit.")).toBeInTheDocument();
+		expect(onOpenReviewerTerminal).not.toHaveBeenCalled();
+	});
+
 	it("shows an approved review and opens its terminal", async () => {
 		mockCommonGets(
 			[

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -122,9 +122,7 @@ export function SessionInspector({
 			</div>
 
 			<div className="session-inspector__body">
-				{view === "summary" ? (
-					<SummaryView onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} />
-				) : null}
+				{view === "summary" ? <SummaryView onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} /> : null}
 				{view === "changes" ? <ChangesView session={session} /> : null}
 				{view === "browser" ? <BrowserView /> : null}
 			</div>
@@ -401,7 +399,11 @@ function ReviewerCard({
 	);
 }
 
-function reviewStatus(review?: ReviewRun): { label: string; tone: "neutral" | "running" | "success" | "danger"; icon: ReactNode } {
+function reviewStatus(review?: ReviewRun): {
+	label: string;
+	tone: "neutral" | "running" | "success" | "danger";
+	icon: ReactNode;
+} {
 	if (!review) return { label: "Not run", tone: "neutral", icon: null };
 	if (review.status === "running") {
 		return { label: "Running", tone: "running", icon: <Play aria-hidden="true" /> };

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -151,6 +151,7 @@ function SummaryView({
 }) {
 	const hasPr = Boolean(session.pullRequest);
 	const queryClient = useQueryClient();
+	const [reviewNotice, setReviewNotice] = useState<string | null>(null);
 	const query = useQuery({
 		queryKey: ["session-pr", session.id],
 		enabled: hasPr,
@@ -190,16 +191,23 @@ function SummaryView({
 	});
 	const triggerReview = useMutation({
 		mutationFn: async () => {
-			const { data, error } = await apiClient.POST("/api/v1/sessions/{sessionId}/reviews/trigger", {
+			const { data, error, response } = await apiClient.POST("/api/v1/sessions/{sessionId}/reviews/trigger", {
 				params: { path: { sessionId: session.id } },
 			});
 			if (error) throw new Error(apiErrorMessage(error, "Unable to start review"));
-			return data;
+			return { data, reused: response?.status === 200 };
 		},
-		onSuccess: (data) => {
+		onMutate: () => {
+			setReviewNotice(null);
+		},
+		onSuccess: ({ data, reused }) => {
 			void queryClient.invalidateQueries({ queryKey: ["session-reviews", session.id] });
 			void queryClient.invalidateQueries({ queryKey: ["session-pr", session.id] });
 			void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+			if (reused) {
+				setReviewNotice("Review is already up to date for this commit.");
+				return;
+			}
 			if (data?.reviewerHandleId) {
 				onOpenReviewerTerminal?.({ handleId: data.reviewerHandleId, harness: data.review.harness || "reviewer" });
 			}
@@ -264,6 +272,7 @@ function SummaryView({
 					onTrigger={() => triggerReview.mutate()}
 					reviewerHandleId={reviewsQuery.data?.reviewerHandleId ?? ""}
 					reviews={reviews}
+					notice={reviewNotice}
 					session={session}
 				/>
 			</Section>
@@ -297,6 +306,7 @@ function ReviewPanel({
 	isLoading,
 	isTriggering,
 	error,
+	notice,
 	onTrigger,
 	onOpenTerminal,
 }: {
@@ -307,6 +317,7 @@ function ReviewPanel({
 	isLoading: boolean;
 	isTriggering: boolean;
 	error: unknown;
+	notice: string | null;
 	onTrigger: () => void;
 	onOpenTerminal?: OpenReviewerTerminal;
 }) {
@@ -323,6 +334,7 @@ function ReviewPanel({
 	return (
 		<div className="reviewer-list">
 			{error ? <p className="reviewer-error">{apiErrorMessage(error, "Review request failed")}</p> : null}
+			{notice ? <p className="reviewer-notice">{notice}</p> : null}
 			<ReviewerCard
 				handleId={reviewerHandleId}
 				harness={harness}

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -1,17 +1,36 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState, type ReactNode } from "react";
-import { GitBranch, GitCommitHorizontal, GitPullRequest, Plus, Square, Trash2 } from "lucide-react";
+import {
+	AlertCircle,
+	CheckCircle2,
+	CircleMinus,
+	GitBranch,
+	GitCommitHorizontal,
+	GitPullRequest,
+	Play,
+	Plus,
+	Shield,
+	Square,
+	Terminal,
+	Trash2,
+} from "lucide-react";
 import type { components } from "../../api/schema";
-import { apiClient } from "../lib/api-client";
+import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { formatTimeCompact } from "../lib/format-time";
 import type { SessionStatus, WorkspaceSession } from "../types/workspace";
 import { workerDisplayStatus } from "../types/workspace";
+import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { cn } from "../lib/utils";
 
 type PRFacts = components["schemas"]["SessionPRFacts"];
+type ProjectConfig = components["schemas"]["ProjectConfig"];
+type ReviewRun = components["schemas"]["ReviewRun"];
+type ReviewsResponse = components["schemas"]["ListReviewsResponse"];
 type InspectorView = "summary" | "changes" | "browser";
+
+type OpenReviewerTerminal = (target: { handleId: string; harness: string }) => void;
 
 const VIEWS: { id: InspectorView; label: string; icon: ReactNode }[] = [
 	{
@@ -65,7 +84,13 @@ const prStateTone: Record<PRFacts["state"], string> = {
  * Tabbed inspector rail beside the terminal — cloned from agent-orchestrator
  * SessionInspector (Summary · Changes · Browser).
  */
-export function SessionInspector({ session }: { session?: WorkspaceSession }) {
+export function SessionInspector({
+	session,
+	onOpenReviewerTerminal,
+}: {
+	session?: WorkspaceSession;
+	onOpenReviewerTerminal?: OpenReviewerTerminal;
+}) {
 	const [view, setView] = useState<InspectorView>("summary");
 
 	if (!session) {
@@ -97,7 +122,9 @@ export function SessionInspector({ session }: { session?: WorkspaceSession }) {
 			</div>
 
 			<div className="session-inspector__body">
-				{view === "summary" ? <SummaryView session={session} /> : null}
+				{view === "summary" ? (
+					<SummaryView onOpenReviewerTerminal={onOpenReviewerTerminal} session={session} />
+				) : null}
 				{view === "changes" ? <ChangesView session={session} /> : null}
 				{view === "browser" ? <BrowserView /> : null}
 			</div>
@@ -117,8 +144,15 @@ function Section({ title, action, children }: { title: string; action?: ReactNod
 	);
 }
 
-function SummaryView({ session }: { session: WorkspaceSession }) {
+function SummaryView({
+	session,
+	onOpenReviewerTerminal,
+}: {
+	session: WorkspaceSession;
+	onOpenReviewerTerminal?: OpenReviewerTerminal;
+}) {
 	const hasPr = Boolean(session.pullRequest);
+	const queryClient = useQueryClient();
 	const query = useQuery({
 		queryKey: ["session-pr", session.id],
 		enabled: hasPr,
@@ -130,8 +164,52 @@ function SummaryView({ session }: { session: WorkspaceSession }) {
 			return data?.prs ?? [];
 		},
 	});
+	const reviewsQuery = useQuery({
+		queryKey: ["session-reviews", session.id],
+		enabled: hasPr,
+		refetchInterval: (query) => {
+			const data = query.state.data as ReviewsResponse | undefined;
+			return data?.reviews.some((review) => review.status === "running") ? 2500 : false;
+		},
+		queryFn: async () => {
+			const { data, error } = await apiClient.GET("/api/v1/sessions/{sessionId}/reviews", {
+				params: { path: { sessionId: session.id } },
+			});
+			if (error) throw new Error(apiErrorMessage(error, "Unable to load reviews"));
+			return data ?? ({ reviewerHandleId: "", reviews: [] } satisfies ReviewsResponse);
+		},
+	});
+	const projectConfigQuery = useQuery({
+		queryKey: ["project-config", session.workspaceId],
+		enabled: hasPr,
+		queryFn: async () => {
+			const { data, error } = await apiClient.GET("/api/v1/projects/{id}", {
+				params: { path: { id: session.workspaceId } },
+			});
+			if (error) return undefined;
+			return projectConfig(data?.project);
+		},
+	});
+	const triggerReview = useMutation({
+		mutationFn: async () => {
+			const { data, error } = await apiClient.POST("/api/v1/sessions/{sessionId}/reviews/trigger", {
+				params: { path: { sessionId: session.id } },
+			});
+			if (error) throw new Error(apiErrorMessage(error, "Unable to start review"));
+			return data;
+		},
+		onSuccess: (data) => {
+			void queryClient.invalidateQueries({ queryKey: ["session-reviews", session.id] });
+			void queryClient.invalidateQueries({ queryKey: ["session-pr", session.id] });
+			void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+			if (data?.reviewerHandleId) {
+				onOpenReviewerTerminal?.({ handleId: data.reviewerHandleId, harness: data.review.harness || "reviewer" });
+			}
+		},
+	});
 	const prFacts = query.data?.[0];
 	const branchLabel = session.branch || `session/${session.id}`;
+	const reviews = reviewsQuery.data?.reviews ?? [];
 
 	return (
 		<div role="tabpanel">
@@ -178,8 +256,22 @@ function SummaryView({ session }: { session: WorkspaceSession }) {
 				)}
 			</Section>
 
+			<Section title="Reviews">
+				<ReviewPanel
+					config={projectConfigQuery.data}
+					error={reviewsQuery.error ?? triggerReview.error}
+					isLoading={reviewsQuery.isLoading}
+					isTriggering={triggerReview.isPending}
+					onOpenTerminal={onOpenReviewerTerminal}
+					onTrigger={() => triggerReview.mutate()}
+					reviewerHandleId={reviewsQuery.data?.reviewerHandleId ?? ""}
+					reviews={reviews}
+					session={session}
+				/>
+			</Section>
+
 			<Section title="Activity">
-				<ActivityTimeline session={session} />
+				<ActivityTimeline reviews={reviews} session={session} />
 			</Section>
 
 			<Section title="Overview">
@@ -194,9 +286,141 @@ function SummaryView({ session }: { session: WorkspaceSession }) {
 	);
 }
 
-type TimelineTone = "now" | "good" | "warn" | "neutral";
+function projectConfig(project: components["schemas"]["ProjectOrDegraded"] | undefined): ProjectConfig | undefined {
+	if (!project || !("config" in project)) return undefined;
+	return project.config;
+}
 
-function ActivityTimeline({ session }: { session: WorkspaceSession }) {
+function ReviewPanel({
+	session,
+	config,
+	reviews,
+	reviewerHandleId,
+	isLoading,
+	isTriggering,
+	error,
+	onTrigger,
+	onOpenTerminal,
+}: {
+	session: WorkspaceSession;
+	config?: ProjectConfig;
+	reviews: ReviewRun[];
+	reviewerHandleId: string;
+	isLoading: boolean;
+	isTriggering: boolean;
+	error: unknown;
+	onTrigger: () => void;
+	onOpenTerminal?: OpenReviewerTerminal;
+}) {
+	if (!session.pullRequest) {
+		return <p className="inspector-empty">No pull request opened yet.</p>;
+	}
+	if (isLoading) {
+		return <p className="inspector-empty">Loading reviews...</p>;
+	}
+
+	const latest = latestReview(reviews);
+	const harness = latest?.harness || config?.reviewers?.[0]?.harness || session.provider || "reviewer";
+
+	return (
+		<div className="reviewer-list">
+			{error ? <p className="reviewer-error">{apiErrorMessage(error, "Review request failed")}</p> : null}
+			<ReviewerCard
+				handleId={reviewerHandleId}
+				harness={harness}
+				isTriggering={isTriggering}
+				onOpenTerminal={onOpenTerminal}
+				onTrigger={onTrigger}
+				review={latest}
+			/>
+		</div>
+	);
+}
+
+function latestReview(reviews: ReviewRun[]): ReviewRun | undefined {
+	return [...reviews].sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))[0];
+}
+
+function ReviewerCard({
+	harness,
+	review,
+	handleId,
+	isTriggering,
+	onTrigger,
+	onOpenTerminal,
+}: {
+	harness: string;
+	review?: ReviewRun;
+	handleId: string;
+	isTriggering: boolean;
+	onTrigger: () => void;
+	onOpenTerminal?: OpenReviewerTerminal;
+}) {
+	const status = reviewStatus(review);
+	const terminalEnabled = Boolean(handleId && onOpenTerminal);
+	const runLabel = review ? "Re-run review" : "Run review";
+
+	return (
+		<div className={cn("reviewer-card", status.tone && `reviewer-card--${status.tone}`)}>
+			<div className="reviewer-card__top">
+				<div className="reviewer-card__name">
+					<Shield aria-hidden="true" />
+					<span>{harness}</span>
+				</div>
+				<span className={cn("reviewer-status", `reviewer-status--${status.tone}`)}>
+					{status.icon}
+					{status.label}
+				</span>
+			</div>
+			<div className="reviewer-card__actions">
+				<button
+					className="reviewer-card__action reviewer-card__action--primary"
+					disabled={isTriggering}
+					onClick={onTrigger}
+					type="button"
+				>
+					<Play aria-hidden="true" />
+					{isTriggering ? "Starting..." : runLabel}
+				</button>
+				{review ? (
+					<button
+						className="reviewer-card__action"
+						disabled={!terminalEnabled}
+						onClick={() => {
+							if (!terminalEnabled) return;
+							onOpenTerminal?.({ handleId, harness });
+						}}
+						type="button"
+					>
+						<Terminal aria-hidden="true" />
+						Open terminal
+					</button>
+				) : null}
+			</div>
+		</div>
+	);
+}
+
+function reviewStatus(review?: ReviewRun): { label: string; tone: "neutral" | "running" | "success" | "danger"; icon: ReactNode } {
+	if (!review) return { label: "Not run", tone: "neutral", icon: null };
+	if (review.status === "running") {
+		return { label: "Running", tone: "running", icon: <Play aria-hidden="true" /> };
+	}
+	if (review.status === "failed") {
+		return { label: "Failed", tone: "danger", icon: <AlertCircle aria-hidden="true" /> };
+	}
+	if (review.verdict === "approved") {
+		return { label: "Approved", tone: "success", icon: <CheckCircle2 aria-hidden="true" /> };
+	}
+	if (review.verdict === "changes_requested") {
+		return { label: "Changes requested", tone: "danger", icon: <CircleMinus aria-hidden="true" /> };
+	}
+	return { label: "Complete", tone: "success", icon: <CheckCircle2 aria-hidden="true" /> };
+}
+
+type TimelineTone = "now" | "good" | "warn" | "bad" | "neutral";
+
+function ActivityTimeline({ session, reviews }: { session: WorkspaceSession; reviews: ReviewRun[] }) {
 	const events: { tone: TimelineTone; node: ReactNode; ts: string | null }[] = [];
 	const detail = activityDetail(session.status);
 
@@ -225,6 +449,18 @@ function ActivityTimeline({ session }: { session: WorkspaceSession }) {
 		});
 	}
 
+	for (const review of reviews.slice(0, 4)) {
+		events.push({
+			tone: reviewTimelineTone(review),
+			node: (
+				<>
+					{reviewTimelineLabel(review)} <span className="inspector-timeline__detail">- {review.harness}</span>
+				</>
+			),
+			ts: formatTimeCompact(review.createdAt),
+		});
+	}
+
 	events.push({
 		tone: "neutral",
 		node: <>Created worktree &amp; branch</>,
@@ -241,6 +477,7 @@ function ActivityTimeline({ session }: { session: WorkspaceSession }) {
 						event.tone === "now" && "inspector-timeline__ev--now",
 						event.tone === "good" && "inspector-timeline__ev--good",
 						event.tone === "warn" && "inspector-timeline__ev--warn",
+						event.tone === "bad" && "inspector-timeline__ev--bad",
 					)}
 				>
 					<span className="inspector-timeline__node" aria-hidden="true" />
@@ -250,6 +487,21 @@ function ActivityTimeline({ session }: { session: WorkspaceSession }) {
 			))}
 		</div>
 	);
+}
+
+function reviewTimelineTone(review: ReviewRun): TimelineTone {
+	if (review.status === "failed" || review.verdict === "changes_requested") return "bad";
+	if (review.status === "running") return "warn";
+	if (review.verdict === "approved") return "good";
+	return "neutral";
+}
+
+function reviewTimelineLabel(review: ReviewRun): string {
+	if (review.status === "running") return "Review requested";
+	if (review.status === "failed") return "Review failed";
+	if (review.verdict === "approved") return "Approved";
+	if (review.verdict === "changes_requested") return "Changes requested";
+	return "Review complete";
 }
 
 function activityDetail(status: SessionStatus): string | null {

--- a/frontend/src/renderer/components/SessionView.tsx
+++ b/frontend/src/renderer/components/SessionView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { PanelImperativeHandle, PanelSize } from "react-resizable-panels";
 import { CenterPane } from "./CenterPane";
 import { SessionInspector } from "./SessionInspector";
@@ -7,6 +7,7 @@ import { useUiStore } from "../stores/ui-store";
 import { useShell } from "../lib/shell-context";
 import { useWorkspaceQuery } from "../hooks/useWorkspaceQuery";
 import { isOrchestratorSession } from "../types/workspace";
+import type { TerminalTarget } from "../types/terminal";
 
 const INSPECTOR_MIN_PERCENT = 22;
 const INSPECTOR_MAX_PERCENT = 45;
@@ -45,9 +46,14 @@ export function SessionView({ sessionId }: SessionViewProps) {
 	const { daemonStatus } = useShell();
 	const inspectorRef = useRef<PanelImperativeHandle | null>(null);
 	const inspectorSeparatorRef = useRef<HTMLDivElement | null>(null);
+	const [terminalTarget, setTerminalTarget] = useState<TerminalTarget>({ kind: "worker" });
 
 	const session = workspaces.flatMap((workspace) => workspace.sessions).find((s) => s.id === sessionId);
 	const isOrchestrator = session ? isOrchestratorSession(session) : false;
+
+	useEffect(() => {
+		setTerminalTarget({ kind: "worker" });
+	}, [sessionId]);
 
 	// Orchestrator sessions are terminal-only; only worker sessions have the rail.
 	const hasInspector = !isOrchestrator;
@@ -148,7 +154,13 @@ export function SessionView({ sessionId }: SessionViewProps) {
 				{/* react-resizable-panels v4: bare numbers are PIXELS; percentages must
             be strings. Numeric sizes here once clamped the inspector to 45px. */}
 				<ResizablePanel defaultSize="72%" id="terminal" minSize="45%">
-					<CenterPane daemonReady={daemonStatus.state === "ready"} session={session} theme={theme} />
+					<CenterPane
+						daemonReady={daemonStatus.state === "ready"}
+						onSelectWorkerTerminal={() => setTerminalTarget({ kind: "worker" })}
+						session={session}
+						terminalTarget={terminalTarget}
+						theme={theme}
+					/>
 				</ResizablePanel>
 				{hasInspector ? (
 					<>
@@ -171,7 +183,12 @@ export function SessionView({ sessionId }: SessionViewProps) {
 							{/* Stable content width while the panel animates (yyork pattern):
                   the pane clips instead of reflowing the inspector mid-collapse. */}
 							<div className="h-full min-w-[280px]">
-								<SessionInspector session={session} />
+								<SessionInspector
+									onOpenReviewerTerminal={({ handleId, harness }) =>
+										setTerminalTarget({ kind: "reviewer", handleId, harness })
+									}
+									session={session}
+								/>
 							</div>
 						</ResizablePanel>
 					</>

--- a/frontend/src/renderer/components/TerminalPane.tsx
+++ b/frontend/src/renderer/components/TerminalPane.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { TerminalTarget } from "../types/terminal";
 import type { WorkspaceSession } from "../types/workspace";
 import type { Theme } from "../stores/ui-store";
 import { useTerminalSession, type AttachableTerminal, type TerminalSessionState } from "../hooks/useTerminalSession";
@@ -8,14 +9,16 @@ type TerminalPaneProps = {
 	session?: WorkspaceSession;
 	theme: Theme;
 	daemonReady: boolean;
+	terminalTarget?: TerminalTarget;
 };
 
-export function TerminalPane({ session, theme, daemonReady }: TerminalPaneProps) {
+export function TerminalPane({ session, theme, daemonReady, terminalTarget }: TerminalPaneProps) {
 	if (!window.ao) {
+		const provider = terminalTarget?.kind === "reviewer" ? terminalTarget.harness : (session?.provider ?? "claude");
 		return (
 			<pre className="h-full overflow-auto bg-terminal p-4 font-mono text-[13px] leading-relaxed text-[var(--term-fg)]">
 				<span className="text-[var(--term-dim)]">~/{session?.workspaceName ?? "reverbcode"}</span>{" "}
-				<span className="text-[var(--term-blue)]">{session?.branch || "main"}</span> $ {session?.provider ?? "claude"}
+				<span className="text-[var(--term-blue)]">{session?.branch || "main"}</span> $ {provider}
 				{"\n"}
 				<span className="text-[var(--term-green)]">✻ Welcome to the agent CLI</span>
 				{"\n\n"}
@@ -26,7 +29,7 @@ export function TerminalPane({ session, theme, daemonReady }: TerminalPaneProps)
 		);
 	}
 
-	return <AttachedTerminal session={session} theme={theme} daemonReady={daemonReady} />;
+	return <AttachedTerminal session={session} theme={theme} daemonReady={daemonReady} terminalTarget={terminalTarget} />;
 }
 
 function bannerText(state: TerminalSessionState, error?: string): string | undefined {
@@ -35,15 +38,19 @@ function bannerText(state: TerminalSessionState, error?: string): string | undef
 	return undefined;
 }
 
-function AttachedTerminal({ session, theme, daemonReady }: TerminalPaneProps) {
+function AttachedTerminal({ session, theme, daemonReady, terminalTarget }: TerminalPaneProps) {
+	const attachSession =
+		session && terminalTarget?.kind === "reviewer"
+			? { ...session, terminalHandleId: terminalTarget.handleId }
+			: session;
 	// One terminal instance per pane lifetime (yyork's core rule): switching
 	// sessions never remounts XtermTerminal — the attachment effect re-points
 	// the mux and clears the screen instead. A keyed remount would tear down the
 	// renderer mid-switch and lose the warm GPU surface.
 	const [terminal, setTerminal] = useState<AttachableTerminal | null>(null);
 	const [initFailed, setInitFailed] = useState(false);
-	const { attach, state, error } = useTerminalSession(session, { daemonReady });
-	const handleId = session?.terminalHandleId;
+	const { attach, state, error } = useTerminalSession(attachSession, { daemonReady });
+	const handleId = attachSession?.terminalHandleId;
 	const hadAttachmentRef = useRef(false);
 
 	const handleReady = useCallback((handle: AttachableTerminal) => setTerminal(handle), []);

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -708,6 +708,17 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	color: var(--red);
 }
 
+.reviewer-notice {
+	margin: 0;
+	border-radius: 6px;
+	border: 1px solid color-mix(in srgb, var(--green) 28%, transparent);
+	background: color-mix(in srgb, var(--green) 8%, transparent);
+	padding: 8px 10px;
+	font-size: 11.5px;
+	line-height: 1.45;
+	color: var(--green);
+}
+
 .reviewer-card {
 	display: flex;
 	flex-direction: column;

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -575,6 +575,77 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	background: var(--border);
 }
 
+.reviewer-terminal-header {
+	display: flex;
+	height: 36px;
+	flex-shrink: 0;
+	align-items: center;
+	gap: 12px;
+	border-bottom: 1px solid var(--border);
+	background: var(--term-bg);
+	padding: 0 14px;
+	font-family: var(--font-mono);
+}
+
+.reviewer-terminal-header__back {
+	display: inline-flex;
+	height: 24px;
+	flex-shrink: 0;
+	align-items: center;
+	gap: 5px;
+	border-radius: 6px;
+	border: 1px solid var(--border);
+	background: var(--bg-1);
+	padding: 0 8px;
+	font-size: 11px;
+	color: var(--fg-muted);
+	transition:
+		background 0.12s ease,
+		color 0.12s ease;
+}
+
+.reviewer-terminal-header__back:hover {
+	background: var(--interactive-hover);
+	color: var(--fg);
+}
+
+.reviewer-terminal-header__back svg,
+.reviewer-terminal-header__role svg {
+	width: 13px;
+	height: 13px;
+	flex-shrink: 0;
+}
+
+.reviewer-terminal-header__role {
+	display: inline-flex;
+	height: 24px;
+	flex-shrink: 0;
+	align-items: center;
+	gap: 6px;
+	border-radius: 6px;
+	border: 1px solid color-mix(in srgb, var(--green) 34%, transparent);
+	background: color-mix(in srgb, var(--green) 9%, transparent);
+	padding: 0 9px;
+	font-size: 11px;
+	font-weight: 700;
+	color: #8bdc75;
+	text-transform: uppercase;
+}
+
+:root[data-theme="light"] .reviewer-terminal-header__role {
+	color: var(--green);
+}
+
+.reviewer-terminal-header__harness {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 13px;
+	font-weight: 650;
+	color: var(--fg);
+}
+
 /* Collapse/expand animation for the inspector panel: rrp v4 drives panel
  * sizes via flex-grow, which is animatable. Suppress it while the separator
  * is actively dragged so resizing tracks the pointer 1:1. */
@@ -618,6 +689,176 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	font-size: 12px;
 	color: var(--fg-muted);
 	line-height: 1.5;
+}
+
+.reviewer-list {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.reviewer-error {
+	margin: 0;
+	border-radius: 6px;
+	border: 1px solid color-mix(in srgb, var(--red) 28%, transparent);
+	background: color-mix(in srgb, var(--red) 8%, transparent);
+	padding: 8px 10px;
+	font-size: 11.5px;
+	line-height: 1.45;
+	color: var(--red);
+}
+
+.reviewer-card {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+	border-radius: 8px;
+	border: 1px solid var(--border);
+	background: var(--bg-1);
+	padding: 14px;
+}
+
+.reviewer-card--success {
+	border-color: color-mix(in srgb, var(--green) 25%, var(--border));
+}
+
+.reviewer-card--danger {
+	border-color: color-mix(in srgb, var(--red) 22%, var(--border));
+}
+
+.reviewer-card__top {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+	min-width: 0;
+}
+
+.reviewer-card__name {
+	display: inline-flex;
+	min-width: 0;
+	align-items: center;
+	gap: 9px;
+	font-family: var(--font-mono);
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--fg);
+}
+
+.reviewer-card__name svg {
+	width: 15px;
+	height: 15px;
+	flex-shrink: 0;
+	color: var(--fg-passive);
+}
+
+.reviewer-card__name span {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.reviewer-status {
+	display: inline-flex;
+	height: 24px;
+	max-width: 58%;
+	flex-shrink: 0;
+	align-items: center;
+	gap: 5px;
+	overflow: hidden;
+	border-radius: 7px;
+	padding: 0 9px;
+	font-size: 11.5px;
+	font-weight: 650;
+	line-height: 1;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+.reviewer-status svg {
+	width: 13px;
+	height: 13px;
+	flex-shrink: 0;
+}
+
+.reviewer-status--neutral {
+	background: var(--bg-2);
+	color: var(--fg-muted);
+}
+
+.reviewer-status--running {
+	background: color-mix(in srgb, var(--orange) 12%, transparent);
+	color: var(--orange);
+}
+
+.reviewer-status--success {
+	background: color-mix(in srgb, var(--green) 14%, transparent);
+	color: var(--green);
+}
+
+.reviewer-status--danger {
+	background: color-mix(in srgb, var(--red) 14%, transparent);
+	color: var(--red);
+}
+
+.reviewer-card__actions {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 10px;
+}
+
+.reviewer-card__actions:has(.reviewer-card__action:only-child) {
+	grid-template-columns: 1fr;
+}
+
+.reviewer-card__action {
+	display: inline-flex;
+	height: 38px;
+	min-width: 0;
+	align-items: center;
+	justify-content: center;
+	gap: 7px;
+	overflow: hidden;
+	border-radius: 7px;
+	border: 1px solid var(--border);
+	background: var(--bg-2);
+	padding: 0 10px;
+	font-size: 12px;
+	font-weight: 650;
+	color: var(--fg-muted);
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	transition:
+		background 0.12s ease,
+		border-color 0.12s ease,
+		color 0.12s ease;
+}
+
+.reviewer-card__action svg {
+	width: 14px;
+	height: 14px;
+	flex-shrink: 0;
+}
+
+.reviewer-card__action:hover:not(:disabled) {
+	background: var(--interactive-hover);
+	color: var(--fg);
+}
+
+.reviewer-card__action:disabled {
+	cursor: not-allowed;
+	opacity: 0.45;
+}
+
+.reviewer-card__action--primary {
+	border-color: color-mix(in srgb, var(--green) 42%, transparent);
+	background: color-mix(in srgb, var(--green) 10%, transparent);
+	color: #8bdc75;
+}
+
+:root[data-theme="light"] .reviewer-card__action--primary {
+	color: var(--green);
 }
 
 .inspector-empty--center {
@@ -732,6 +973,10 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 
 .inspector-timeline__ev--warn .inspector-timeline__node {
 	background: var(--amber);
+}
+
+.inspector-timeline__ev--bad .inspector-timeline__node {
+	background: var(--red);
 }
 
 .inspector-timeline__et {

--- a/frontend/src/renderer/types/terminal.ts
+++ b/frontend/src/renderer/types/terminal.ts
@@ -1,0 +1,7 @@
+export type TerminalTarget =
+	| { kind: "worker" }
+	| {
+			kind: "reviewer";
+			handleId: string;
+			harness: string;
+	  };


### PR DESCRIPTION
## Summary
- add reviewer cards to the session Summary inspector with run/re-run controls and status chips
- allow the center terminal pane to switch to the live reviewer handle and back to the worker terminal
- add focused frontend tests for triggering reviews and opening reviewer terminals

## Testing
- npm.cmd run typecheck
- npx.cmd vitest run --config vite.renderer.config.ts src/renderer/components/SessionView.test.tsx src/renderer/components/SessionInspector.test.tsx

## Notes
- Branch was created from origin/main in a clean temporary worktree so unrelated local workspace changes are excluded.