### PR TITLE
fix: avoid duplicate terminal paste shortcuts

### DIFF
--- a/frontend/src/renderer/components/XtermTerminal.test.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.test.tsx
@@ -274,10 +274,10 @@ describe("XtermTerminal", () => {
 		expect(window.ao!.clipboard.writeText).not.toHaveBeenCalled();
 	});
 
-	it("pastes from the Electron clipboard on Windows/Linux paste shortcuts", async () => {
+	it("pastes once from the Electron clipboard on Windows/Linux paste shortcuts", async () => {
 		const onInput = vi.fn();
 		window.ao!.clipboard.readText = vi.fn().mockResolvedValue("hello\nworld");
-		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+		const { container } = render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
 
 		const event = {
 			key: "v",
@@ -289,13 +289,45 @@ describe("XtermTerminal", () => {
 			stopPropagation: vi.fn(),
 		} as unknown as KeyboardEvent;
 		const allowed = state.lastTerminal!.keyHandler!(event);
+		const pasteEvent = new Event("paste", { bubbles: true, cancelable: true }) as ClipboardEvent;
+		Object.defineProperty(pasteEvent, "clipboardData", {
+			value: { getData: vi.fn().mockReturnValue("hello\nworld") },
+		});
+		container.firstElementChild!.dispatchEvent(pasteEvent);
 		await Promise.resolve();
 
 		expect(allowed).toBe(false);
 		expect(event.preventDefault).toHaveBeenCalled();
 		expect(event.stopPropagation).toHaveBeenCalled();
 		expect(window.ao!.clipboard.readText).toHaveBeenCalled();
+		expect(pasteEvent.defaultPrevented).toBe(true);
+		expect(onInput).toHaveBeenCalledTimes(1);
 		expect(onInput).toHaveBeenCalledWith("hello\rworld", "paste");
+	});
+
+	it("supports Windows Ctrl+V paste without relying on a native paste event", async () => {
+		setNavigatorPlatform("Win32");
+		const onInput = vi.fn();
+		window.ao!.clipboard.readText = vi.fn().mockResolvedValue("windows paste");
+		render(<XtermTerminal theme="dark" onReady={(terminal) => terminal.onUserInput(onInput)} />);
+
+		const event = {
+			key: "v",
+			metaKey: false,
+			ctrlKey: true,
+			shiftKey: false,
+			altKey: false,
+			preventDefault: vi.fn(),
+			stopPropagation: vi.fn(),
+		} as unknown as KeyboardEvent;
+		const allowed = state.lastTerminal!.keyHandler!(event);
+		await Promise.resolve();
+
+		expect(allowed).toBe(false);
+		expect(event.preventDefault).toHaveBeenCalled();
+		expect(event.stopPropagation).toHaveBeenCalled();
+		expect(window.ao!.clipboard.readText).toHaveBeenCalled();
+		expect(onInput).toHaveBeenCalledWith("windows paste", "paste");
 	});
 
 	it("supports classic Windows terminal copy and paste shortcuts", async () => {

--- a/frontend/src/renderer/components/XtermTerminal.tsx
+++ b/frontend/src/renderer/components/XtermTerminal.tsx
@@ -102,7 +102,8 @@ function isTerminalPasteShortcut(event: KeyboardEvent): boolean {
 	if (event.key === "Insert") return event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey;
 	if (event.key.toLowerCase() !== "v") return false;
 	if (event.metaKey) return true;
-	return event.ctrlKey && event.shiftKey;
+	if (event.ctrlKey && event.shiftKey && !event.altKey) return true;
+	return isWindowsPlatform() && event.ctrlKey && !event.shiftKey && !event.altKey && !event.metaKey;
 }
 
 function consumeTerminalShortcut(event: KeyboardEvent): void {
@@ -298,6 +299,23 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			const bracketed = term.modes.bracketedPasteMode && term.options.ignoreBracketedPasteMode !== true;
 			emitUserInput(bracketPastedText(prepared, bracketed), "paste");
 		};
+		let suppressNextNativePaste = false;
+		let suppressPasteTimer: number | null = null;
+		const suppressNativePasteOnce = () => {
+			suppressNextNativePaste = true;
+			if (suppressPasteTimer !== null) window.clearTimeout(suppressPasteTimer);
+			suppressPasteTimer = window.setTimeout(() => {
+				suppressNextNativePaste = false;
+				suppressPasteTimer = null;
+			}, 0);
+		};
+		const clearSuppressNativePaste = () => {
+			suppressNextNativePaste = false;
+			if (suppressPasteTimer !== null) {
+				window.clearTimeout(suppressPasteTimer);
+				suppressPasteTimer = null;
+			}
+		};
 		const pasteFromClipboard = () => {
 			void aoBridge.clipboard
 				.readText()
@@ -320,6 +338,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			}
 			if (isTerminalPasteShortcut(event)) {
 				consumeTerminalShortcut(event);
+				suppressNativePasteOnce();
 				pasteFromClipboard();
 				return false;
 			}
@@ -463,6 +482,10 @@ export function XtermTerminal(props: XtermTerminalProps) {
 		const pasteInput = (event: ClipboardEvent) => {
 			event.preventDefault();
 			event.stopPropagation();
+			if (suppressNextNativePaste) {
+				clearSuppressNativePaste();
+				return;
+			}
 			const text = event.clipboardData?.getData("text/plain") ?? "";
 			pasteText(text);
 		};
@@ -505,6 +528,7 @@ export function XtermTerminal(props: XtermTerminalProps) {
 			selectionChange.dispose();
 			host.removeEventListener("paste", pasteInput, true);
 			host.removeEventListener("compositionend", compositionInput, true);
+			clearSuppressNativePaste();
 			terminalInput.dispose();
 			userInputListeners.clear();
 			try {


### PR DESCRIPTION
## Summary
- prevent shortcut-triggered terminal paste from also processing the follow-up native paste event
- support Windows Ctrl+V paste through the same terminal paste path
- add regression coverage for Linux-style duplicate paste and Windows Ctrl+V

## Tests
- npm --prefix frontend test -- XtermTerminal.test.tsx
- npm --prefix frontend run typecheck