### PR TITLE
fix(sidebar): always show project row action icons

### DIFF
--- a/frontend/src/renderer/components/Sidebar.test.tsx
+++ b/frontend/src/renderer/components/Sidebar.test.tsx
@@ -97,18 +97,13 @@ describe("Sidebar", () => {
 		expect(navigateMock).toHaveBeenCalledWith({ to: "/projects/$projectId", params: { projectId: "proj-1" } });
 	});
 
-	it("hides the worker count in every state that reveals project actions", () => {
+	it("always shows action icons and reserves padding for them", () => {
 		renderSidebar();
 
 		const projectRow = screen.getByText("Project One").closest("button");
-		const count = screen.getByText("0");
 
 		if (!projectRow) throw new Error("Project row button not found");
-		expect(projectRow).toHaveClass("group-hover/menu-item:pr-[84px]");
-		expect(projectRow).toHaveClass("group-focus-within/menu-item:pr-[84px]");
-		expect(projectRow).toHaveClass("group-has-data-[state=open]/menu-item:pr-[84px]");
-		expect(count).toHaveClass("group-hover/menu-item:opacity-0");
-		expect(count).toHaveClass("group-focus-within/menu-item:opacity-0");
-		expect(count).toHaveClass("group-has-data-[state=open]/menu-item:opacity-0");
+		// Padding is always reserved for the action cluster (not hover-gated)
+		expect(projectRow).toHaveClass("pr-[84px]");
 	});
 });

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -465,10 +465,9 @@ function ProjectItem({
 					"before:absolute before:top-2 before:bottom-2 before:left-0 before:w-px before:rounded-full before:bg-transparent",
 					"hover:bg-interactive-hover hover:text-foreground active:bg-interactive-hover active:text-foreground",
 					"data-[active=true]:bg-interactive-active data-[active=true]:font-semibold data-[active=true]:text-foreground data-[active=true]:before:bg-accent",
-					// Make room for the hover actions (dashboard, orchestrator, kebab)
-					// when the row is hovered, focused, or its menu is open (the
-					// absolutely-positioned cluster replaces the count).
-					"group-hover/menu-item:pr-[84px] group-focus-within/menu-item:pr-[84px] group-has-data-[state=open]/menu-item:pr-[84px]",
+					// Always reserve room for the action cluster (dashboard,
+					// orchestrator, kebab) — icons are always visible, not hover-gated.
+					"pr-[84px]",
 					// Icon rail: the old 36px letter tile.
 					"group-data-[collapsible=icon]:size-9! group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:rounded-lg group-data-[collapsible=icon]:p-0! group-data-[collapsible=icon]:font-semibold",
 				)}
@@ -483,18 +482,16 @@ function ProjectItem({
 				/>
 				<span className="hidden group-data-[collapsible=icon]:block">{workspace.name.charAt(0).toUpperCase()}</span>
 				<span className="min-w-0 flex-1 truncate group-data-[collapsible=icon]:hidden">{workspace.name}</span>
-				<span className="grid h-4 min-w-4 shrink-0 place-items-center rounded bg-interactive-hover px-1 font-mono text-[10px] leading-none text-passive group-hover/menu-item:pointer-events-none group-hover/menu-item:opacity-0 group-focus-within/menu-item:opacity-0 group-focus-within/menu-item:pointer-events-none group-has-data-[state=open]/menu-item:opacity-0 group-has-data-[state=open]/menu-item:pointer-events-none group-data-[collapsible=icon]:hidden">
+				<span className="hidden group-data-[collapsible=icon]:grid h-4 min-w-4 shrink-0 place-items-center rounded bg-interactive-hover px-1 font-mono text-[10px] leading-none text-passive">
 					{sessions.length}
 				</span>
 			</SidebarMenuButton>
-			{/* Per-project hover actions: dashboard board, orchestrator, and a kebab
-          menu. The cluster reveals on row hover/focus (or while the kebab is
-          open), replacing the session count, and stays hidden in the icon rail. */}
+			{/* Per-project actions: dashboard board, orchestrator, and a kebab
+			menu. Always visible (not hover-gated) to avoid CSS :hover group
+			propagation issues in Electron's Chromium. Hidden in the icon rail. */}
 			<div
 				className={cn(
 					"absolute top-0 right-1 z-10 flex h-9 items-center gap-px",
-					"opacity-0 transition-opacity",
-					"group-hover/menu-item:opacity-100 group-focus-within/menu-item:opacity-100 group-has-data-[state=open]/menu-item:opacity-100",
 					"group-data-[collapsible=icon]:hidden",
 				)}
 			>

--- a/frontend/src/renderer/components/Sidebar.tsx
+++ b/frontend/src/renderer/components/Sidebar.tsx
@@ -482,7 +482,7 @@ function ProjectItem({
 				/>
 				<span className="hidden group-data-[collapsible=icon]:block">{workspace.name.charAt(0).toUpperCase()}</span>
 				<span className="min-w-0 flex-1 truncate group-data-[collapsible=icon]:hidden">{workspace.name}</span>
-				<span className="hidden group-data-[collapsible=icon]:grid h-4 min-w-4 shrink-0 place-items-center rounded bg-interactive-hover px-1 font-mono text-[10px] leading-none text-passive">
+				<span className="hidden h-4 min-w-4 shrink-0 place-items-center rounded bg-interactive-hover px-1 font-mono text-[10px] leading-none text-passive">
 					{sessions.length}
 				</span>
 			</SidebarMenuButton>


### PR DESCRIPTION
## Problem

The hover-reveal mechanism for project row action icons (dashboard, orchestrator, kebab) was not working in the Electron app. The icons use CSS `opacity-0` → `group-hover/menu-item:opacity-100` to appear on hover, but `group-hover` never triggered — icons were invisible no matter what.

PR #345 attempted to fix clickability (z-index, pointer-events, padding), but the underlying visibility issue remained: the icons never showed up at all.

## Fix

Make the action icons **always visible** instead of relying on CSS `:hover` group propagation:

1. **Action cluster div**: Removed `opacity-0` default and `group-hover/menu-item:opacity-100` hover variant — icons are always at full opacity
2. **Button padding**: Changed from hover-gated `group-hover/menu-item:pr-[84px]` to always `pr-[84px]` — text always reserves room for icons
3. **Session count badge**: Now hidden by default (was only visible when icons were hidden) — icons replace it permanently
4. **z-10 retained**: Keeps icons above positioned session rows for clickability

## Verification

- ✅ `pnpm typecheck` passes
- ✅ All 5 sidebar tests pass
- ✅ Build succeeds

Reported by @phylolver(vaibhaav). Supersedes #345.