### PR TITLE
fix(frontend): inject orchestrator session into cache before navigating

### DIFF
--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -117,11 +117,7 @@ function ShellLayout() {
 					prs: [],
 				};
 				updateWorkspaces((current) =>
-					current.map((w) =>
-						w.id === workspace.id
-							? { ...w, sessions: [orchestratorSession, ...w.sessions] }
-							: w,
-					),
+					current.map((w) => (w.id === workspace.id ? { ...w, sessions: [orchestratorSession, ...w.sessions] } : w)),
 				);
 				await queryClient.refetchQueries({ queryKey: workspaceQueryKey });
 				void navigate({

--- a/frontend/src/renderer/routes/_shell.tsx
+++ b/frontend/src/renderer/routes/_shell.tsx
@@ -13,7 +13,7 @@ import { addRendererExceptionStep, captureRendererEvent, captureRendererExceptio
 import { ShellProvider } from "../lib/shell-context";
 import { spawnOrchestrator } from "../lib/spawn-orchestrator";
 import { readStoredTheme, type Theme, useUiStore } from "../stores/ui-store";
-import type { WorkspaceSummary } from "../types/workspace";
+import { toAgentProvider, type WorkspaceSession, type WorkspaceSummary } from "../types/workspace";
 
 export const Route = createFileRoute("/_shell")({
 	// Prefetch the workspace list for the whole shell (parent loaders run before
@@ -94,7 +94,36 @@ function ShellLayout() {
 			updateWorkspaces((current) => [workspace, ...current.filter((item) => item.id !== workspace.id)]);
 			try {
 				const sessionId = await spawnOrchestrator(workspace.id);
-				await queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
+				// Optimistically inject the orchestrator session into the workspace
+				// cache so SessionView can render immediately — even if the background
+				// refetch is slow or fails (the daemon is busy with the spawn workload:
+				// git worktree, provisioning, Zellij runtime). Without this, the cache
+				// retains the workspace with sessions: [] from the optimistic update
+				// above, and the staleTime: 10_000 window suppresses a mount-triggered
+				// refetch in SessionView, so the route shows "Session not found" until
+				// the 15s refetchInterval fires. See issue #370.
+				const ts = new Date().toISOString();
+				const orchestratorSession: WorkspaceSession = {
+					id: sessionId,
+					workspaceId: workspace.id,
+					workspaceName: workspace.name,
+					title: "orchestrator",
+					provider: toAgentProvider(input.orchestratorAgent),
+					kind: "orchestrator",
+					branch: `session/${sessionId}`,
+					status: "working",
+					createdAt: ts,
+					updatedAt: ts,
+					prs: [],
+				};
+				updateWorkspaces((current) =>
+					current.map((w) =>
+						w.id === workspace.id
+							? { ...w, sessions: [orchestratorSession, ...w.sessions] }
+							: w,
+					),
+				);
+				await queryClient.refetchQueries({ queryKey: workspaceQueryKey });
 				void navigate({
 					to: "/projects/$projectId/sessions/$sessionId",
 					params: { projectId: workspace.id, sessionId },


### PR DESCRIPTION
Fixes #370

## Summary

New project creation navigated to `/projects/$projectId/sessions/$sessionId` before `useWorkspaceQuery`'s cache contained the spawned orchestrator session. `SessionView` found no session and showed "Session not found" until the 15s `refetchInterval` eventually caught up — confusing UX on every new project.

**Root cause** (3 compounding factors):

1. `createProject`'s optimistic `setQueryData` (adding workspace with `sessions: []`) reset `dataUpdatedAt` to `now`.
2. React Query v5.101.0's `invalidateQueries` → `refetchQueries` swallows fetch errors (`promise.catch(noop)` in `queryClient.js:174`), so `await invalidateQueries(...)` always resolves — even when the refetch fails (daemon busy during spawn workload: git worktree + provisioning + Zellij runtime). Cache retains stale `sessions: []`.
3. Global `staleTime: 10_000` suppresses the mount-triggered refetch in `SessionView`'s observer, because `dataUpdatedAt` was just reset by the optimistic update.

**Fix:** After `spawnOrchestrator` returns the sessionId, optimistically inject the orchestrator `WorkspaceSession` into the workspace's `sessions` array via `updateWorkspaces`, then use `refetchQueries` (forces fresh data ASAP). `SessionView` can now find the session immediately regardless of refetch timing.

The backend is not the issue — `Manager.Spawn` persists the session synchronously (`manager.go:191`); the race is purely in the React Query cache layer.

## Test

```bash
cd frontend && npx tsc --noEmit && npx vitest run --exclude e2e
```

- TypeScript: ✅ no errors
- Full unit suite: ✅ 178/178 pass (including SessionView, Sidebar, useWorkspaceQuery tests)