### PR TITLE
fix(desktop): handle Squirrel startup events + CI smoke-install the Windows build

### DIFF
--- a/.github/workflows/testing-build.yml
+++ b/.github/workflows/testing-build.yml
@@ -76,11 +76,15 @@ jobs:
           Write-Host "Running $($setup.FullName) --silent"
           $proc = Start-Process -FilePath $setup.FullName -ArgumentList '--silent' -PassThru -Wait
           Write-Host "Setup.exe exit code: $($proc.ExitCode)"
-          # Update.exe writes the install log here; copy it into the workspace so the
-          # next step can upload it regardless of whether the install succeeded.
-          $log = Join-Path $env:LOCALAPPDATA 'SquirrelTemp\SquirrelSetup.log'
-          if (Test-Path $log) { Copy-Item $log squirrel-setup.log } else { Write-Host '::warning::no SquirrelSetup.log written (failed before Update.exe ran)' }
           $installDir = Join-Path $env:LOCALAPPDATA 'AgentOrchestrator'
+          # Update.exe writes SquirrelSetup.log into the app root dir; the Setup.exe
+          # bootstrapper only logs to SquirrelTemp for the earliest extraction stage.
+          # Grab whichever exists and copy it into the workspace for upload.
+          $log = @(
+            (Join-Path $installDir 'SquirrelSetup.log'),
+            (Join-Path $env:LOCALAPPDATA 'SquirrelTemp\SquirrelSetup.log')
+          ) | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if ($log) { Copy-Item $log squirrel-setup.log; Write-Host "captured log: $log" } else { Write-Host '::warning::no SquirrelSetup.log found in install dir or SquirrelTemp' }
           if (Test-Path $installDir) {
             Write-Host "INSTALL OK: $installDir created"
             Get-ChildItem $installDir | Select-Object Name | Format-Table -AutoSize

--- a/.github/workflows/testing-build.yml
+++ b/.github/workflows/testing-build.yml
@@ -58,6 +58,42 @@ jobs:
         # `npm run make` keeps the premake daemon build; --targets restricts to this
         # platform's maker.
         run: npm run make -- --targets ${{ matrix.target }}
+      # Smoke-install the Squirrel installer on a clean, native x64 Windows runner.
+      # This is a build-vs-host verdict: if it installs here it proves the artifact
+      # is good and a failing user machine is host-side (AV/disk/signing); if it
+      # fails here the build/Squirrel config is wrong. continue-on-error so a failed
+      # install never blocks publishing the artifacts. The runner has no real-time
+      # AV blocking, so a clean install here does NOT prove SmartScreen/Defender
+      # won't reject the unsigned binaries on end-user machines.
+      - name: Smoke-install the Windows installer
+        if: runner.os == 'Windows'
+        continue-on-error: true
+        timeout-minutes: 5
+        shell: pwsh
+        run: |
+          $setup = Get-ChildItem -Path out/make/squirrel.windows -Recurse -Filter '*Setup.exe' | Select-Object -First 1
+          if (-not $setup) { Write-Host '::error::no Setup.exe produced under out/make/squirrel.windows'; exit 1 }
+          Write-Host "Running $($setup.FullName) --silent"
+          $proc = Start-Process -FilePath $setup.FullName -ArgumentList '--silent' -PassThru -Wait
+          Write-Host "Setup.exe exit code: $($proc.ExitCode)"
+          # Update.exe writes the install log here; copy it into the workspace so the
+          # next step can upload it regardless of whether the install succeeded.
+          $log = Join-Path $env:LOCALAPPDATA 'SquirrelTemp\SquirrelSetup.log'
+          if (Test-Path $log) { Copy-Item $log squirrel-setup.log } else { Write-Host '::warning::no SquirrelSetup.log written (failed before Update.exe ran)' }
+          $installDir = Join-Path $env:LOCALAPPDATA 'AgentOrchestrator'
+          if (Test-Path $installDir) {
+            Write-Host "INSTALL OK: $installDir created"
+            Get-ChildItem $installDir | Select-Object Name | Format-Table -AutoSize
+          } else {
+            Write-Host "::warning::INSTALL FAILED: $installDir was not created"
+          }
+      - name: Upload SquirrelSetup.log
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: squirrel-setup-log-${{ github.sha }}
+          path: frontend/squirrel-setup.log
+          if-no-files-found: warn
       - name: Publish to a 0.0.0-testing-<sha> prerelease
         shell: bash
         env:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
 				"@xterm/xterm": "^5.5.0",
 				"class-variance-authority": "^0.7.1",
 				"clsx": "^2.1.1",
+				"electron-squirrel-startup": "^1.0.1",
 				"lucide-react": "^1.17.0",
 				"openapi-fetch": "^0.17.0",
 				"posthog-js": "^1.390.2",
@@ -8517,6 +8518,30 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/electron-squirrel-startup": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/electron-squirrel-startup/-/electron-squirrel-startup-1.0.1.tgz",
+			"integrity": "sha512-sTfFIHGku+7PsHLJ7v0dRcZNkALrV+YEozINTW8X1nM//e5O3L+rfYuvSW00lmGHnYmUjARZulD8F2V8ISI9RA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"debug": "^2.2.0"
+			}
+		},
+		"node_modules/electron-squirrel-startup/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/electron-squirrel-startup/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.371",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,6 +68,7 @@
 		"@xterm/xterm": "^5.5.0",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
+		"electron-squirrel-startup": "^1.0.1",
 		"lucide-react": "^1.17.0",
 		"openapi-fetch": "^0.17.0",
 		"posthog-js": "^1.390.2",

--- a/frontend/src/electron-squirrel-startup.d.ts
+++ b/frontend/src/electron-squirrel-startup.d.ts
@@ -1,0 +1,7 @@
+// electron-squirrel-startup ships no types. Its default export is the boolean
+// result of handling any --squirrel-* startup event (true when the app should
+// quit, false on macOS/Linux or a normal launch).
+declare module "electron-squirrel-startup" {
+	const startup: boolean;
+	export default startup;
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -12,6 +12,7 @@ import {
 	type OpenDialogOptions,
 } from "electron";
 import { updateElectronApp } from "update-electron-app";
+import squirrelStartup from "electron-squirrel-startup";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
@@ -47,6 +48,18 @@ const ignoreStdStreamError = (err: NodeJS.ErrnoException): void => {
 };
 process.stdout.on("error", ignoreStdStreamError);
 process.stderr.on("error", ignoreStdStreamError);
+
+// Windows Squirrel runs this exe with a --squirrel-{install,updated,uninstall,
+// obsolete} flag during install/update/uninstall. electron-squirrel-startup
+// creates/removes the shortcuts for that event and returns true; we then quit
+// immediately instead of booting the full app. A full launch (window + daemon
+// spawn) would hang the installer, which runs this hook and waits for it to
+// exit — that hang is the Squirrel-side failure. Returns false on macOS/Linux,
+// so this is a no-op there.
+const isSquirrelStartup: boolean = squirrelStartup;
+if (isSquirrelStartup) {
+	app.quit();
+}
 
 // Must run before app ready so the About panel and default-menu role labels use it.
 app.setName("Agent Orchestrator");
@@ -676,6 +689,9 @@ function initAutoUpdates(): void {
 }
 
 app.whenReady().then(() => {
+	// A Squirrel install/update hook already called app.quit() above; do no
+	// startup work (no window, no daemon spawn) so the hook exits promptly.
+	if (isSquirrelStartup) return;
 	registerRendererProtocol();
 	createWindow();
 	void startDaemon();


### PR DESCRIPTION
## Context

The Windows Squirrel installer fails on a tester's machine with "Installation has failed" and **no `SquirrelSetup.log` entry at all**, meaning `Setup.exe` dies before `Update.exe` (the part that logs) runs. The built artifacts are healthy (119MB Setup.exe wrapping a 118MB nupkg + RELEASES), so the build isn't truncated; the failure is host-side and/or in the install hooks. This PR addresses the app-side gap and gives us a way to actually capture the log.

## Changes

**1. Handle Squirrel startup events (`main.ts`).** The app had no `electron-squirrel-startup` handler, only `update-electron-app` (auto-updates, unrelated). During install Squirrel runs the exe with `--squirrel-install`/`--squirrel-updated`/`--squirrel-uninstall`/`--squirrel-obsolete` and waits for it to exit; without the handler the full app booted (window + daemon) and never exited, hanging the installer. Now it creates/removes shortcuts and quits immediately. No-op on macOS/Linux. (`electron-squirrel-startup` ships no types, so a 6-line ambient `.d.ts` is added rather than pulling in `@types`.)

**2. CI smoke-install (`testing-build.yml`).** After the Windows build, run `Setup.exe --silent` on the clean native x64 `windows-latest` runner, assert `%LocalAppData%\AgentOrchestrator` is created, and upload `SquirrelSetup.log` as a workflow artifact (`continue-on-error`, so it never blocks publishing).

This is a **build-vs-host verdict**:
- Installs cleanly on the runner → the artifact is good → a failing user machine is host-side (AV / disk space / signing).
- Fails on the runner → the build/Squirrel config is wrong, and we now have the log to see why.

Caveat documented in the workflow: the runner has no real-time AV, so a clean install there does **not** prove SmartScreen/Defender will accept the unsigned binaries on end-user machines. Authenticode code-signing remains the durable fix and is the next follow-up.

## Testing

- `npm run typecheck` ✅ (confirms the import + ambient declaration resolve)
- The smoke-install step is itself the integration test; first CI run on this branch will exercise it and attach the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)