### PR TITLE
ci: build unsigned desktop artifacts on 0.0.0-testing-* tags

### DIFF
--- a/.github/workflows/desktop-testing.yml
+++ b/.github/workflows/desktop-testing.yml
@@ -1,0 +1,75 @@
+name: Desktop testing build
+
+# Builds UNSIGNED desktop artifacts on a `0.0.0-testing-<sha>` tag and attaches
+# them to a GitHub prerelease, so the packaging pipeline can be exercised
+# end-to-end before any signing/notarization secrets exist.
+#
+# Per OS the current electron-forge makers produce:
+#   - macOS   → .zip          (the .dmg maker is a follow-up)
+#   - Windows → Setup.exe + .nupkg + RELEASES (Squirrel)
+#   - Linux   → .deb and .rpm
+#
+# Each OS builds on its own native runner because build-daemon.mjs compiles the
+# bundled `ao` daemon for the build host's platform; cross-OS packaging would
+# ship the wrong daemon (issues #235/#256). The macOS runner is arm64, so the
+# macOS artifact is arm64-only until per-arch builds are wired.
+#
+# Signing is intentionally OFF (no CSC_LINK / APPLE_ID / Windows cert), so these
+# builds do NOT pass Gatekeeper/SmartScreen. They are for pipeline validation,
+# not distribution.
+
+on:
+  push:
+    tags:
+      - "0.0.0-testing-*"
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      # The daemon is compiled by build-daemon.mjs during premake, so the Go
+      # toolchain must be present and pinned on every runner.
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+      # The Linux rpm maker needs rpmbuild, which ubuntu-latest does not ship.
+      - name: Install rpm tooling (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y rpm
+      - run: npm ci
+      - name: Build artifacts (unsigned)
+        run: npm run make
+      - name: Publish artifacts to the tag's GitHub release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # Create the prerelease once. Parallel matrix jobs race here, so a
+          # second job's "already exists" failure is expected and ignored.
+          gh release create "$TAG" --prerelease --title "$TAG" \
+            --notes "Unsigned desktop testing build (pipeline validation only — not signed or notarized)." \
+            || true
+          # Upload every maker output. NUL-delimited to survive spaces in the
+          # app name ("Agent Orchestrator-..."); --clobber makes re-runs idempotent.
+          find out/make -type f -print0 | while IFS= read -r -d '' f; do
+            echo "uploading: $f"
+            gh release upload "$TAG" "$f" --clobber
+          done


### PR DESCRIPTION
## What

Adds `.github/workflows/desktop-testing.yml`: a tag-triggered workflow that builds the Electron desktop app (with the bundled Go daemon) on **macOS, Windows, and Linux** runners and attaches the artifacts to a GitHub **prerelease**.

Trigger: pushing a `0.0.0-testing-*` tag (tag only, nothing else).

## Why

We want to validate the desktop packaging pipeline end-to-end before investing in signing certs. This lets us push a `0.0.0-testing-<sha>` tag and get downloadable artifacts to smoke-test the bundle-daemon-in-app flow.

## What it produces (per OS, current makers)

- **macOS** → `.zip` (the `.dmg` maker is a deliberate follow-up)
- **Windows** → `Setup.exe` + `.nupkg` + `RELEASES` (Squirrel)
- **Linux** → `.deb` and `.rpm`

## Notes / intentional scope

- **Unsigned on purpose.** No `CSC_LINK`/`APPLE_ID`/Windows cert wired, so these builds will *not* pass Gatekeeper/SmartScreen. They are for pipeline validation, not distribution.
- **Native per-OS runners** (same rationale as `frontend-release.yml`): `build-daemon.mjs` compiles the daemon for the build host, so cross-OS builds would ship the wrong daemon (#235/#256).
- **macOS artifact is arm64-only** (the runner is arm64) until per-arch daemon builds are wired.
- Release creation is matrix-race-safe (`gh release create ... || true`) and re-run idempotent (`--clobber`); uploads are NUL-delimited to survive the space in the app name.
- The `.rpm` maker needs `rpmbuild`, installed on the Linux job.

This must land on `main` for the `0.0.0-testing-*` tag to trigger it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)