### PR TITLE
fix(terminal): enable zellij mouse mode so wheel scroll works

### DIFF
--- a/backend/internal/adapters/runtime/zellij/commands.go
+++ b/backend/internal/adapters/runtime/zellij/commands.go
@@ -86,7 +86,15 @@ func attachArgs(id string) []string {
 func embeddedClientOptions() []string {
 	return []string{
 		"--pane-frames", "false",
-		"--mouse-mode", "false",
+		// Mouse mode MUST be on. The terminal runs `zellij attach` in the
+		// alternate screen buffer, and xterm.js is configured with
+		// scrollback: 0 (XtermTerminal.tsx), so there is no local scrollback
+		// to fall back on. With mouse mode off, zellij never enables mouse
+		// tracking — wheel events reach neither xterm (no buffer) nor zellij
+		// (no tracking) and scroll is completely dead. Enabling mouse mode
+		// makes zellij intercept wheel events and scroll its own scrollback.
+		// Text selection still works via shift-drag (xterm.js built-in bypass).
+		"--mouse-mode", "true",
 		"--advanced-mouse-actions", "false",
 		"--mouse-hover-effects", "false",
 		"--focus-follows-mouse", "false",

--- a/backend/internal/adapters/runtime/zellij/zellij_test.go
+++ b/backend/internal/adapters/runtime/zellij/zellij_test.go
@@ -89,7 +89,7 @@ func containsKey(values []string, key string) bool {
 func TestCommandBuilders(t *testing.T) {
 	embeddedOptions := []string{
 		"--pane-frames", "false",
-		"--mouse-mode", "false",
+		"--mouse-mode", "true",
 		"--advanced-mouse-actions", "false",
 		"--mouse-hover-effects", "false",
 		"--focus-follows-mouse", "false",
@@ -441,7 +441,7 @@ func TestAttachCommandUsesEmbeddedClientOptions(t *testing.T) {
 	}
 	embeddedOptions := []string{
 		"--pane-frames", "false",
-		"--mouse-mode", "false",
+		"--mouse-mode", "true",
 		"--advanced-mouse-actions", "false",
 		"--mouse-hover-effects", "false",
 		"--focus-follows-mouse", "false",

--- a/backend/internal/terminal/attachment_integration_test.go
+++ b/backend/internal/terminal/attachment_integration_test.go
@@ -53,8 +53,9 @@ func TestAttachmentStreamsRealZellijPane(t *testing.T) {
 	eventually(t, 5*time.Second, func() bool { return strings.Contains(got.string(), "AO_MARKER_42") })
 
 	// A fresh attach must carry zellij's alt-screen init handshake. Mouse
-	// reporting is deliberately disabled for AO's embedded client, so this test
-	// should not require SGR mouse mode.
+	// mode is enabled (--mouse-mode true) so wheel events reach zellij and
+	// scroll its internal scrollback; the attach enables SGR mouse tracking
+	// as part of that handshake.
 	eventually(t, 5*time.Second, func() bool {
 		out := got.string()
 		return strings.Contains(out, "\x1b[?1049h")

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -130,9 +130,12 @@ export function XtermTerminal(props: XtermTerminalProps) {
 				// The mux PTY runs `zellij attach` (backend AttachCommand), a
 				// full-screen alt-buffer app that owns scrollback itself — same as
 				// yyork. xterm's own buffer never accumulates history (the alt screen
-				// doesn't feed scrollback), and wheel events reach zellij as mouse
-				// reports instead of scrolling locally. 0 also stops FitAddon
-				// reserving ~14px on the right for a scrollbar that can never appear.
+				// doesn't feed scrollback). The backend enables zellij mouse mode
+				// (--mouse-mode true in embeddedClientOptions), so wheel events reach
+				// zellij as SGR mouse reports and scroll zellij's internal scrollback.
+				// 0 also stops FitAddon reserving ~14px on the right for a scrollbar
+				// that can never appear. Text selection still works via shift-drag
+				// (xterm.js built-in mouse-tracking bypass).
 				scrollback: 0,
 				theme: props.theme === "dark" ? terminalThemes.dark : terminalThemes.light,
 			});


### PR DESCRIPTION
## Problem

Terminal scroll is completely dead — scrolling the wheel does nothing.

## Root cause

The terminal runs `zellij attach` in the alternate screen buffer. The frontend sets `scrollback: 0` on xterm.js (`XtermTerminal.tsx`) because zellij owns scrollback — there is no local buffer to fall back on.

But the backend passed `--mouse-mode false` in `embeddedClientOptions()` (`commands.go:86`), applied to **both** session creation and every per-client attach. With mouse tracking off, zellij never enables SGR mouse mode. Wheel events reach:
- **xterm.js** → nothing (no scrollback buffer, `scrollback: 0`)
- **zellij** → nothing (mouse tracking disabled, events ignored)

Wheel events fall into a void.

Introduced in #325 (`5e8c8de`) when client options were extracted into `embeddedClientOptions()`. The integration test even documented the decision: *"Mouse reporting is deliberately disabled."*

## Fix

Set `--mouse-mode true`. Zellij now enables SGR mouse tracking on attach, so wheel events reach zellij and scroll its internal scrollback.

Text selection still works — xterm.js bypasses mouse tracking for shift-drag by default.

## Changes

| File | Change |
|------|--------|
| `backend/.../zellij/commands.go` | `--mouse-mode false` → `true` + explanatory comment |
| `backend/.../zellij/zellij_test.go` | Updated 2 test expectations to match |
| `backend/.../terminal/attachment_integration_test.go` | Updated stale comment |
| `frontend/.../XtermTerminal.tsx` | Updated scrollback comment to document the dependency on mouse mode |

## Testing

- `go test ./internal/adapters/runtime/zellij/` ✓
- `go test ./internal/terminal/` ✓
- Full backend suite (`go test ./...`) — all 36 packages pass, zero regressions