### PR TITLE
fix(frontend): make review inspector panels responsive

### DIFF
--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -235,15 +235,15 @@ function SummaryView({
 					<p className="inspector-empty">Loading pull request…</p>
 				) : (
 					<div className="flex flex-col gap-2">
-						<div className="flex items-center gap-2">
+						<div className="inspector-pr-summary">
 							<GitPullRequest className="h-3.5 w-3.5 shrink-0 text-passive" aria-hidden="true" />
-							<span className="text-[12.5px] font-medium text-foreground">
+							<span className="inspector-pr-summary__title">
 								PR #{prFacts?.number ?? session.pullRequest?.number}
 							</span>
 							{prFacts ? (
 								<Badge
 									variant="outline"
-									className={cn("ml-auto h-5 px-1.5 text-[10px] font-medium", prStateTone[prFacts.state])}
+									className={cn("inspector-pr-summary__state h-5 px-1.5 text-[10px] font-medium", prStateTone[prFacts.state])}
 								>
 									{prFacts.state}
 								</Badge>

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -237,13 +237,14 @@ function SummaryView({
 					<div className="flex flex-col gap-2">
 						<div className="inspector-pr-summary">
 							<GitPullRequest className="h-3.5 w-3.5 shrink-0 text-passive" aria-hidden="true" />
-							<span className="inspector-pr-summary__title">
-								PR #{prFacts?.number ?? session.pullRequest?.number}
-							</span>
+							<span className="inspector-pr-summary__title">PR #{prFacts?.number ?? session.pullRequest?.number}</span>
 							{prFacts ? (
 								<Badge
 									variant="outline"
-									className={cn("inspector-pr-summary__state h-5 px-1.5 text-[10px] font-medium", prStateTone[prFacts.state])}
+									className={cn(
+										"inspector-pr-summary__state h-5 px-1.5 text-[10px] font-medium",
+										prStateTone[prFacts.state],
+									)}
 								>
 									{prFacts.state}
 								</Badge>

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -546,6 +546,7 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 
 /* ── Session inspector rail (agent-orchestrator SessionInspector) ───────── */
 .session-inspector {
+	container-type: inline-size;
 	display: flex;
 	height: 100%;
 	min-height: 0;
@@ -757,6 +758,28 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	font-size: 12px;
 	color: var(--fg-muted);
 	line-height: 1.5;
+}
+
+.inspector-pr-summary {
+	display: flex;
+	min-width: 0;
+	align-items: center;
+	gap: 8px;
+}
+
+.inspector-pr-summary__title {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 12.5px;
+	font-weight: 500;
+	color: var(--fg);
+}
+
+.inspector-pr-summary__state {
+	margin-left: auto;
+	flex-shrink: 0;
 }
 
 .reviewer-list {
@@ -1002,6 +1025,54 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 .inspector-kv__v--mono {
 	font-family: var(--font-mono);
 	font-size: 11.5px;
+}
+
+@container (max-width: 300px) {
+	.session-inspector__body {
+		padding-inline: 14px;
+	}
+
+	.inspector-pr-summary {
+		align-items: flex-start;
+		flex-wrap: wrap;
+	}
+
+	.inspector-pr-summary__state {
+		margin-left: 22px;
+	}
+
+	.inspector-kv__row {
+		align-items: flex-start;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.inspector-kv__k {
+		width: auto;
+	}
+
+	.inspector-kv__v {
+		width: 100%;
+	}
+
+	.reviewer-card {
+		gap: 12px;
+		padding: 12px;
+		overflow: hidden;
+	}
+
+	.reviewer-card__top {
+		align-items: flex-start;
+		flex-direction: column;
+	}
+
+	.reviewer-status {
+		max-width: 100%;
+	}
+
+	.reviewer-card__actions {
+		grid-template-columns: 1fr;
+	}
 }
 
 .inspector-timeline {


### PR DESCRIPTION
Fixes the review inspector responsiveness mismatch from #299. Summary: make the Reviews card controls/status stack in narrow inspector widths; make the Pull request summary and metadata wrap responsively; add container-query rules for narrow rails. Tests: npm.cmd --prefix frontend run typecheck; npm.cmd --prefix frontend run test -- SessionInspector.test.tsx. Closes #299.