### PR TITLE
fix(sidebar): make project row hover icons clickable and non-overlapping

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -104,9 +104,9 @@ describe("Sidebar", () => {
 		const count = screen.getByText("0");
 
 		if (!projectRow) throw new Error("Project row button not found");
-		expect(projectRow).toHaveClass("group-hover/menu-item:pr-[78px]");
-		expect(projectRow).toHaveClass("group-focus-within/menu-item:pr-[78px]");
-		expect(projectRow).toHaveClass("group-has-data-[state=open]/menu-item:pr-[78px]");
+		expect(projectRow).toHaveClass("group-hover/menu-item:pr-[84px]");
+		expect(projectRow).toHaveClass("group-focus-within/menu-item:pr-[84px]");
+		expect(projectRow).toHaveClass("group-has-data-[state=open]/menu-item:pr-[84px]");
 		expect(count).toHaveClass("group-hover/menu-item:opacity-0");
 		expect(count).toHaveClass("group-focus-within/menu-item:opacity-0");
 		expect(count).toHaveClass("group-has-data-[state=open]/menu-item:opacity-0");

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -468,7 +468,7 @@ function ProjectItem({
 					// Make room for the hover actions (dashboard, orchestrator, kebab)
 					// when the row is hovered, focused, or its menu is open (the
 					// absolutely-positioned cluster replaces the count).
-					"group-hover/menu-item:pr-[78px] group-focus-within/menu-item:pr-[78px] group-has-data-[state=open]/menu-item:pr-[78px]",
+					"group-hover/menu-item:pr-[84px] group-focus-within/menu-item:pr-[84px] group-has-data-[state=open]/menu-item:pr-[84px]",
 					// Icon rail: the old 36px letter tile.
 					"group-data-[collapsible=icon]:size-9! group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:rounded-lg group-data-[collapsible=icon]:p-0! group-data-[collapsible=icon]:font-semibold",
 				)}
@@ -483,7 +483,7 @@ function ProjectItem({
 				/>
 				<span className="hidden group-data-[collapsible=icon]:block">{workspace.name.charAt(0).toUpperCase()}</span>
 				<span className="min-w-0 flex-1 truncate group-data-[collapsible=icon]:hidden">{workspace.name}</span>
-				<span className="grid h-4 min-w-4 shrink-0 place-items-center rounded bg-interactive-hover px-1 font-mono text-[10px] leading-none text-passive group-hover/menu-item:opacity-0 group-focus-within/menu-item:opacity-0 group-has-data-[state=open]/menu-item:opacity-0 group-data-[collapsible=icon]:hidden">
+				<span className="grid h-4 min-w-4 shrink-0 place-items-center rounded bg-interactive-hover px-1 font-mono text-[10px] leading-none text-passive group-hover/menu-item:pointer-events-none group-hover/menu-item:opacity-0 group-focus-within/menu-item:opacity-0 group-focus-within/menu-item:pointer-events-none group-has-data-[state=open]/menu-item:opacity-0 group-has-data-[state=open]/menu-item:pointer-events-none group-data-[collapsible=icon]:hidden">
 					{sessions.length}
 				</span>
 			</SidebarMenuButton>
@@ -492,7 +492,7 @@ function ProjectItem({
           open), replacing the session count, and stays hidden in the icon rail. */}
 			<div
 				className={cn(
-					"absolute top-0 right-1 flex h-9 items-center gap-px",
+					"absolute top-0 right-1 z-10 flex h-9 items-center gap-px",
 					"opacity-0 transition-opacity",
 					"group-hover/menu-item:opacity-100 group-focus-within/menu-item:opacity-100 group-has-data-[state=open]/menu-item:opacity-100",
 					"group-data-[collapsible=icon]:hidden",


### PR DESCRIPTION
## Problem

The project row hover action icons (dashboard, orchestrator, kebab) in the sidebar have three issues:

1. **Icons not clickable on hover** — the session count badge fades to `opacity-0` on hover but keeps `pointer-events: auto`, intercepting clicks meant for the action buttons
2. **Icons only work on the second project** — when the first project is expanded with sessions, positioned session rows (`SidebarMenuSubItem` with `position: relative`) paint on top of the action cluster (which has no `z-index`), blocking hover/click on the first project's icons
3. **Icons overlap text** — `pr-[78px]` is tight for three 20px action buttons + right offset

## Fix

Three changes in `Sidebar.tsx`:

1. **Count span pointer-events:** Added `group-hover/menu-item:pointer-events-none`, `group-focus-within/menu-item:pointer-events-none`, and `group-has-data-[state=open]/menu-item:pointer-events-none` so the invisible count badge cannot intercept clicks

2. **Action cluster z-index:** Added `z-10` to the absolutely-positioned action div so it paints above positioned session rows

3. **Padding clearance:** Bumped `pr-[78px]` → `pr-[84px]` for consistent clearance

## Verification

- ✅ `pnpm typecheck` passes clean
- Reported by @aditi and @phylolver(vaibhaav)