### PR TITLE
feat(cli): add examples to ao preview --help

### DIFF
--- a/backend/internal/cli/preview.go
+++ b/backend/internal/cli/preview.go
@@ -23,9 +23,13 @@ func newPreviewCommand(ctx *commandContext) *cobra.Command {
 		Use:   "preview [url]",
 		Short: "Open a URL (or the workspace's index.html) in the desktop browser panel for the current session",
 		Long: "Open a URL in the desktop browser panel for the current session.\n\n" +
-			"With no argument it opens the workspace's index.html. A workspace-relative path\n" +
-			"(e.g. ./dist/index.html) is served as a local file. Use `ao preview\n" +
-			"clear` to empty the panel.",
+			"With no argument it opens the workspace's index.html. A local file can be\n" +
+			"opened by its absolute file:// URL (e.g. file:///home/me/proj/index.html).\n" +
+			"Use `ao preview clear` to empty the panel.",
+		Example: `  ao preview
+  ao preview file://$(pwd)/index.html
+  ao preview http://localhost:5173
+  ao preview clear`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var target string

--- a/backend/internal/cli/preview.go
+++ b/backend/internal/cli/preview.go
@@ -23,9 +23,10 @@ func newPreviewCommand(ctx *commandContext) *cobra.Command {
 		Use:   "preview [url]",
 		Short: "Open a URL (or the workspace's index.html) in the desktop browser panel for the current session",
 		Long: "Open a URL in the desktop browser panel for the current session.\n\n" +
-			"With no argument it opens the workspace's index.html. A local file can be\n" +
-			"opened by its absolute file:// URL (e.g. file:///home/me/proj/index.html).\n" +
-			"Use `ao preview clear` to empty the panel.",
+			"With no argument it opens the workspace's static entry point, falling\n" +
+			"back to this session's existing preview target when no entry point exists.\n" +
+			"A local file can be opened by its absolute file:// URL\n" +
+			"(e.g. file:///home/me/proj/index.html). Use `ao preview clear` to empty the panel.",
 		Example: `  ao preview
   ao preview file://$(pwd)/index.html
   ao preview http://localhost:5173

--- a/backend/internal/cli/preview_test.go
+++ b/backend/internal/cli/preview_test.go
@@ -154,6 +154,24 @@ func TestPreview_MissingSessionIDIsUsageError(t *testing.T) {
 	}
 }
 
+func TestPreview_HelpIncludesExamples(t *testing.T) {
+	out, _, err := executeCLI(t, Deps{}, "preview", "--help")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Examples section present.
+	if !strings.Contains(out, "EXAMPLES") && !strings.Contains(out, "Examples") {
+		t.Errorf("help output missing Examples section:\n%s", out)
+	}
+	// file:// URL example (not a relative path).
+	if !strings.Contains(out, "file://$(pwd)/index.html") {
+		t.Errorf("help output missing file:// example:\n%s", out)
+	}
+	if strings.Contains(out, "./dist/index.html") {
+		t.Errorf("help output still references relative ./dist/index.html:\n%s", out)
+	}
+}
+
 func TestPreview_BlankSessionIDIsUsageError(t *testing.T) {
 	t.Setenv("AO_SESSION_ID", " \t ")
 	cfg := setConfigEnv(t)


### PR DESCRIPTION
## What

Improves `ao preview --help` with concrete examples for the common workflows.

Closes #387

## Changes

- **Added `Example` field** to the preview command — renders an `Examples:` section in `--help` with the four common workflows:
  ```bash
  ao preview
  ao preview file://$(pwd)/index.html
  ao preview http://localhost:5173
  ao preview clear
  ```
- **Updated `Long` description** — replaced the workspace-relative path (`./dist/index.html`) with the absolute `file://` URL pattern agents actually use.
- **Added test** (`TestPreview_HelpIncludesExamples`) verifying the examples section is present, the `file://` example exists, and the old relative-path reference is gone.

## Acceptance criteria

| Criterion | Status |
|---|---|
| `ao preview --help` includes a concise examples section | ✅ |
| File example uses `file://$(pwd)/index.html`, not `./index.html` | ✅ |
| Existing behavior and command syntax unchanged | ✅ |

## Test output

```
=== RUN   TestPreview_WithURLArg              --- PASS
=== RUN   TestPreview_NoArgPostsEmptyURL      --- PASS
=== RUN   TestPreviewClear_DeletesSessionPreview --- PASS
=== RUN   TestPreviewClear_MissingSessionIDIsUsageError --- PASS
=== RUN   TestPreview_MissingSessionIDIsUsageError --- PASS
=== RUN   TestPreview_HelpIncludesExamples    --- PASS
=== RUN   TestPreview_BlankSessionIDIsUsageError --- PASS
PASS
```