### PR TITLE
chore: add daemon build script

### DIFF
--- a/scripts/daemon-build.sh
+++ b/scripts/daemon-build.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+backend_dir="${repo_root}/backend"
+build_dir="${XDG_CACHE_HOME:-${HOME}/.cache}/aoagents/agent-orchestrator/bin"
+binary_path="${build_dir}/ao"
+
+can_write_dir() {
+  local dir="$1"
+
+  mkdir -p "${dir}"
+  [[ -d "${dir}" && -w "${dir}" ]]
+}
+
+select_install_dir() {
+  local gopath
+  local existing_path
+  local dir
+  local candidate
+  local -a path_entries
+  gopath="$(go env GOPATH)"
+  existing_path="$(command -v ao || true)"
+
+  if [[ -n "${existing_path}" && "${existing_path}" = /* ]] && can_write_dir "$(dirname "${existing_path}")"; then
+    dirname "${existing_path}"
+    return 0
+  fi
+
+  local candidates=(
+    "${gopath}/bin"
+    "/usr/local/bin"
+    "/opt/homebrew/bin"
+    "${HOME}/.local/bin"
+  )
+
+  IFS=':' read -r -a path_entries <<< "${PATH:-}"
+  for dir in "${path_entries[@]}"; do
+    for candidate in "${candidates[@]}"; do
+      if [[ "${dir}" == "${candidate}" ]] && can_write_dir "${dir}"; then
+        printf '%s\n' "${dir}"
+        return 0
+      fi
+    done
+  done
+
+  for dir in "${path_entries[@]}"; do
+    if [[ "${dir}" = /* ]] && can_write_dir "${dir}"; then
+      printf '%s\n' "${dir}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+command -v go >/dev/null
+
+mkdir -p "${build_dir}"
+(cd "${backend_dir}" && go build -o "${binary_path}" ./cmd/ao)
+
+if ! install_dir="$(select_install_dir)"; then
+  printf 'Could not find a writable directory on PATH for ao\n' >&2
+  exit 1
+fi
+install_path="${install_dir}/ao"
+
+ln -sfn "${binary_path}" "${install_path}"
+
+resolved="$(command -v ao)"
+if [[ "$(cd "$(dirname "${resolved}")" && pwd -P)/$(basename "${resolved}")" != "$(cd "$(dirname "${install_path}")" && pwd -P)/$(basename "${install_path}")" ]]; then
+  printf 'ao resolves to %s, expected %s\n' "${resolved}" "${install_path}" >&2
+  exit 1
+fi
+
+printf 'Built %s\n' "${binary_path}"
+printf 'Linked %s\n' "${install_path}"

--- a/scripts/daemon-build.sh
+++ b/scripts/daemon-build.sh
@@ -5,13 +5,44 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/.." && pwd)"
 backend_dir="${repo_root}/backend"
 build_dir="${XDG_CACHE_HOME:-${HOME}/.cache}/aoagents/agent-orchestrator/bin"
-binary_path="${build_dir}/ao"
 
 can_write_dir() {
   local dir="$1"
 
+  [[ -n "${dir}" ]] || return 1
   mkdir -p "${dir}"
   [[ -d "${dir}" && -w "${dir}" ]]
+}
+
+resolve_ao() {
+  local resolved
+
+  resolved="$(command -v ao || true)"
+  if [[ -z "${resolved}" && -n "${goexe:-}" ]]; then
+    resolved="$(command -v "ao${goexe}" || true)"
+  fi
+
+  printf '%s\n' "${resolved}"
+}
+
+absolute_path() {
+  local path="$1"
+
+  printf '%s/%s\n' "$(cd "$(dirname "${path}")" && pwd -P)" "$(basename "${path}")"
+}
+
+install_file() {
+  local source_path="$1"
+  local target_path="$2"
+
+  if ln -sfn "${source_path}" "${target_path}" 2>/dev/null; then
+    printf 'Linked %s\n' "${target_path}"
+  else
+    rm -f "${target_path}"
+    cp "${source_path}" "${target_path}"
+    chmod +x "${target_path}"
+    printf 'Installed %s\n' "${target_path}"
+  fi
 }
 
 select_install_dir() {
@@ -21,7 +52,7 @@ select_install_dir() {
   local candidate
   local -a path_entries
   gopath="$(go env GOPATH)"
-  existing_path="$(command -v ao || true)"
+  existing_path="$(resolve_ao)"
 
   if [[ -n "${existing_path}" && "${existing_path}" = /* ]] && can_write_dir "$(dirname "${existing_path}")"; then
     dirname "${existing_path}"
@@ -56,6 +87,9 @@ select_install_dir() {
 }
 
 command -v go >/dev/null
+goexe="$(go env GOEXE)"
+binary_name="ao${goexe}"
+binary_path="${build_dir}/${binary_name}"
 
 mkdir -p "${build_dir}"
 (cd "${backend_dir}" && go build -o "${binary_path}" ./cmd/ao)
@@ -64,15 +98,34 @@ if ! install_dir="$(select_install_dir)"; then
   printf 'Could not find a writable directory on PATH for ao\n' >&2
   exit 1
 fi
-install_path="${install_dir}/ao"
+install_path="${install_dir}/${binary_name}"
+shim_path=""
 
-ln -sfn "${binary_path}" "${install_path}"
+install_file "${binary_path}" "${install_path}"
 
-resolved="$(command -v ao)"
-if [[ "$(cd "$(dirname "${resolved}")" && pwd -P)/$(basename "${resolved}")" != "$(cd "$(dirname "${install_path}")" && pwd -P)/$(basename "${install_path}")" ]]; then
+if [[ -n "${goexe}" ]]; then
+  shim_path="${install_dir}/ao"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"' \
+    'exec "${script_dir}/ao.exe" "$@"' > "${shim_path}"
+  chmod +x "${shim_path}"
+fi
+
+resolved="$(resolve_ao)"
+if [[ -z "${resolved}" ]]; then
+  printf 'ao did not resolve on PATH after installing %s\n' "${install_path}" >&2
+  exit 1
+fi
+resolved_path="$(absolute_path "${resolved}")"
+install_abs_path="$(absolute_path "${install_path}")"
+shim_abs_path=""
+if [[ -n "${shim_path}" ]]; then
+  shim_abs_path="$(absolute_path "${shim_path}")"
+fi
+if [[ "${resolved_path}" != "${install_abs_path}" && "${resolved_path}" != "${shim_abs_path}" ]]; then
   printf 'ao resolves to %s, expected %s\n' "${resolved}" "${install_path}" >&2
   exit 1
 fi
 
 printf 'Built %s\n' "${binary_path}"
-printf 'Linked %s\n' "${install_path}"


### PR DESCRIPTION
## Summary
- Add scripts/daemon-build.sh to build backend/cmd/ao from the backend module.
- Link or install ao into a writable directory already on PATH, preferring an existing ao location, then common global bin directories.
- Use go env GOEXE so Windows bash environments build and install ao.exe.
- Create an ao bash shim next to ao.exe on Windows best effort, while native Windows shells can resolve ao.exe through PATHEXT.
- Fall back from symlink to copying when symlinks are unavailable.
- Build output is stored under the user cache so the repository does not collect local binary artifacts.

## Verification
- bash -n scripts/daemon-build.sh
- bash scripts/daemon-build.sh
- which ao -> /opt/homebrew/bin/ao
- readlink "$(which ao)" -> /Users/harshitsinghbhandari/.cache/aoagents/agent-orchestrator/bin/ao
- git diff --check

## Platform notes
- Verified locally on macOS.
- Linux should follow the same POSIX path as macOS.
- Windows support is best effort for bash-style environments such as Git Bash, MSYS, and WSL. Native Windows shells should find ao.exe after installation if the selected install directory is on PATH.