### PR TITLE
fix: remove projects with incomplete session handles

### DIFF
--- a/backend/internal/service/session/service.go
+++ b/backend/internal/service/session/service.go
@@ -366,11 +366,22 @@ func (s *Service) TeardownProject(ctx context.Context, project domain.ProjectID)
 			continue
 		}
 		if _, err := s.Kill(ctx, rec.ID); err != nil {
+			if isIncompleteHandleError(err) {
+				continue
+			}
 			return err
 		}
 	}
 	_, err = s.Cleanup(ctx, project)
 	return err
+}
+
+func isIncompleteHandleError(err error) bool {
+	if errors.Is(err, sessionmanager.ErrIncompleteHandle) {
+		return true
+	}
+	var apiErr *apierr.Error
+	return errors.As(err, &apiErr) && apiErr.Code == "SESSION_INCOMPLETE_HANDLE"
 }
 
 // List returns sessions as enriched display models after applying API filters.

--- a/backend/internal/service/session/service_test.go
+++ b/backend/internal/service/session/service_test.go
@@ -235,6 +235,20 @@ func TestTeardownProjectStopsOnKillError(t *testing.T) {
 	}
 }
 
+func TestTeardownProjectContinuesOnIncompleteHandle(t *testing.T) {
+	st := newFakeStore()
+	st.sessions["mer-1"] = domain.SessionRecord{ID: "mer-1", ProjectID: "mer"}
+	fc := &fakeCommander{killErr: sessionmanager.ErrIncompleteHandle}
+	svc := &Service{manager: fc, store: st}
+
+	if err := svc.TeardownProject(context.Background(), "mer"); err != nil {
+		t.Fatalf("TeardownProject: %v", err)
+	}
+	if len(fc.cleanupProjects) != 1 || fc.cleanupProjects[0] != "mer" {
+		t.Fatalf("cleanup projects = %#v, want [mer]", fc.cleanupProjects)
+	}
+}
+
 func TestSpawnOrchestratorCleanKillsActiveOrchestratorsBeforeSpawn(t *testing.T) {
 	st := newFakeStore()
 	st.projects["mer"] = domain.ProjectRecord{ID: "mer"}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -320,7 +320,9 @@ ipcMain.handle("daemon:getStatus", () => daemonStatus);
 ipcMain.handle("daemon:start", () => startDaemon());
 ipcMain.handle("daemon:stop", () => stopDaemon());
 ipcMain.handle("app:getVersion", () => app.getVersion());
-ipcMain.handle("telemetry:getBootstrap", () => buildTelemetryBootstrap(process.env, app.getVersion(), process.platform));
+ipcMain.handle("telemetry:getBootstrap", () =>
+	buildTelemetryBootstrap(process.env, app.getVersion(), process.platform),
+);
 ipcMain.handle("app:chooseDirectory", async () => {
 	const options: OpenDialogOptions = {
 		properties: ["openDirectory"],

--- a/frontend/src/renderer/components/TelemetryBoundary.tsx
+++ b/frontend/src/renderer/components/TelemetryBoundary.tsx
@@ -29,7 +29,9 @@ export class TelemetryBoundary extends React.Component<Props, State> {
 				<div className="flex h-screen items-center justify-center bg-background px-6 text-center text-foreground">
 					<div>
 						<h1 className="text-lg font-semibold">The app hit an unexpected error.</h1>
-						<p className="mt-2 text-sm text-muted-foreground">Restart the app or check the daemon logs if this keeps happening.</p>
+						<p className="mt-2 text-sm text-muted-foreground">
+							Restart the app or check the daemon logs if this keeps happening.
+						</p>
 					</div>
 				</div>
 			);

--- a/frontend/src/renderer/lib/telemetry.test.ts
+++ b/frontend/src/renderer/lib/telemetry.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-	routeSurface,
-	sanitizeRendererExceptionProperties,
-	sanitizeRendererProperties,
-} from "./telemetry";
+import { routeSurface, sanitizeRendererExceptionProperties, sanitizeRendererProperties } from "./telemetry";
 
 describe("telemetry sanitizers", () => {
 	it("categorizes routes without exporting raw paths", () => {

--- a/frontend/src/renderer/lib/telemetry.ts
+++ b/frontend/src/renderer/lib/telemetry.ts
@@ -70,7 +70,7 @@ export async function sanitizeRendererProperties(
 		case "ao.renderer.orchestrator_open_requested": {
 			const projectIDHash = await hashedTelemetryID(properties?.project_id);
 			if (projectIDHash) safe.project_id_hash = projectIDHash;
-			break
+			break;
 		}
 	}
 	return safe;
@@ -157,10 +157,7 @@ export async function captureRendererEvent(event: string, properties?: Record<st
 	posthog.capture(event, safeProperties);
 }
 
-export async function captureRendererException(
-	error: unknown,
-	properties?: Record<string, unknown>,
-): Promise<void> {
+export async function captureRendererException(error: unknown, properties?: Record<string, unknown>): Promise<void> {
 	if (!(await initTelemetry())) return;
 	const safeProperties = await sanitizeRendererExceptionProperties(error, properties);
 	posthog.capture("ao.renderer.exception", safeProperties);

--- a/frontend/src/shared/telemetry.test.ts
+++ b/frontend/src/shared/telemetry.test.ts
@@ -7,7 +7,11 @@ import { buildTelemetryBootstrap, defaultDataDir, loadOrCreateTelemetryInstallId
 const tempDirs: string[] = [];
 
 afterEach(async () => {
-	await Promise.all(tempDirs.splice(0).map((dir) => import("node:fs/promises").then(({ rm }) => rm(dir, { recursive: true, force: true }))));
+	await Promise.all(
+		tempDirs
+			.splice(0)
+			.map((dir) => import("node:fs/promises").then(({ rm }) => rm(dir, { recursive: true, force: true }))),
+	);
 });
 
 test("defaultDataDir prefers AO_DATA_DIR", () => {


### PR DESCRIPTION
Summary: allow project removal teardown to continue when a live session is missing runtime/workspace handles; keep other teardown errors blocking removal; add regression coverage. Fixes #326. Tests: cd backend && go test ./internal/service/session ./internal/service/project