### PR TITLE
fix(frontend): stop sidebar repeating the session id under the title

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Sidebar } from "./Sidebar";
-import type { WorkspaceSummary } from "../types/workspace";
+import type { WorkspaceSession, WorkspaceSummary } from "../types/workspace";
 
 const { navigateMock } = vi.hoisted(() => ({ navigateMock: vi.fn() }));
 
@@ -24,6 +24,21 @@ const workspace: WorkspaceSummary = {
 	path: "/repo/project-one",
 	sessions: [],
 };
+
+function workerSession(overrides: Partial<WorkspaceSession>): WorkspaceSession {
+	return {
+		id: "reverbcode-2",
+		workspaceId: "proj-1",
+		workspaceName: "Project One",
+		title: "reverbcode-2",
+		provider: "claude-code",
+		kind: "worker",
+		branch: "session/reverbcode-2",
+		status: "working",
+		updatedAt: "2026-06-17T00:00:00Z",
+		...overrides,
+	};
+}
 
 function renderSidebar(onRemoveProject = vi.fn().mockResolvedValue(undefined)) {
 	render(
@@ -72,6 +87,40 @@ describe("Sidebar", () => {
 		await user.click(await screen.findByRole("menuitem", { name: "Remove project" }));
 
 		expect(onRemoveProject).not.toHaveBeenCalled();
+	});
+
+	it("does not repeat the session id under the title when the title is the id", () => {
+		const sessions = [workerSession({ id: "reverbcode-2", title: "reverbcode-2" })];
+		render(
+			<SidebarProvider>
+				<Sidebar
+					daemonStatus={{ state: "running" }}
+					onCreateProject={vi.fn()}
+					onRemoveProject={vi.fn()}
+					workspaces={[{ ...workspace, sessions }]}
+				/>
+			</SidebarProvider>,
+		);
+
+		// Title renders once; the id subtitle is suppressed because it would duplicate it.
+		expect(screen.getAllByText("reverbcode-2")).toHaveLength(1);
+	});
+
+	it("shows the session id under a distinct display name", () => {
+		const sessions = [workerSession({ id: "reverbcode-2", title: "fix the sidebar" })];
+		render(
+			<SidebarProvider>
+				<Sidebar
+					daemonStatus={{ state: "running" }}
+					onCreateProject={vi.fn()}
+					onRemoveProject={vi.fn()}
+					workspaces={[{ ...workspace, sessions }]}
+				/>
+			</SidebarProvider>,
+		);
+
+		expect(screen.getByText("fix the sidebar")).toBeInTheDocument();
+		expect(screen.getByText("reverbcode-2")).toBeInTheDocument();
 	});
 
 	it("hides the worker count in every state that reveals project actions", () => {

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -503,9 +503,7 @@ function ProjectItem({
 											    id (useWorkspaceQuery), so skip the line rather than
 											    repeat the same string twice. */}
 											{session.title !== session.id && (
-												<span className="block truncate font-mono text-[10px] text-passive">
-													{session.id}
-												</span>
+												<span className="block truncate font-mono text-[10px] text-passive">{session.id}</span>
 											)}
 										</span>
 									</button>

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -498,7 +498,15 @@ function ProjectItem({
 											>
 												{session.title}
 											</span>
-											<span className="block truncate font-mono text-[10px] text-passive">{session.id}</span>
+											{/* The id is a secondary handle; when the worker has no
+											    displayName/issueId the title already falls back to the
+											    id (useWorkspaceQuery), so skip the line rather than
+											    repeat the same string twice. */}
+											{session.title !== session.id && (
+												<span className="block truncate font-mono text-[10px] text-passive">
+													{session.id}
+												</span>
+											)}
 										</span>
 									</button>
 								</SidebarMenuSubButton>


### PR DESCRIPTION
Fixes #282

## Summary
A worker session with no `displayName`/`issueId` gets its title from `useWorkspaceQuery`'s fallback (`session.displayName ?? session.issueId ?? session.id`), which resolves to the session id. The sidebar then rendered the title line (`Sidebar.tsx`) **and** an id subtitle unconditionally, so the same string printed twice (e.g. `reverbcode-2` over `reverbcode-2`) — the default state for any plainly-spawned, un-renamed worker.

This renders the id subtitle only when it differs from the title: it stays a useful secondary handle for renamed / issue-backed workers, and collapses to a single line otherwise.

## Test
- `cd frontend && npm run typecheck` — clean
- `cd frontend && npx vitest run src/renderer/components/Sidebar.test.tsx` — 5 passed, including two new regression tests:
  - id subtitle suppressed when `title === id` (asserts the string renders once)
  - id subtitle shown under a distinct display name

🤖 Generated with [Claude Code](https://claude.com/claude-code)