### PR TITLE
feat: show multi-PR review status

### DIFF
--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -181,7 +181,7 @@ describe("SessionInspector reviews tab", () => {
 		);
 		await openReviewsTab();
 
-		await userEvent.click(await screen.findByRole("button", { name: /^run$/i }));
+		await userEvent.click(await screen.findByRole("button", { name: /run review/i }));
 
 		await waitFor(() =>
 			expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/reviews/trigger", {
@@ -206,8 +206,9 @@ describe("SessionInspector reviews tab", () => {
 		expect(screen.getByText("#4")).toBeInTheDocument();
 		expect(screen.getAllByText("Not run")).not.toHaveLength(0);
 		expect(screen.getAllByText("Approved")).not.toHaveLength(0);
-		expect(screen.getByRole("button", { name: "Run" })).toBeInTheDocument();
-		expect(screen.getByRole("button", { name: "Re-run" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Re-run review" })).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Run" })).not.toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Re-run" })).not.toBeInTheDocument();
 	});
 
 	it("shows a no-needed-reviews notice instead of opening the terminal when the backend reuses runs", async () => {
@@ -226,7 +227,7 @@ describe("SessionInspector reviews tab", () => {
 		);
 		await openReviewsTab();
 
-		await userEvent.click(await screen.findByRole("button", { name: /re-run/i }));
+		await userEvent.click(await screen.findByRole("button", { name: /re-run review/i }));
 
 		expect(await screen.findByText("No needed reviews were started.")).toBeInTheDocument();
 		expect(onOpenReviewerTerminal).not.toHaveBeenCalled();
@@ -245,6 +246,7 @@ describe("SessionInspector reviews tab", () => {
 		await openReviewsTab();
 
 		await waitFor(() => expect(screen.getAllByText("Open terminal")).toHaveLength(1));
+		expect(screen.getAllByRole("button", { name: /review/i })).toHaveLength(1);
 		await userEvent.click(screen.getByRole("button", { name: /open terminal/i }));
 
 		expect(onOpenReviewerTerminal).toHaveBeenCalledWith({ handleId: "reviewer-pane", harness: "codex" });
@@ -257,7 +259,9 @@ describe("SessionInspector reviews tab", () => {
 		await openReviewsTab();
 
 		expect(await screen.findByText("codex")).toBeInTheDocument();
+		expect(screen.getByText("reviewer")).toBeInTheDocument();
 		expect(screen.getByText("sess-1")).toBeInTheDocument();
+		expect(screen.getByText("review session")).toBeInTheDocument();
 		expect(screen.getAllByText("Changes requested")).not.toHaveLength(0);
 	});
 

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -252,7 +252,7 @@ describe("SessionInspector reviews tab", () => {
 		expect(onOpenReviewerTerminal).toHaveBeenCalledWith({ handleId: "reviewer-pane", harness: "codex" });
 	});
 
-	it("shows the session reviewer identity, worker session name, and aggregate verdict", async () => {
+	it("shows the reviewer identity and aggregate verdict", async () => {
 		mockCommonGets([approvedReview], "reviewer-pane", [reviewState(3, "changes_requested", "abc123")]);
 
 		renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
@@ -260,8 +260,8 @@ describe("SessionInspector reviews tab", () => {
 
 		expect(await screen.findByText("codex")).toBeInTheDocument();
 		expect(screen.getByText("reviewer")).toBeInTheDocument();
-		expect(screen.getByText("sess-1")).toBeInTheDocument();
-		expect(screen.getByText("review session")).toBeInTheDocument();
+		expect(screen.queryByText("sess-1")).not.toBeInTheDocument();
+		expect(screen.queryByText("review session")).not.toBeInTheDocument();
 		expect(screen.getAllByText("Changes requested")).not.toHaveLength(0);
 	});
 

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -97,6 +97,7 @@ const approvedReview = {
 const reviewState = (n: number, status: string, targetSha = `sha-${n}`) => ({
 	prUrl: `https://example.com/pr/${n}`,
 	prNumber: n,
+	title: `Reviewable change ${n}`,
 	targetSha,
 	status,
 	latestRun:
@@ -180,7 +181,7 @@ describe("SessionInspector reviews tab", () => {
 		);
 		await openReviewsTab();
 
-		await userEvent.click(await screen.findByRole("button", { name: /run needed reviews/i }));
+		await userEvent.click(await screen.findByRole("button", { name: /^run$/i }));
 
 		await waitFor(() =>
 			expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/reviews/trigger", {
@@ -199,10 +200,14 @@ describe("SessionInspector reviews tab", () => {
 		renderWithQuery(<SessionInspector session={session([pr(3, "open"), pr(4, "open")])} />);
 		await openReviewsTab();
 
-		expect(await screen.findByText("PR #3")).toBeInTheDocument();
-		expect(screen.getByText("Needs review")).toBeInTheDocument();
-		expect(screen.getByText("PR #4")).toBeInTheDocument();
-		expect(screen.getByText("Up to date")).toBeInTheDocument();
+		expect(await screen.findByText("Reviewable change 3")).toBeInTheDocument();
+		expect(screen.getByText("#3")).toBeInTheDocument();
+		expect(screen.getByText("Reviewable change 4")).toBeInTheDocument();
+		expect(screen.getByText("#4")).toBeInTheDocument();
+		expect(screen.getAllByText("Not run")).not.toHaveLength(0);
+		expect(screen.getAllByText("Approved")).not.toHaveLength(0);
+		expect(screen.getByRole("button", { name: "Run" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Re-run" })).toBeInTheDocument();
 	});
 
 	it("shows a no-needed-reviews notice instead of opening the terminal when the backend reuses runs", async () => {
@@ -221,7 +226,7 @@ describe("SessionInspector reviews tab", () => {
 		);
 		await openReviewsTab();
 
-		await userEvent.click(await screen.findByRole("button", { name: /run needed reviews/i }));
+		await userEvent.click(await screen.findByRole("button", { name: /re-run/i }));
 
 		expect(await screen.findByText("No needed reviews were started.")).toBeInTheDocument();
 		expect(onOpenReviewerTerminal).not.toHaveBeenCalled();
@@ -243,6 +248,17 @@ describe("SessionInspector reviews tab", () => {
 		await userEvent.click(screen.getByRole("button", { name: /open terminal/i }));
 
 		expect(onOpenReviewerTerminal).toHaveBeenCalledWith({ handleId: "reviewer-pane", harness: "codex" });
+	});
+
+	it("shows the session reviewer identity, worker session name, and aggregate verdict", async () => {
+		mockCommonGets([approvedReview], "reviewer-pane", [reviewState(3, "changes_requested", "abc123")]);
+
+		renderWithQuery(<SessionInspector session={session([pr(3, "open")])} />);
+		await openReviewsTab();
+
+		expect(await screen.findByText("codex")).toBeInTheDocument();
+		expect(screen.getByText("sess-1")).toBeInTheDocument();
+		expect(screen.getAllByText("Changes requested")).not.toHaveLength(0);
 	});
 
 	it("shows the no-PR empty state when the session has no PRs", async () => {

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -56,7 +56,7 @@ function renderWithQuery(children: ReactNode) {
 	return render(<QueryClientProvider client={client}>{children}</QueryClientProvider>);
 }
 
-function mockCommonGets(reviews: unknown[] = [], reviewerHandleId = "") {
+function mockCommonGets(_unusedRuns: unknown[] = [], reviewerHandleId = "", reviews: unknown[] = []) {
 	getMock.mockImplementation(async (path: string) => {
 		if (path === "/api/v1/sessions/{sessionId}/reviews") {
 			return { data: { reviewerHandleId, reviews } };
@@ -85,7 +85,6 @@ const approvedReview = {
 	id: "run-1",
 	reviewId: "review-1",
 	sessionId: "sess-1",
-	batchId: "batch-1",
 	harness: "codex",
 	status: "complete",
 	verdict: "approved",
@@ -95,12 +94,12 @@ const approvedReview = {
 	createdAt: "2026-06-16T10:06:00Z",
 };
 
-const reviewState = (latestRun = approvedReview) => ({
-	prUrl: latestRun.prUrl,
-	prNumber: 3,
-	targetSha: latestRun.targetSha,
-	status: latestRun.status === "running" ? "running" : "up_to_date",
-	latestRun,
+const reviewState = (n: number, status: string, targetSha = `sha-${n}`) => ({
+	prUrl: `https://example.com/pr/${n}`,
+	prNumber: n,
+	targetSha,
+	status,
+	latestRun: status === "up_to_date" ? { ...approvedReview, prUrl: `https://example.com/pr/${n}`, targetSha } : undefined,
 });
 
 beforeEach(() => {
@@ -164,12 +163,13 @@ describe("SessionInspector reviews tab", () => {
 	const openReviewsTab = async () => userEvent.click(screen.getByRole("tab", { name: /Reviews/ }));
 
 	it("triggers a review and opens the returned reviewer terminal", async () => {
-		mockCommonGets();
+		mockCommonGets([], "", [reviewState(3, "needs_review")]);
+		const runningReview = { ...approvedReview, status: "running", verdict: "", body: "" };
 		postMock.mockResolvedValue({
 			response: { status: 201 },
 			data: {
 				reviewerHandleId: "reviewer-pane",
-				reviews: [reviewState({ ...approvedReview, status: "running", verdict: "", body: "" })],
+				reviews: [{ ...reviewState(3, "running"), latestRun: runningReview }],
 			},
 		});
 		const onOpenReviewerTerminal = vi.fn();
@@ -179,7 +179,7 @@ describe("SessionInspector reviews tab", () => {
 		);
 		await openReviewsTab();
 
-		await userEvent.click(await screen.findByRole("button", { name: /run review/i }));
+		await userEvent.click(await screen.findByRole("button", { name: /run needed reviews/i }));
 
 		await waitFor(() =>
 			expect(postMock).toHaveBeenCalledWith("/api/v1/sessions/{sessionId}/reviews/trigger", {
@@ -189,11 +189,29 @@ describe("SessionInspector reviews tab", () => {
 		expect(onOpenReviewerTerminal).toHaveBeenCalledWith({ handleId: "reviewer-pane", harness: "codex" });
 	});
 
-	it("shows an up-to-date notice instead of opening the terminal when the backend reuses a run", async () => {
-		mockCommonGets([reviewState()], "reviewer-pane");
+	it("shows eligible and up-to-date PR review rows", async () => {
+		mockCommonGets([approvedReview], "reviewer-pane", [
+			reviewState(3, "needs_review", "abc123"),
+			reviewState(4, "up_to_date", "def456"),
+		]);
+
+		renderWithQuery(<SessionInspector session={session([pr(3, "open"), pr(4, "open")])} />);
+		await openReviewsTab();
+
+		expect(await screen.findByText("PR #3")).toBeInTheDocument();
+		expect(screen.getByText("Needs review")).toBeInTheDocument();
+		expect(screen.getByText("PR #4")).toBeInTheDocument();
+		expect(screen.getByText("Up to date")).toBeInTheDocument();
+	});
+
+	it("shows a no-needed-reviews notice instead of opening the terminal when the backend reuses runs", async () => {
+		mockCommonGets([approvedReview], "reviewer-pane", [reviewState(3, "up_to_date")]);
 		postMock.mockResolvedValue({
 			response: { status: 200 },
-			data: { reviewerHandleId: "reviewer-pane", reviews: [reviewState()] },
+			data: {
+				reviewerHandleId: "reviewer-pane",
+				reviews: [],
+			},
 		});
 		const onOpenReviewerTerminal = vi.fn();
 
@@ -202,14 +220,17 @@ describe("SessionInspector reviews tab", () => {
 		);
 		await openReviewsTab();
 
-		await userEvent.click(await screen.findByRole("button", { name: /re-run review/i }));
+		await userEvent.click(await screen.findByRole("button", { name: /run needed reviews/i }));
 
-		expect(await screen.findByText("Review is already up to date for this commit.")).toBeInTheDocument();
+		expect(await screen.findByText("No needed reviews were started.")).toBeInTheDocument();
 		expect(onOpenReviewerTerminal).not.toHaveBeenCalled();
 	});
 
-	it("shows an approved review and opens its terminal", async () => {
-		mockCommonGets([reviewState()], "reviewer-pane");
+	it("shows one shared terminal action", async () => {
+		mockCommonGets([approvedReview], "reviewer-pane", [
+			reviewState(3, "running", "abc123"),
+			reviewState(4, "up_to_date", "def456"),
+		]);
 		const onOpenReviewerTerminal = vi.fn();
 
 		renderWithQuery(
@@ -217,7 +238,7 @@ describe("SessionInspector reviews tab", () => {
 		);
 		await openReviewsTab();
 
-		await waitFor(() => expect(screen.getAllByText("Approved").length).toBeGreaterThan(0));
+		await waitFor(() => expect(screen.getAllByText("Open terminal")).toHaveLength(1));
 		await userEvent.click(screen.getByRole("button", { name: /open terminal/i }));
 
 		expect(onOpenReviewerTerminal).toHaveBeenCalledWith({ handleId: "reviewer-pane", harness: "codex" });

--- a/frontend/src/renderer/components/SessionInspector.test.tsx
+++ b/frontend/src/renderer/components/SessionInspector.test.tsx
@@ -99,7 +99,8 @@ const reviewState = (n: number, status: string, targetSha = `sha-${n}`) => ({
 	prNumber: n,
 	targetSha,
 	status,
-	latestRun: status === "up_to_date" ? { ...approvedReview, prUrl: `https://example.com/pr/${n}`, targetSha } : undefined,
+	latestRun:
+		status === "up_to_date" ? { ...approvedReview, prUrl: `https://example.com/pr/${n}`, targetSha } : undefined,
 });
 
 beforeEach(() => {

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -26,7 +26,6 @@ import { cn } from "../lib/utils";
 import { PRAttentionPanel, PRSummaryMeta } from "./PRSummaryDisplay";
 
 type ProjectConfig = components["schemas"]["ProjectConfig"];
-type ReviewRun = components["schemas"]["ReviewRun"];
 type PRReviewState = components["schemas"]["PRReviewState"];
 type ReviewsResponse = components["schemas"]["ListReviewsResponse"];
 type OpenReviewerTerminal = (target: { handleId: string; harness: string }) => void;
@@ -388,7 +387,8 @@ function ReviewsView({
 		enabled: hasPr,
 		refetchInterval: (query) => {
 			const data = query.state.data as ReviewsResponse | undefined;
-			return data?.reviews.some((review) => review.status === "running") ? 2500 : false;
+			const reviews = data?.reviews ?? [];
+			return reviews.some((review) => review.status === "running") ? 2500 : false;
 		},
 		queryFn: async () => {
 			const { data, error } = await apiClient.GET("/api/v1/sessions/{sessionId}/reviews", {
@@ -423,17 +423,18 @@ function ReviewsView({
 		onSuccess: ({ data, reused }) => {
 			void queryClient.invalidateQueries({ queryKey: ["session-reviews", session.id] });
 			void queryClient.invalidateQueries({ queryKey: workspaceQueryKey });
-			if (reused) {
-				setReviewNotice("Review is already up to date for this commit.");
+			const started = data?.reviews?.find((review) => review.status === "running" && review.latestRun);
+			if (reused || !started?.latestRun) {
+				setReviewNotice("No needed reviews were started.");
 				return;
 			}
 			if (data?.reviewerHandleId) {
-				const harness = latestReview(data.reviews)?.harness || "reviewer";
+				const harness = started.latestRun.harness || "reviewer";
 				onOpenReviewerTerminal?.({ handleId: data.reviewerHandleId, harness });
 			}
 		},
 	});
-	const reviews = reviewsQuery.data?.reviews ?? [];
+	const reviewStates = reviewsQuery.data?.reviews ?? [];
 
 	return (
 		<div role="tabpanel">
@@ -446,7 +447,7 @@ function ReviewsView({
 					onOpenTerminal={onOpenReviewerTerminal}
 					onTrigger={() => triggerReview.mutate()}
 					reviewerHandleId={reviewsQuery.data?.reviewerHandleId ?? ""}
-					reviews={reviews}
+					reviewStates={reviewStates}
 					notice={reviewNotice}
 					session={session}
 				/>
@@ -463,7 +464,7 @@ function projectConfig(project: components["schemas"]["ProjectOrDegraded"] | und
 function ReviewPanel({
 	session,
 	config,
-	reviews,
+	reviewStates,
 	reviewerHandleId,
 	isLoading,
 	isTriggering,
@@ -474,7 +475,7 @@ function ReviewPanel({
 }: {
 	session: WorkspaceSession;
 	config?: ProjectConfig;
-	reviews: PRReviewState[];
+	reviewStates: PRReviewState[];
 	reviewerHandleId: string;
 	isLoading: boolean;
 	isTriggering: boolean;
@@ -490,111 +491,98 @@ function ReviewPanel({
 		return <p className="inspector-empty">Loading reviews...</p>;
 	}
 
-	const latest = latestReview(reviews);
+	const latest = reviewStates.find((review) => review.latestRun)?.latestRun;
 	const harness = latest?.harness || config?.reviewers?.[0]?.harness || session.provider || "reviewer";
+	const terminalEnabled = Boolean(reviewerHandleId && onOpenTerminal);
 
 	return (
 		<div className="reviewer-list">
 			{error ? <p className="reviewer-error">{apiErrorMessage(error, "Review request failed")}</p> : null}
 			{notice ? <p className="reviewer-notice">{notice}</p> : null}
-			<ReviewerCard
-				handleId={reviewerHandleId}
-				harness={harness}
-				isTriggering={isTriggering}
-				onOpenTerminal={onOpenTerminal}
-				onTrigger={onTrigger}
-				review={latest}
-			/>
-		</div>
-	);
-}
-
-function latestReview(reviews: PRReviewState[]): ReviewRun | undefined {
-	return reviews
-		.map((review) => review.latestRun)
-		.filter((review): review is ReviewRun => Boolean(review))
-		.sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))[0];
-}
-
-function ReviewerCard({
-	harness,
-	review,
-	handleId,
-	isTriggering,
-	onTrigger,
-	onOpenTerminal,
-}: {
-	harness: string;
-	review?: ReviewRun;
-	handleId: string;
-	isTriggering: boolean;
-	onTrigger: () => void;
-	onOpenTerminal?: OpenReviewerTerminal;
-}) {
-	const status = reviewStatus(review);
-	const terminalEnabled = Boolean(handleId && onOpenTerminal);
-	const runLabel = review ? "Re-run review" : "Run review";
-
-	return (
-		<div className={cn("reviewer-card", status.tone && `reviewer-card--${status.tone}`)}>
-			<div className="reviewer-card__top">
-				<div className="reviewer-card__name">
-					<Shield aria-hidden="true" />
-					<span>{harness}</span>
+			<div className="reviewer-card">
+				<div className="reviewer-card__top">
+					<div className="reviewer-card__name">
+						<Shield aria-hidden="true" />
+						<span>{harness}</span>
+					</div>
+					<span className="reviewer-status reviewer-status--neutral">{reviewStates.length} PRs</span>
 				</div>
-				<span className={cn("reviewer-status", `reviewer-status--${status.tone}`)}>
-					{status.icon}
-					{status.label}
-				</span>
-			</div>
-			<div className="reviewer-card__actions">
-				<button
-					className="reviewer-card__action reviewer-card__action--primary"
-					disabled={isTriggering}
-					onClick={onTrigger}
-					type="button"
-				>
-					<Play aria-hidden="true" />
-					{isTriggering ? "Starting..." : runLabel}
-				</button>
-				{review ? (
+				<div className="reviewer-card__actions">
+					<button
+						className="reviewer-card__action reviewer-card__action--primary"
+						disabled={isTriggering}
+						onClick={onTrigger}
+						type="button"
+					>
+						<Play aria-hidden="true" />
+						{isTriggering ? "Starting..." : "Run needed reviews"}
+					</button>
 					<button
 						className="reviewer-card__action"
 						disabled={!terminalEnabled}
 						onClick={() => {
 							if (!terminalEnabled) return;
-							onOpenTerminal?.({ handleId, harness });
+							onOpenTerminal?.({ handleId: reviewerHandleId, harness });
 						}}
 						type="button"
 					>
 						<Terminal aria-hidden="true" />
 						Open terminal
 					</button>
-				) : null}
+				</div>
+			</div>
+			<div className="flex flex-col gap-2">
+				{reviewStates.length === 0 ? <p className="inspector-empty">No review state loaded yet.</p> : null}
+				{reviewStates.map((reviewState) => (
+					<ReviewStateCard key={`${reviewState.prUrl}:${reviewState.targetSha}`} reviewState={reviewState} />
+				))}
 			</div>
 		</div>
 	);
 }
 
-function reviewStatus(review?: ReviewRun): {
+function ReviewStateCard({ reviewState }: { reviewState: PRReviewState }) {
+	const status = reviewStateStatus(reviewState);
+	return (
+		<div className={cn("reviewer-card", status.tone && `reviewer-card--${status.tone}`, reviewState.status === "ineligible" && "opacity-70")}>
+			<div className="reviewer-card__top">
+				<div className="reviewer-card__name">
+					<GitPullRequest aria-hidden="true" />
+					<span>PR #{reviewState.prNumber}</span>
+				</div>
+				<span className={cn("reviewer-status", `reviewer-status--${status.tone}`)}>
+					{status.icon}
+					{status.label}
+				</span>
+			</div>
+			<div className="mt-2 min-w-0 truncate font-mono text-[10.5px] text-passive">
+				<a href={reviewState.prUrl} target="_blank" rel="noopener noreferrer" className="text-accent hover:underline">
+					{reviewState.prUrl}
+				</a>
+				{reviewState.targetSha ? <span className="ml-2">{reviewState.targetSha.slice(0, 7)}</span> : null}
+			</div>
+		</div>
+	);
+}
+
+function reviewStateStatus(reviewState: PRReviewState): {
 	label: string;
 	tone: "neutral" | "running" | "success" | "danger";
 	icon: ReactNode;
 } {
-	if (!review) return { label: "Not run", tone: "neutral", icon: null };
-	if (review.status === "running") {
-		return { label: "Running", tone: "running", icon: <Play aria-hidden="true" /> };
+	switch (reviewState.status) {
+		case "needs_review":
+			return { label: "Needs review", tone: "neutral", icon: null };
+		case "running":
+			return { label: "Running", tone: "running", icon: <Play aria-hidden="true" /> };
+		case "up_to_date":
+			return { label: "Up to date", tone: "success", icon: <CheckCircle2 aria-hidden="true" /> };
+		case "changes_requested":
+			return { label: "Changes requested", tone: "danger", icon: <CircleMinus aria-hidden="true" /> };
+		case "ineligible":
+			return { label: "Ineligible", tone: "neutral", icon: <AlertCircle aria-hidden="true" /> };
 	}
-	if (review.status === "failed") {
-		return { label: "Failed", tone: "danger", icon: <AlertCircle aria-hidden="true" /> };
-	}
-	if (review.verdict === "approved") {
-		return { label: "Approved", tone: "success", icon: <CheckCircle2 aria-hidden="true" /> };
-	}
-	if (review.verdict === "changes_requested") {
-		return { label: "Changes requested", tone: "danger", icon: <CircleMinus aria-hidden="true" /> };
-	}
-	return { label: "Complete", tone: "success", icon: <CheckCircle2 aria-hidden="true" /> };
+	return { label: reviewState.status, tone: "neutral", icon: null };
 }
 
 function BrowserView({

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState, type ReactNode } from "react";
-import { ArrowUpRight, GitPullRequest, Shield, Terminal } from "lucide-react";
+import { ArrowUpRight, GitPullRequest, Play, Shield, Terminal } from "lucide-react";
 import type { components } from "../../api/schema";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
@@ -486,64 +486,71 @@ function ReviewPanel({
 	const harness = latest?.harness || config?.reviewers?.[0]?.harness || session.provider || "reviewer";
 	const terminalEnabled = Boolean(reviewerHandleId && onOpenTerminal);
 	const aggregateVerdict = sessionReviewVerdict(reviewStates);
+	const runAction = reviewSessionRunAction(reviewStates, isTriggering);
+	const runDisabled =
+		isTriggering ||
+		reviewStates.length === 0 ||
+		reviewStates.some((reviewState) => reviewState.status === "running") ||
+		reviewStates.every((reviewState) => reviewState.status === "ineligible");
 
 	return (
 		<div className="reviewer-list">
 			{error ? <p className="reviewer-error">{apiErrorMessage(error, "Review request failed")}</p> : null}
 			{notice ? <p className="reviewer-notice">{notice}</p> : null}
+			<div className="reviewer-kicker">
+				<Shield aria-hidden="true" />
+				<span>{harness}</span>
+				<span>reviewer</span>
+			</div>
 			<div className="reviewer-card">
 				<div className="reviewer-card__top">
 					<div className="reviewer-card__identity">
 						<div className="reviewer-card__name">
-							<Shield aria-hidden="true" />
-							<span>{harness}</span>
+							<GitPullRequest aria-hidden="true" />
+							<span>{session.id}</span>
 						</div>
-						<div className="reviewer-card__session">{session.id}</div>
+						<div className="reviewer-card__session">review session</div>
 					</div>
 					<span className={cn("reviewer-status", `reviewer-status--${aggregateVerdict.tone}`)}>
 						{aggregateVerdict.label}
 					</span>
 				</div>
+				<div className="reviewer-summary-list">
+					{reviewStates.length === 0 ? <p className="inspector-empty">No review state loaded yet.</p> : null}
+					{reviewStates.map((reviewState) => (
+						<ReviewStateRow key={`${reviewState.prUrl}:${reviewState.targetSha}`} reviewState={reviewState} />
+					))}
+				</div>
+				<div className="reviewer-card__actions">
+					<button
+						className="reviewer-card__action reviewer-card__action--primary"
+						disabled={runDisabled}
+						onClick={onTrigger}
+						type="button"
+					>
+						<Play aria-hidden="true" />
+						{runAction}
+					</button>
+					<button
+						className="reviewer-card__action"
+						disabled={!terminalEnabled}
+						onClick={() => {
+							if (!terminalEnabled) return;
+							onOpenTerminal?.({ handleId: reviewerHandleId, harness });
+						}}
+						type="button"
+					>
+						<Terminal aria-hidden="true" />
+						Open terminal
+					</button>
+				</div>
 			</div>
-			<div className="reviewer-summary-list">
-				{reviewStates.length === 0 ? <p className="inspector-empty">No review state loaded yet.</p> : null}
-				{reviewStates.map((reviewState) => (
-					<ReviewStateRow
-						key={`${reviewState.prUrl}:${reviewState.targetSha}`}
-						isTriggering={isTriggering}
-						onTrigger={onTrigger}
-						reviewState={reviewState}
-					/>
-				))}
-			</div>
-			<button
-				className="reviewer-card__action reviewer-card__action--wide"
-				disabled={!terminalEnabled}
-				onClick={() => {
-					if (!terminalEnabled) return;
-					onOpenTerminal?.({ handleId: reviewerHandleId, harness });
-				}}
-				type="button"
-			>
-				<Terminal aria-hidden="true" />
-				Open terminal
-			</button>
 		</div>
 	);
 }
 
-function ReviewStateRow({
-	reviewState,
-	isTriggering,
-	onTrigger,
-}: {
-	reviewState: PRReviewState;
-	isTriggering: boolean;
-	onTrigger: () => void;
-}) {
+function ReviewStateRow({ reviewState }: { reviewState: PRReviewState }) {
 	const verdict = reviewVerdict(reviewState);
-	const buttonLabel = reviewRunButtonLabel(reviewState, isTriggering);
-	const disabled = isTriggering || reviewState.status === "running" || reviewState.status === "ineligible";
 	const title = reviewState.title?.trim() || `PR #${reviewState.prNumber}`;
 	return (
 		<div
@@ -563,10 +570,9 @@ function ReviewStateRow({
 					<span className="reviewer-row__number">#{reviewState.prNumber}</span>
 				</div>
 			</div>
-			<span className={cn("reviewer-row__verdict", `reviewer-row__verdict--${verdict.tone}`)}>{verdict.label}</span>
-			<button className="reviewer-row__action" disabled={disabled} onClick={onTrigger} type="button">
-				{buttonLabel}
-			</button>
+			<span className={cn("reviewer-row__verdict", `reviewer-row__verdict--${verdict.tone}`)}>
+				{verdict.label}
+			</span>
 		</div>
 	);
 }
@@ -606,9 +612,14 @@ function reviewVerdict(reviewState: PRReviewState): {
 	return { label: "Not run", tone: "neutral" };
 }
 
-function reviewRunButtonLabel(reviewState: PRReviewState, isTriggering: boolean): string {
-	if (reviewState.status === "running" || isTriggering) return "Reviewing...";
-	return reviewState.latestRun ? "Re-run" : "Run";
+function reviewSessionRunAction(reviewStates: PRReviewState[], isTriggering: boolean): string {
+	if (isTriggering || reviewStates.some((reviewState) => reviewState.status === "running")) {
+		return "Reviewing...";
+	}
+	if (reviewStates.some((reviewState) => reviewState.status === "changes_requested" || reviewState.latestRun)) {
+		return "Re-run review";
+	}
+	return "Run review";
 }
 
 function BrowserView({

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -1,12 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState, type ReactNode } from "react";
 import {
-	AlertCircle,
 	ArrowUpRight,
-	CheckCircle2,
-	CircleMinus,
 	GitPullRequest,
-	Play,
 	Shield,
 	Terminal,
 } from "lucide-react";
@@ -494,6 +490,7 @@ function ReviewPanel({
 	const latest = reviewStates.find((review) => review.latestRun)?.latestRun;
 	const harness = latest?.harness || config?.reviewers?.[0]?.harness || session.provider || "reviewer";
 	const terminalEnabled = Boolean(reviewerHandleId && onOpenTerminal);
+	const aggregateVerdict = sessionReviewVerdict(reviewStates);
 
 	return (
 		<div className="reviewer-list">
@@ -501,94 +498,124 @@ function ReviewPanel({
 			{notice ? <p className="reviewer-notice">{notice}</p> : null}
 			<div className="reviewer-card">
 				<div className="reviewer-card__top">
-					<div className="reviewer-card__name">
-						<Shield aria-hidden="true" />
-						<span>{harness}</span>
+					<div className="reviewer-card__identity">
+						<div className="reviewer-card__name">
+							<Shield aria-hidden="true" />
+							<span>{harness}</span>
+						</div>
+						<div className="reviewer-card__session">{session.id}</div>
 					</div>
-					<span className="reviewer-status reviewer-status--neutral">{reviewStates.length} PRs</span>
-				</div>
-				<div className="reviewer-card__actions">
-					<button
-						className="reviewer-card__action reviewer-card__action--primary"
-						disabled={isTriggering}
-						onClick={onTrigger}
-						type="button"
-					>
-						<Play aria-hidden="true" />
-						{isTriggering ? "Starting..." : "Run needed reviews"}
-					</button>
-					<button
-						className="reviewer-card__action"
-						disabled={!terminalEnabled}
-						onClick={() => {
-							if (!terminalEnabled) return;
-							onOpenTerminal?.({ handleId: reviewerHandleId, harness });
-						}}
-						type="button"
-					>
-						<Terminal aria-hidden="true" />
-						Open terminal
-					</button>
+					<span className={cn("reviewer-status", `reviewer-status--${aggregateVerdict.tone}`)}>
+						{aggregateVerdict.label}
+					</span>
 				</div>
 			</div>
-			<div className="flex flex-col gap-2">
+			<div className="reviewer-summary-list">
 				{reviewStates.length === 0 ? <p className="inspector-empty">No review state loaded yet.</p> : null}
 				{reviewStates.map((reviewState) => (
-					<ReviewStateCard key={`${reviewState.prUrl}:${reviewState.targetSha}`} reviewState={reviewState} />
+					<ReviewStateRow
+						key={`${reviewState.prUrl}:${reviewState.targetSha}`}
+						isTriggering={isTriggering}
+						onTrigger={onTrigger}
+						reviewState={reviewState}
+					/>
 				))}
 			</div>
+			<button
+				className="reviewer-card__action reviewer-card__action--wide"
+				disabled={!terminalEnabled}
+				onClick={() => {
+					if (!terminalEnabled) return;
+					onOpenTerminal?.({ handleId: reviewerHandleId, harness });
+				}}
+				type="button"
+			>
+				<Terminal aria-hidden="true" />
+				Open terminal
+			</button>
 		</div>
 	);
 }
 
-function ReviewStateCard({ reviewState }: { reviewState: PRReviewState }) {
-	const status = reviewStateStatus(reviewState);
+function ReviewStateRow({
+	reviewState,
+	isTriggering,
+	onTrigger,
+}: {
+	reviewState: PRReviewState;
+	isTriggering: boolean;
+	onTrigger: () => void;
+}) {
+	const verdict = reviewVerdict(reviewState);
+	const buttonLabel = reviewRunButtonLabel(reviewState, isTriggering);
+	const disabled = isTriggering || reviewState.status === "running" || reviewState.status === "ineligible";
+	const title = reviewState.title?.trim() || `PR #${reviewState.prNumber}`;
 	return (
 		<div
 			className={cn(
-				"reviewer-card",
-				status.tone && `reviewer-card--${status.tone}`,
+				"reviewer-row",
+				`reviewer-row--${verdict.tone}`,
 				reviewState.status === "ineligible" && "opacity-70",
 			)}
 		>
-			<div className="reviewer-card__top">
-				<div className="reviewer-card__name">
+			<div className="reviewer-row__main">
+				<span className={cn("reviewer-row__dot", `reviewer-row__dot--${verdict.tone}`)} />
+				<div className="reviewer-row__copy">
 					<GitPullRequest aria-hidden="true" />
-					<span>PR #{reviewState.prNumber}</span>
+					<a href={reviewState.prUrl} target="_blank" rel="noopener noreferrer">
+						{title}
+					</a>
+					<span className="reviewer-row__number">#{reviewState.prNumber}</span>
 				</div>
-				<span className={cn("reviewer-status", `reviewer-status--${status.tone}`)}>
-					{status.icon}
-					{status.label}
-				</span>
 			</div>
-			<div className="mt-2 min-w-0 truncate font-mono text-[10.5px] text-passive">
-				<a href={reviewState.prUrl} target="_blank" rel="noopener noreferrer" className="text-accent hover:underline">
-					{reviewState.prUrl}
-				</a>
-				{reviewState.targetSha ? <span className="ml-2">{reviewState.targetSha.slice(0, 7)}</span> : null}
-			</div>
+			<span className={cn("reviewer-row__verdict", `reviewer-row__verdict--${verdict.tone}`)}>
+				{verdict.label}
+			</span>
+			<button className="reviewer-row__action" disabled={disabled} onClick={onTrigger} type="button">
+				{buttonLabel}
+			</button>
 		</div>
 	);
 }
 
-function reviewStateStatus(reviewState: PRReviewState): {
+function sessionReviewVerdict(reviewStates: PRReviewState[]): {
 	label: string;
 	tone: "neutral" | "running" | "success" | "danger";
-	icon: ReactNode;
+} {
+	if (reviewStates.some((reviewState) => reviewState.status === "running")) {
+		return { label: "Reviewing...", tone: "running" };
+	}
+	if (reviewStates.some((reviewState) => reviewState.status === "changes_requested")) {
+		return { label: "Changes requested", tone: "danger" };
+	}
+	const eligibleReviews = reviewStates.filter((reviewState) => reviewState.status !== "ineligible");
+	if (eligibleReviews.length > 0 && eligibleReviews.every((reviewState) => reviewState.status === "up_to_date")) {
+		return { label: "Approved", tone: "success" };
+	}
+	return { label: "Not run", tone: "neutral" };
+}
+
+function reviewVerdict(reviewState: PRReviewState): {
+	label: string;
+	tone: "neutral" | "running" | "success" | "danger";
 } {
 	switch (reviewState.status) {
-		case "needs_review":
-			return { label: "Needs review", tone: "neutral", icon: null };
 		case "running":
-			return { label: "Running", tone: "running", icon: <Play aria-hidden="true" /> };
+			return { label: "Reviewing...", tone: "running" };
 		case "up_to_date":
-			return { label: "Up to date", tone: "success", icon: <CheckCircle2 aria-hidden="true" /> };
+			return { label: "Approved", tone: "success" };
 		case "changes_requested":
-			return { label: "Changes requested", tone: "danger", icon: <CircleMinus aria-hidden="true" /> };
+			return { label: "Changes requested", tone: "danger" };
+		case "needs_review":
 		case "ineligible":
-			return { label: "Ineligible", tone: "neutral", icon: <AlertCircle aria-hidden="true" /> };
+			return { label: "Not run", tone: "neutral" };
 	}
-	return { label: reviewState.status, tone: "neutral", icon: null };
+	return { label: "Not run", tone: "neutral" };
+}
+
+function reviewRunButtonLabel(reviewState: PRReviewState, isTriggering: boolean): string {
+	if (reviewState.status === "running" || isTriggering) return "Reviewing...";
+	return reviewState.latestRun ? "Re-run" : "Run";
 }
 
 function BrowserView({

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -570,9 +570,7 @@ function ReviewStateRow({ reviewState }: { reviewState: PRReviewState }) {
 					<span className="reviewer-row__number">#{reviewState.prNumber}</span>
 				</div>
 			</div>
-			<span className={cn("reviewer-row__verdict", `reviewer-row__verdict--${verdict.tone}`)}>
-				{verdict.label}
-			</span>
+			<span className={cn("reviewer-row__verdict", `reviewer-row__verdict--${verdict.tone}`)}>{verdict.label}</span>
 		</div>
 	);
 }

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -504,13 +504,7 @@ function ReviewPanel({
 			</div>
 			<div className="reviewer-card">
 				<div className="reviewer-card__top">
-					<div className="reviewer-card__identity">
-						<div className="reviewer-card__name">
-							<GitPullRequest aria-hidden="true" />
-							<span>{session.id}</span>
-						</div>
-						<div className="reviewer-card__session">review session</div>
-					</div>
+					<span className="reviewer-card__label">Pull requests</span>
 					<span className={cn("reviewer-status", `reviewer-status--${aggregateVerdict.tone}`)}>
 						{aggregateVerdict.label}
 					</span>

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -1,11 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState, type ReactNode } from "react";
-import {
-	ArrowUpRight,
-	GitPullRequest,
-	Shield,
-	Terminal,
-} from "lucide-react";
+import { ArrowUpRight, GitPullRequest, Shield, Terminal } from "lucide-react";
 import type { components } from "../../api/schema";
 import { apiClient, apiErrorMessage } from "../lib/api-client";
 import { workspaceQueryKey } from "../hooks/useWorkspaceQuery";
@@ -568,9 +563,7 @@ function ReviewStateRow({
 					<span className="reviewer-row__number">#{reviewState.prNumber}</span>
 				</div>
 			</div>
-			<span className={cn("reviewer-row__verdict", `reviewer-row__verdict--${verdict.tone}`)}>
-				{verdict.label}
-			</span>
+			<span className={cn("reviewer-row__verdict", `reviewer-row__verdict--${verdict.tone}`)}>{verdict.label}</span>
 			<button className="reviewer-row__action" disabled={disabled} onClick={onTrigger} type="button">
 				{buttonLabel}
 			</button>

--- a/frontend/src/renderer/components/SessionInspector.tsx
+++ b/frontend/src/renderer/components/SessionInspector.tsx
@@ -544,7 +544,13 @@ function ReviewPanel({
 function ReviewStateCard({ reviewState }: { reviewState: PRReviewState }) {
 	const status = reviewStateStatus(reviewState);
 	return (
-		<div className={cn("reviewer-card", status.tone && `reviewer-card--${status.tone}`, reviewState.status === "ineligible" && "opacity-70")}>
+		<div
+			className={cn(
+				"reviewer-card",
+				status.tone && `reviewer-card--${status.tone}`,
+				reviewState.status === "ineligible" && "opacity-70",
+			)}
+		>
 			<div className="reviewer-card__top">
 				<div className="reviewer-card__name">
 					<GitPullRequest aria-hidden="true" />

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -1021,6 +1021,22 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	white-space: nowrap;
 }
 
+.reviewer-card__identity {
+	display: flex;
+	min-width: 0;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.reviewer-card__session {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 11px;
+	color: var(--fg-passive);
+}
+
 .reviewer-status {
 	display: inline-flex;
 	height: 24px;
@@ -1117,6 +1133,157 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	border-color: color-mix(in srgb, var(--green) 42%, transparent);
 	background: color-mix(in srgb, var(--green) 10%, transparent);
 	color: #8bdc75;
+}
+
+.reviewer-card__action--wide {
+	width: 100%;
+}
+
+.reviewer-summary-list {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.reviewer-row {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto 88px;
+	align-items: center;
+	gap: 10px;
+	border-radius: 8px;
+	border: 1px solid var(--border);
+	background: var(--bg-1);
+	padding: 10px;
+}
+
+.reviewer-row--success {
+	border-color: color-mix(in srgb, var(--green) 22%, var(--border));
+}
+
+.reviewer-row--danger {
+	border-color: color-mix(in srgb, var(--red) 20%, var(--border));
+}
+
+.reviewer-row__main {
+	display: inline-flex;
+	min-width: 0;
+	align-items: center;
+	gap: 9px;
+}
+
+.reviewer-row__dot {
+	width: 8px;
+	height: 8px;
+	flex-shrink: 0;
+	border-radius: 999px;
+	background: var(--fg-passive);
+}
+
+.reviewer-row__dot--running {
+	background: var(--orange);
+}
+
+.reviewer-row__dot--success {
+	background: var(--green);
+}
+
+.reviewer-row__dot--danger {
+	background: var(--red);
+}
+
+.reviewer-row__copy {
+	display: inline-flex;
+	min-width: 0;
+	align-items: center;
+	gap: 7px;
+	font-size: 12.5px;
+	font-weight: 650;
+	color: var(--fg);
+}
+
+.reviewer-row__copy svg {
+	width: 14px;
+	height: 14px;
+	flex-shrink: 0;
+	color: var(--fg-passive);
+}
+
+.reviewer-row__copy a {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	color: inherit;
+	text-decoration: none;
+}
+
+.reviewer-row__copy a:hover {
+	text-decoration: underline;
+}
+
+.reviewer-row__number {
+	flex-shrink: 0;
+	font-family: var(--font-mono);
+	font-size: 11px;
+	color: var(--fg-passive);
+}
+
+.reviewer-row__verdict {
+	white-space: nowrap;
+	font-size: 11.5px;
+	font-weight: 650;
+	color: var(--fg-muted);
+}
+
+.reviewer-row__verdict--running {
+	color: var(--orange);
+}
+
+.reviewer-row__verdict--success {
+	color: var(--green);
+}
+
+.reviewer-row__verdict--danger {
+	color: var(--red);
+}
+
+.reviewer-row__action {
+	display: inline-flex;
+	height: 30px;
+	min-width: 0;
+	align-items: center;
+	justify-content: center;
+	overflow: hidden;
+	border-radius: 7px;
+	border: 1px solid var(--border);
+	background: var(--bg-2);
+	padding: 0 9px;
+	font-size: 11.5px;
+	font-weight: 650;
+	color: var(--fg-muted);
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+.reviewer-row__action:hover:not(:disabled) {
+	background: var(--interactive-hover);
+	color: var(--fg);
+}
+
+.reviewer-row__action:disabled {
+	cursor: not-allowed;
+	opacity: 0.45;
+}
+
+@media (max-width: 680px) {
+	.reviewer-row {
+		grid-template-columns: minmax(0, 1fr) auto;
+	}
+
+	.reviewer-row__action {
+		grid-column: 1 / -1;
+		width: 100%;
+	}
 }
 
 :root[data-theme="light"] .reviewer-card__action--primary {

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -945,7 +945,39 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 .reviewer-list {
 	display: flex;
 	flex-direction: column;
-	gap: 12px;
+	gap: 14px;
+}
+
+.reviewer-kicker {
+	display: inline-flex;
+	min-width: 0;
+	align-items: center;
+	gap: 8px;
+	font-family: var(--font-mono);
+	font-size: 13px;
+	font-weight: 700;
+	color: var(--fg);
+}
+
+.reviewer-kicker svg {
+	width: 15px;
+	height: 15px;
+	flex-shrink: 0;
+	color: var(--fg-passive);
+}
+
+.reviewer-kicker span:first-of-type {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.reviewer-kicker span:last-child {
+	font-family: var(--font-sans);
+	font-size: 11.5px;
+	font-weight: 500;
+	color: var(--fg-passive);
 }
 
 .reviewer-error {
@@ -973,11 +1005,11 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 .reviewer-card {
 	display: flex;
 	flex-direction: column;
-	gap: 14px;
+	gap: 12px;
 	border-radius: 8px;
 	border: 1px solid var(--border);
 	background: var(--bg-1);
-	padding: 14px;
+	padding: 12px;
 }
 
 .reviewer-card--success {
@@ -1000,9 +1032,9 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	display: inline-flex;
 	min-width: 0;
 	align-items: center;
-	gap: 9px;
+	gap: 8px;
 	font-family: var(--font-mono);
-	font-size: 13px;
+	font-size: 12.5px;
 	font-weight: 600;
 	color: var(--fg);
 }
@@ -1033,21 +1065,23 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	font-size: 11px;
+	font-size: 10.5px;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
 	color: var(--fg-passive);
 }
 
 .reviewer-status {
 	display: inline-flex;
-	height: 24px;
+	height: 20px;
 	max-width: 58%;
 	flex-shrink: 0;
 	align-items: center;
 	gap: 5px;
 	overflow: hidden;
-	border-radius: 7px;
-	padding: 0 9px;
-	font-size: 11.5px;
+	border-radius: 6px;
+	padding: 0 8px;
+	font-size: 10.5px;
 	font-weight: 650;
 	line-height: 1;
 	white-space: nowrap;
@@ -1084,6 +1118,7 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	display: grid;
 	grid-template-columns: repeat(2, minmax(0, 1fr));
 	gap: 10px;
+	padding-top: 4px;
 }
 
 .reviewer-card__actions:has(.reviewer-card__action:only-child) {
@@ -1142,26 +1177,36 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 .reviewer-summary-list {
 	display: flex;
 	flex-direction: column;
-	gap: 8px;
+	gap: 0;
+	overflow: hidden;
+	border-radius: 7px;
+	border: 1px solid var(--border);
+	background: color-mix(in srgb, var(--bg-0) 35%, transparent);
 }
 
 .reviewer-row {
 	display: grid;
-	grid-template-columns: minmax(0, 1fr) auto 88px;
+	grid-template-columns: minmax(0, 1fr) auto;
 	align-items: center;
 	gap: 10px;
-	border-radius: 8px;
-	border: 1px solid var(--border);
-	background: var(--bg-1);
-	padding: 10px;
+	border-radius: 0;
+	border: 0;
+	border-bottom: 1px solid var(--border);
+	background: transparent;
+	padding: 11px 12px;
+	min-height: 52px;
+}
+
+.reviewer-row:last-child {
+	border-bottom: 0;
 }
 
 .reviewer-row--success {
-	border-color: color-mix(in srgb, var(--green) 22%, var(--border));
+	border-color: var(--border);
 }
 
 .reviewer-row--danger {
-	border-color: color-mix(in srgb, var(--red) 20%, var(--border));
+	border-color: var(--border);
 }
 
 .reviewer-row__main {
@@ -1172,8 +1217,8 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 }
 
 .reviewer-row__dot {
-	width: 8px;
-	height: 8px;
+	width: 7px;
+	height: 7px;
 	flex-shrink: 0;
 	border-radius: 999px;
 	background: var(--fg-passive);
@@ -1192,16 +1237,19 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 }
 
 .reviewer-row__copy {
-	display: inline-flex;
+	display: grid;
+	grid-template-columns: auto auto;
 	min-width: 0;
-	align-items: center;
-	gap: 7px;
-	font-size: 12.5px;
+	align-items: baseline;
+	column-gap: 6px;
+	row-gap: 2px;
+	font-size: 12px;
 	font-weight: 650;
 	color: var(--fg);
 }
 
 .reviewer-row__copy svg {
+	display: none;
 	width: 14px;
 	height: 14px;
 	flex-shrink: 0;
@@ -1209,6 +1257,7 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 }
 
 .reviewer-row__copy a {
+	grid-column: 1 / -1;
 	min-width: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -1222,7 +1271,7 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 }
 
 .reviewer-row__number {
-	flex-shrink: 0;
+	grid-column: 1;
 	font-family: var(--font-mono);
 	font-size: 11px;
 	color: var(--fg-passive);
@@ -1230,7 +1279,7 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 
 .reviewer-row__verdict {
 	white-space: nowrap;
-	font-size: 11.5px;
+	font-size: 11px;
 	font-weight: 650;
 	color: var(--fg-muted);
 }
@@ -1247,42 +1296,9 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	color: var(--red);
 }
 
-.reviewer-row__action {
-	display: inline-flex;
-	height: 30px;
-	min-width: 0;
-	align-items: center;
-	justify-content: center;
-	overflow: hidden;
-	border-radius: 7px;
-	border: 1px solid var(--border);
-	background: var(--bg-2);
-	padding: 0 9px;
-	font-size: 11.5px;
-	font-weight: 650;
-	color: var(--fg-muted);
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.reviewer-row__action:hover:not(:disabled) {
-	background: var(--interactive-hover);
-	color: var(--fg);
-}
-
-.reviewer-row__action:disabled {
-	cursor: not-allowed;
-	opacity: 0.45;
-}
-
 @media (max-width: 680px) {
 	.reviewer-row {
 		grid-template-columns: minmax(0, 1fr) auto;
-	}
-
-	.reviewer-row__action {
-		grid-column: 1 / -1;
-		width: 100%;
 	}
 }
 

--- a/frontend/src/renderer/styles.css
+++ b/frontend/src/renderer/styles.css
@@ -1060,15 +1060,14 @@ body.is-resizing-x [data-slot="sidebar-container"] {
 	gap: 4px;
 }
 
-.reviewer-card__session {
+.reviewer-card__label {
 	min-width: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	font-size: 10.5px;
-	text-transform: uppercase;
-	letter-spacing: 0.04em;
-	color: var(--fg-passive);
+	font-size: 12px;
+	font-weight: 650;
+	color: var(--fg-muted);
 }
 
 .reviewer-status {


### PR DESCRIPTION
## Summary
- update the Reviews tab to render PR-scoped review state from reviews
- show per-PR statuses for needed, running, changes-requested, up-to-date, and ineligible reviews
- use each review row's latestRun for harness/terminal metadata when needed
- keep one session-level Run needed reviews action and one shared Open terminal action for the reviewer terminal

## Tests
- cd frontend && npm run typecheck
- cd frontend && npm test -- SessionInspector

Stacked on #396. Refs #395