### PR TITLE
fix(review): gate idempotency on a recorded verdict, not run status

### DIFF
--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -185,9 +185,27 @@ func (e *Engine) Trigger(ctx context.Context, workerID domain.SessionID) (Trigge
 	}
 
 	// Idempotency: return a non-failed pass as-is. Failed passes stay visible
-	// but can be retried after the user fixes the underlying issue.
+	// but can be retried after the user fixes the underlying issue. A Running
+	// pass whose reviewer pane was killed out-of-band (e.g. the user closed the
+	// terminal directly, bypassing Submit) is not actually in progress, so its
+	// liveness is checked before trusting it — otherwise the worker is stuck
+	// forever unable to re-review the commit (#342).
 	if existing, ok, err := e.store.GetReviewRunBySessionAndSHA(ctx, workerID, targetSHA); err != nil {
 		return TriggerResult{}, err
+	} else if ok && existing.Status == domain.ReviewRunRunning {
+		alive := false
+		if review.ReviewerHandleID != "" {
+			alive, err = e.launcher.Alive(ctx, review.ReviewerHandleID)
+			if err != nil {
+				return TriggerResult{}, err
+			}
+		}
+		if alive {
+			return TriggerResult{Run: existing, ReviewerHandleID: review.ReviewerHandleID, Created: false}, nil
+		}
+		if _, err := e.store.UpdateReviewRunResult(ctx, existing.ID, domain.ReviewRunFailed, domain.VerdictNone, "reviewer pane no longer running"); err != nil {
+			return TriggerResult{}, err
+		}
 	} else if ok && existing.Status != domain.ReviewRunFailed {
 		return TriggerResult{Run: existing, ReviewerHandleID: review.ReviewerHandleID, Created: false}, nil
 	}

--- a/backend/internal/review/review.go
+++ b/backend/internal/review/review.go
@@ -184,30 +184,32 @@ func (e *Engine) Trigger(ctx context.Context, workerID domain.SessionID) (Trigge
 		return TriggerResult{}, err
 	}
 
-	// Idempotency: return a non-failed pass as-is. Failed passes stay visible
-	// but can be retried after the user fixes the underlying issue. A Running
-	// pass whose reviewer pane was killed out-of-band (e.g. the user closed the
-	// terminal directly, bypassing Submit) is not actually in progress, so its
-	// liveness is checked before trusting it — otherwise the worker is stuck
-	// forever unable to re-review the commit (#342).
+	// Idempotency: a pass only counts as done once it actually carries a
+	// verdict (set exclusively by Submit). Status alone isn't enough — a
+	// Running pass with no verdict may have been interrupted (its execution
+	// stopped, or its pane killed) without ever calling Submit, and pane
+	// liveness can't distinguish "still working" from "pane open, work
+	// stopped." So an un-verdicted Running pass is superseded on retry: it's
+	// marked Failed, and a fresh pass is started below — reusing the pane via
+	// Notify if it's still alive, or spawning a new one if not (#342).
 	if existing, ok, err := e.store.GetReviewRunBySessionAndSHA(ctx, workerID, targetSHA); err != nil {
 		return TriggerResult{}, err
+	} else if ok && existing.Verdict != domain.VerdictNone {
+		return TriggerResult{Run: existing, ReviewerHandleID: review.ReviewerHandleID, Created: false}, nil
 	} else if ok && existing.Status == domain.ReviewRunRunning {
-		alive := false
-		if review.ReviewerHandleID != "" {
-			alive, err = e.launcher.Alive(ctx, review.ReviewerHandleID)
-			if err != nil {
-				return TriggerResult{}, err
-			}
-		}
-		if alive {
-			return TriggerResult{Run: existing, ReviewerHandleID: review.ReviewerHandleID, Created: false}, nil
-		}
-		if _, err := e.store.UpdateReviewRunResult(ctx, existing.ID, domain.ReviewRunFailed, domain.VerdictNone, "reviewer pane no longer running"); err != nil {
+		superseded, err := e.store.UpdateReviewRunResult(ctx, existing.ID, domain.ReviewRunFailed, domain.VerdictNone, "superseded by a new review trigger")
+		if err != nil {
 			return TriggerResult{}, err
 		}
-	} else if ok && existing.Status != domain.ReviewRunFailed {
-		return TriggerResult{Run: existing, ReviewerHandleID: review.ReviewerHandleID, Created: false}, nil
+		if !superseded {
+			// Lost the race to a concurrent Submit: re-read and trust its verdict
+			// rather than starting a redundant pass.
+			if latest, ok, err := e.store.GetReviewRun(ctx, existing.ID); err != nil {
+				return TriggerResult{}, err
+			} else if ok {
+				return TriggerResult{Run: latest, ReviewerHandleID: review.ReviewerHandleID, Created: false}, nil
+			}
+		}
 	}
 
 	harness, err := e.reviewerHarness(ctx, worker)

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -128,7 +128,9 @@ func (f *fakeLauncher) Notify(_ context.Context, handleID string, spec LaunchSpe
 	f.gotSpec = spec
 	return f.notifyErr
 }
-func (f *fakeLauncher) Alive(_ context.Context, _ string) (bool, error) { return f.alive, nil }
+func (f *fakeLauncher) Alive(_ context.Context, _ string) (bool, error) {
+	return f.alive || f.spawned, nil
+}
 
 func liveWorker() domain.SessionRecord {
 	return domain.SessionRecord{
@@ -246,7 +248,7 @@ func TestTriggerIsIdempotentForSameCommit(t *testing.T) {
 		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", ReviewerHandleID: "review-mer-1"},
 		runs:   []domain.ReviewRun{{ID: "run-1", SessionID: "mer-1", TargetSHA: "sha1", Status: domain.ReviewRunRunning}},
 	}
-	launcher := &fakeLauncher{}
+	launcher := &fakeLauncher{alive: true}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
 	res, err := eng.Trigger(context.Background(), "mer-1")
@@ -261,6 +263,34 @@ func TestTriggerIsIdempotentForSameCommit(t *testing.T) {
 	}
 	if len(store.runs) != 1 {
 		t.Fatalf("should not insert another run: %+v", store.runs)
+	}
+}
+
+func TestTriggerRespawnsWhenRunningRowIsStale(t *testing.T) {
+	// The reviewer pane for an in-flight run was killed out-of-band (e.g. the
+	// user closed its terminal directly instead of letting it finish), so the
+	// run never reaches Failed via Submit. Retrying must not report "already
+	// up to date" — it must mark the stale row Failed and start a fresh pass.
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", ReviewerHandleID: "review-mer-1"},
+		runs:   []domain.ReviewRun{{ID: "run-1", SessionID: "mer-1", TargetSHA: "sha1", Status: domain.ReviewRunRunning}},
+	}
+	launcher := &fakeLauncher{alive: false, handle: "review-mer-2"}
+	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	res, err := eng.Trigger(context.Background(), "mer-1")
+	if err != nil {
+		t.Fatalf("Trigger: %v", err)
+	}
+	if !res.Created {
+		t.Fatalf("expected a fresh pass when the prior run's pane is dead: %+v", res)
+	}
+	if !launcher.spawned {
+		t.Fatalf("expected a fresh spawn, not a notify, since the old pane is dead: %+v", launcher)
+	}
+	stale := store.runs[0]
+	if stale.ID != "run-1" || stale.Status != domain.ReviewRunFailed {
+		t.Fatalf("expected stale run-1 marked Failed, got %+v", stale)
 	}
 }
 

--- a/backend/internal/review/review_test.go
+++ b/backend/internal/review/review_test.go
@@ -182,42 +182,37 @@ func TestTriggerSpawnsNewReviewerAndRecordsRunAfterLaunch(t *testing.T) {
 	}
 }
 
-func TestTriggerConcurrentSameWorkerSpawnsOnce(t *testing.T) {
+func TestTriggerConcurrentSameWorkerNeverDoubleSpawns(t *testing.T) {
+	// Concurrent triggers for the same worker must never end up with two
+	// independent reviewer panes for the same commit (#242): the loser of
+	// each race either finds the pane already alive (Notify, not Spawn) or
+	// loses the unique-insert race outright. Verdict-gated idempotency (#342)
+	// means a run with no verdict yet is no longer trusted blindly, so repeat
+	// triggers may notify the live pane again instead of being a pure no-op —
+	// that's fine; only an actual second Spawn would be a regression.
 	store := &fakeStore{}
 	launcher := &fakeLauncher{handle: "review-mer-1"}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
 
 	const n = 8
 	var wg sync.WaitGroup
-	results := make([]TriggerResult, n)
 	errs := make([]error, n)
 	wg.Add(n)
 	for i := 0; i < n; i++ {
 		go func(i int) {
 			defer wg.Done()
-			results[i], errs[i] = eng.Trigger(context.Background(), "mer-1")
+			_, errs[i] = eng.Trigger(context.Background(), "mer-1")
 		}(i)
 	}
 	wg.Wait()
 
-	created := 0
 	for i := 0; i < n; i++ {
 		if errs[i] != nil {
 			t.Fatalf("Trigger[%d]: %v", i, errs[i])
 		}
-		if results[i].Created {
-			created++
-		}
-	}
-	// Exactly one trigger does the work; the rest reuse its run.
-	if created != 1 {
-		t.Errorf("Created=true count = %d, want exactly 1", created)
 	}
 	if launcher.spawnCount != 1 {
-		t.Errorf("reviewer spawn count = %d, want 1", launcher.spawnCount)
-	}
-	if len(store.runs) != 1 {
-		t.Errorf("recorded review runs = %d, want 1", len(store.runs))
+		t.Errorf("reviewer spawn count = %d, want exactly 1 (no double-spawn)", launcher.spawnCount)
 	}
 }
 
@@ -244,9 +239,14 @@ func TestTriggerFallsBackToExistingRunOnUniqueConflict(t *testing.T) {
 }
 
 func TestTriggerIsIdempotentForSameCommit(t *testing.T) {
+	// A verdict was actually recorded for this commit (via Submit) — this is
+	// the only state that counts as genuinely done.
 	store := &fakeStore{
 		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", ReviewerHandleID: "review-mer-1"},
-		runs:   []domain.ReviewRun{{ID: "run-1", SessionID: "mer-1", TargetSHA: "sha1", Status: domain.ReviewRunRunning}},
+		runs: []domain.ReviewRun{{
+			ID: "run-1", SessionID: "mer-1", TargetSHA: "sha1",
+			Status: domain.ReviewRunComplete, Verdict: domain.VerdictApproved,
+		}},
 	}
 	launcher := &fakeLauncher{alive: true}
 	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
@@ -266,11 +266,14 @@ func TestTriggerIsIdempotentForSameCommit(t *testing.T) {
 	}
 }
 
-func TestTriggerRespawnsWhenRunningRowIsStale(t *testing.T) {
-	// The reviewer pane for an in-flight run was killed out-of-band (e.g. the
-	// user closed its terminal directly instead of letting it finish), so the
-	// run never reaches Failed via Submit. Retrying must not report "already
-	// up to date" — it must mark the stale row Failed and start a fresh pass.
+func TestTriggerRespawnsWhenRunningRowHasNoVerdict(t *testing.T) {
+	// A prior pass for this commit never produced a verdict — its execution
+	// may have been stopped (e.g. the user killed the terminal, or just
+	// interrupted the agent without killing the pane) without ever calling
+	// Submit. Pane liveness alone can't tell those apart, so Status=Running
+	// with no verdict is never trusted blindly: the stale row is marked
+	// Failed and a fresh pass starts, reusing the pane if it's still alive
+	// (Notify) and spawning a new one only if it's not (#342).
 	store := &fakeStore{
 		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", ReviewerHandleID: "review-mer-1"},
 		runs:   []domain.ReviewRun{{ID: "run-1", SessionID: "mer-1", TargetSHA: "sha1", Status: domain.ReviewRunRunning}},
@@ -283,10 +286,38 @@ func TestTriggerRespawnsWhenRunningRowIsStale(t *testing.T) {
 		t.Fatalf("Trigger: %v", err)
 	}
 	if !res.Created {
-		t.Fatalf("expected a fresh pass when the prior run's pane is dead: %+v", res)
+		t.Fatalf("expected a fresh pass when the prior run has no verdict: %+v", res)
 	}
 	if !launcher.spawned {
-		t.Fatalf("expected a fresh spawn, not a notify, since the old pane is dead: %+v", launcher)
+		t.Fatalf("expected a fresh spawn since the old pane is dead: %+v", launcher)
+	}
+	stale := store.runs[0]
+	if stale.ID != "run-1" || stale.Status != domain.ReviewRunFailed {
+		t.Fatalf("expected stale run-1 marked Failed, got %+v", stale)
+	}
+}
+
+func TestTriggerNotifiesLiveReviewerWhenRunningRowHasNoVerdict(t *testing.T) {
+	// Same as above, but the pane is still alive (e.g. the user only
+	// interrupted the agent's work without killing the terminal/pane). The
+	// stale row is still superseded, but the live pane is re-notified instead
+	// of spawning a redundant second pane.
+	store := &fakeStore{
+		review: &domain.Review{ID: "rev-1", SessionID: "mer-1", ReviewerHandleID: "review-mer-1"},
+		runs:   []domain.ReviewRun{{ID: "run-1", SessionID: "mer-1", TargetSHA: "sha1", Status: domain.ReviewRunRunning}},
+	}
+	launcher := &fakeLauncher{alive: true, handle: "review-mer-1"}
+	eng := newEngineForTest(store, fakeSessions{rec: liveWorker(), ok: true}, prAt("sha1"), fakeProjects{}, launcher)
+
+	res, err := eng.Trigger(context.Background(), "mer-1")
+	if err != nil {
+		t.Fatalf("Trigger: %v", err)
+	}
+	if !res.Created {
+		t.Fatalf("expected a fresh pass even though the pane is reused: %+v", res)
+	}
+	if !launcher.notified || launcher.spawned {
+		t.Fatalf("expected notify on the still-alive pane, not a spawn: %+v", launcher)
 	}
 	stale := store.runs[0]
 	if stale.ID != "run-1" || stale.Status != domain.ReviewRunFailed {


### PR DESCRIPTION
Fixes #342

## Summary
- `Trigger`'s idempotency check now treats a run as "already up to date" only when it actually carries a verdict (set exclusively by `Submit`), not merely a non-`Failed` status.
- A `Running` run with no verdict is never trusted blindly — pane liveness alone can't distinguish "still actively reviewing" from "pane left open after the user stopped/interrupted the agent without killing it." It's superseded (marked `Failed`) and a fresh pass is started: the live pane is notified if it's still alive, or a new one is spawned if not.
- This means a review the user stopped mid-run (via terminal/Ctrl-C, or by killing the pane outright) can always be retried, instead of permanently reporting "Review is already up to date for this commit."

## Test
- `TestTriggerIsIdempotentForSameCommit` now requires an actual recorded verdict to reuse a run.
- Added `TestTriggerRespawnsWhenRunningRowHasNoVerdict` (dead pane → fresh spawn) and `TestTriggerNotifiesLiveReviewerWhenRunningRowHasNoVerdict` (alive pane → notify, not spawn) covering the reported bug.
- Renamed/adjusted the concurrency regression test (`TestTriggerConcurrentSameWorkerNeverDoubleSpawns`) to assert the invariant that actually matters under the new contract: concurrent triggers never spawn two independent reviewer panes for the same commit (#242), even though they may no longer be a pure single-row no-op.
- `go test -race ./internal/review/...` passes.