### PR TITLE
fix: stabilize frontend Playwright e2e

### DIFF
--- a/frontend/e2e/history-nav.spec.ts
+++ b/frontend/e2e/history-nav.spec.ts
@@ -7,7 +7,7 @@ test("titlebar back/forward arrows traverse history", async ({ page }) => {
 	await expect(page.getByText("Projects")).toBeVisible();
 
 	// Navigate: home → session view (in-app push).
-	await page.getByRole("button", { name: "Open refactor-mux" }).click();
+	await page.getByRole("button", { name: "Open Split terminal mux responsibilities" }).click();
 	await expect(page).toHaveURL(/sessions\/refactor-mux/);
 
 	const back = page.getByRole("button", { name: "Go back" });

--- a/frontend/e2e/inspector-toggle.spec.ts
+++ b/frontend/e2e/inspector-toggle.spec.ts
@@ -10,7 +10,7 @@ import { expect, test } from "@playwright/test";
 // the real rrp + CSS pipeline, which the mocked unit tests can't exercise.
 test("topbar button collapses and reopens the inspector rail", async ({ page }) => {
 	await page.goto("/");
-	await page.getByRole("button", { name: "Open refactor-mux" }).click();
+	await page.getByRole("button", { name: "Open Split terminal mux responsibilities" }).click();
 	await expect(page).toHaveURL(/sessions\/refactor-mux/);
 
 	// Fresh profile: the rail must mount open, not get toggled shut by

--- a/frontend/e2e/workbench.spec.ts
+++ b/frontend/e2e/workbench.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 // The Playwright web server runs `dev:web` (VITE_NO_ELECTRON=1), so
 // useWorkspaceQuery serves the deterministic preview fixtures from
@@ -7,24 +7,34 @@ import { expect, test } from "@playwright/test";
 
 test("renders the orchestrator-first workbench shell", async ({ page }) => {
 	await page.goto("/");
-	// The single pinned Orchestrator anchor + the Projects group + a name-only worker row.
-	await expect(page.getByRole("button", { name: "Orchestrator", exact: true })).toBeVisible();
+	// The single pinned Orchestrator anchor + the Projects group + current title-based worker rows.
+	await expect(page.getByRole("button", { name: "Orchestrator board" })).toBeVisible();
 	await expect(page.getByText("Projects")).toBeVisible();
-	await expect(page.getByRole("button", { name: "fix-webgl-fallback", exact: true })).toBeVisible();
-	// Orchestrator side rail = the quiet Workers list.
-	await expect(page.getByText("Workers", { exact: true })).toBeVisible();
+	await expect(
+		page.getByRole("button", { name: "Open Restore fallback renderer after WebGL init fails" }),
+	).toBeVisible();
+	await expect(page.getByRole("button", { name: "Open Split terminal mux responsibilities" })).toBeVisible();
 });
 
 test("deep-links into a worker session", async ({ page }) => {
-	await page.goto("/#/workspaces/api-gateway/sessions/refactor-mux");
-	// Worker view = emdash three-pane with the Git review rail.
-	await expect(page.getByText("Changed")).toBeVisible();
-	await expect(page.getByRole("button", { name: /Commit & Push/ })).toBeVisible();
+	await page.goto("/#/projects/api-gateway/sessions/refactor-mux");
+	// Worker view = terminal preview plus current Summary inspector rail.
+	await expectSessionDetail(page);
 });
 
-test("drilling into a worker opens its Git review rail", async ({ page }) => {
+test("drilling into a worker opens its session detail view", async ({ page }) => {
 	await page.goto("/");
-	await page.getByRole("button", { name: "refactor-mux", exact: true }).click();
-	await expect(page.getByRole("button", { name: /Commit & Push/ })).toBeVisible();
-	await expect(page.getByText("internal/mux/terminal_mux.go")).toBeVisible();
+	await page.getByRole("button", { name: "Open Split terminal mux responsibilities" }).click();
+	await expect(page).toHaveURL(/projects\/api-gateway\/sessions\/refactor-mux/);
+	await expectSessionDetail(page);
 });
+
+async function expectSessionDetail(page: Page) {
+	const inspector = page.getByTestId("inspector");
+	await expect(inspector).toBeVisible();
+	await expect(page.getByText("Split terminal mux responsibilities")).toBeVisible();
+	await expect(inspector.getByText("feat/refactor-mux")).toBeVisible();
+	await expect(
+		page.getByTestId("terminal").getByText("Browser preview renders a static terminal surface."),
+	).toBeVisible();
+}

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,15 +1,33 @@
 import { defineConfig } from "@playwright/test";
 
+const e2ePort = parseE2EPort(process.env.PLAYWRIGHT_E2E_PORT);
+const e2eHost = "127.0.0.1";
+const webServerEnv = Object.fromEntries(
+	Object.entries(process.env).filter(
+		(entry): entry is [string, string] => entry[0].startsWith("VITE_") && typeof entry[1] === "string",
+	),
+);
+webServerEnv.VITE_AO_API_BASE_URL = `http://${e2eHost}:${e2ePort}`;
+
+function parseE2EPort(value: string | undefined): number {
+	const port = Number(value ?? 5174);
+	if (!Number.isInteger(port) || port < 1 || port > 65535) {
+		throw new Error(`PLAYWRIGHT_E2E_PORT must be an integer TCP port, got ${value ?? "5174"}`);
+	}
+	return port;
+}
+
 export default defineConfig({
 	testDir: "e2e",
 	use: {
-		baseURL: "http://127.0.0.1:5173",
+		baseURL: `http://${e2eHost}:${e2ePort}`,
 	},
 	webServer: {
 		// dev:web serves the renderer alone (VITE_NO_ELECTRON=1) — no Electron child to
 		// launch, which is all the browser-based e2e suite needs.
-		command: "npm run dev:web -- --port 5173",
-		port: 5173,
-		reuseExistingServer: !process.env.CI,
+		command: `npm run dev:web -- --host ${e2eHost} --port ${e2ePort} --strictPort`,
+		env: webServerEnv,
+		port: e2ePort,
+		reuseExistingServer: false,
 	},
 });

--- a/frontend/src/renderer/lib/event-transport.test.ts
+++ b/frontend/src/renderer/lib/event-transport.test.ts
@@ -70,10 +70,25 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	vi.unstubAllEnvs();
 	delete (globalThis as unknown as { EventSource?: unknown }).EventSource;
 });
 
 describe("createEventTransport", () => {
+	it("skips the SSE stream in deterministic browser preview mode", () => {
+		vi.stubEnv("VITE_NO_ELECTRON", "1");
+
+		const disconnect = createEventTransport(fakeQueryClient()).connect();
+
+		expect(EventSourceStub.instances).toHaveLength(0);
+		expect(onStatusMock).not.toHaveBeenCalled();
+		expect(subscribeApiBaseUrlMock).not.toHaveBeenCalled();
+		expect(getEventsConnectionState()).toBe("idle");
+
+		disconnect();
+		expect(getEventsConnectionState()).toBe("idle");
+	});
+
 	it("opens a single SSE connection to the current base URL on connect", () => {
 		createEventTransport(fakeQueryClient()).connect();
 

--- a/frontend/src/renderer/lib/event-transport.ts
+++ b/frontend/src/renderer/lib/event-transport.ts
@@ -16,6 +16,10 @@ const SSE_RETRY_MS = 5_000;
 // constants still work.
 const EVENTSOURCE_CLOSED = 2;
 
+function usesDeterministicPreviewData(): boolean {
+	return import.meta.env.VITE_NO_ELECTRON === "1";
+}
+
 // CDC event types the daemon pushes over the SSE stream (see
 // backend/internal/cdc/event.go). The SSE writer tags each frame with
 // `event: <type>`, so named events bypass EventSource.onmessage and must be
@@ -42,6 +46,13 @@ const CDC_EVENT_TYPES = [
 export function createEventTransport(queryClient: QueryClient): EventTransport {
 	return {
 		connect() {
+			if (usesDeterministicPreviewData()) {
+				setEventsConnectionState("idle");
+				return () => {
+					setEventsConnectionState("idle");
+				};
+			}
+
 			let debounce: ReturnType<typeof setTimeout> | undefined;
 			let retryTimer: ReturnType<typeof setTimeout> | undefined;
 			let source: EventSource | undefined;


### PR DESCRIPTION
## Summary

- run the browser e2e preview on a dedicated deterministic loopback server (`127.0.0.1:5174`) with `--strictPort`
- disable local `reuseExistingServer` so Playwright cannot silently attach to a daemon-backed renderer or another app on the same port
- set `VITE_AO_API_BASE_URL` for the preview server so e2e route stubs still cover direct API calls after the daemon-status API-base changes
- skip the daemon SSE event stream when the renderer is running deterministic browser preview mode (`VITE_NO_ELECTRON=1`), removing the noisy `/api/v1/events` 502/proxy errors from local Playwright and dashboard smoke runs
- refresh stale workbench/history/inspector selectors and the worker deep link to match current title-based labels and `/projects/...` routes
- validate `PLAYWRIGHT_E2E_PORT` and avoid manually forwarding the full shell env into the Vite web server config

Fixes #357

## Notes

- This stays inside frontend preview/e2e behavior; no daemon, API schema, or production Electron lifecycle changes.
- The current GitHub frontend workflow runs Vitest, not Playwright e2e, so the browser suite remains local/manual unless a future PR wires it into CI.
- The previous `Changed` / `Commit & Push` / changed-file assertions targeted the old Git review rail. That rail was replaced by the current Summary/Reviews inspector flow (`feat(frontend): swap inspector Changes tab for empty Reviews placeholder`, later expanded by #335), so those assertions are obsolete rather than dropped coverage for a still-rendered UI.
- `VITE_AO_API_BASE_URL` intentionally points to the preview server during e2e so `page.route()` stubs catch direct API calls without reaching a real daemon; unstubbed API calls will hit the Vite preview server, so future tests should stub any daemon endpoint they rely on.
- Deterministic browser preview mode now also avoids opening the live daemon SSE stream, since that mode serves mock workspace data and intentionally does not require a daemon.

## Tests

- `npm --prefix frontend test -- src/renderer/lib/event-transport.test.ts`
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend test`
- `npm --prefix frontend run test:e2e -- --workers=1 e2e/workbench.spec.ts e2e/history-nav.spec.ts e2e/inspector-toggle.spec.ts`
- `npm --prefix frontend run test:e2e`
- Manual dashboard smoke: launched `dev:web` on `127.0.0.1:5174` with `VITE_AO_API_BASE_URL=http://127.0.0.1:5174`; verified deterministic mock board/session routes and confirmed no browser console failures, request failures, `/api/v1/events`, `502`, `Bad Gateway`, or `ECONNREFUSED` errors.
