### PR TITLE
fix(desktop): stop console-window flashing on Windows

### DIFF
--- a/backend/internal/adapters/runtime/zellij/process_other.go
+++ b/backend/internal/adapters/runtime/zellij/process_other.go
@@ -2,7 +2,13 @@
 
 package zellij
 
-import "errors"
+import (
+	"errors"
+	"os/exec"
+)
+
+// hideWindow is a no-op off Windows: only Windows pops a console window.
+func hideWindow(*exec.Cmd) {}
 
 // startBackgroundProcess is a stub: the fire-and-forget path is only used by
 // the Windows zellij codepath. Non-Windows builds create sessions

--- a/backend/internal/adapters/runtime/zellij/process_windows.go
+++ b/backend/internal/adapters/runtime/zellij/process_windows.go
@@ -10,12 +10,23 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// hideWindow suppresses the console window for a console-subsystem child so
+// frequent zellij calls (e.g. the reaper's list-sessions) don't flash on Windows.
+func hideWindow(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: windows.CREATE_NO_WINDOW,
+	}
+}
+
 func startBackgroundProcess(env []string, name string, args ...string) error {
 	script := "Start-Process -FilePath " + psQuote(name) + " -ArgumentList " + psQuote(windowsCommandLine(args)) + " -WindowStyle Hidden"
 	cmd := exec.Command("powershell.exe", "-NoLogo", "-NoProfile", "-EncodedCommand", powerShellEncodedCommand(script))
 	cmd.Env = env
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		CreationFlags: windows.CREATE_NEW_CONSOLE,
+		// CREATE_NO_WINDOW, not CREATE_NEW_CONSOLE: the latter creates a console
+		// then hides it, which flashed a window.
+		CreationFlags: windows.CREATE_NO_WINDOW,
 		HideWindow:    true,
 	}
 	if err := cmd.Start(); err != nil {

--- a/backend/internal/adapters/runtime/zellij/zellij.go
+++ b/backend/internal/adapters/runtime/zellij/zellij.go
@@ -93,6 +93,7 @@ type execRunner struct{}
 func (execRunner) Run(ctx context.Context, env []string, name string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Env = zellijCommandEnv(os.Environ(), env)
+	hideWindow(cmd)
 	return cmd.CombinedOutput()
 }
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -506,6 +506,8 @@ async function startDaemonInner(startEpoch: number): Promise<DaemonStatus> {
 		env: daemonEnv(),
 		shell: launch.shell,
 		detached: true,
+		// Hide the daemon's console on a Windows GUI launch (no flashing terminal).
+		windowsHide: true,
 	});
 	daemonProcess = child;
 


### PR DESCRIPTION
## Problem

On Windows the AO desktop app shows rapid console-window blinking while running.

## Diagnosis

The daemon shells out to console-subsystem processes (zellij) without suppressing the console window. The reaper polls session liveness on a timer (and the attach loop retries), and every call runs a zellij command (notably `list-sessions`). Each invocation pops a console window that instantly closes, producing the rapid blinking. Those processes are daemon children, so they vanish when the app closes.

`execRunner.Run` (the generic runner for every zellij command) set no `SysProcAttr`, so on Windows each call flashed a console. Separately, `startBackgroundProcess` used `CREATE_NEW_CONSOLE` (which creates a console and then hides it, flash-prone), and the daemon's own `spawn` in the renderer had no `windowsHide`, leaving its console visible.

## Changes

1. Add a platform-split `hideWindow(cmd *exec.Cmd)` helper to the zellij package:
   - `process_windows.go`: sets `HideWindow: true` + `CreationFlags: windows.CREATE_NO_WINDOW`.
   - `process_other.go`: no-op.
   Call it in `execRunner.Run` after building `cmd`, so `list-sessions` and the other reaper/attach calls stop flashing.
2. `startBackgroundProcess` now uses `windows.CREATE_NO_WINDOW` instead of `CREATE_NEW_CONSOLE` (the latter creates a console then hides it, which flashed).
3. `frontend/src/main.ts`: add `windowsHide: true` to the daemon `spawn(...)` so the daemon's own console stays hidden on a Windows GUI launch.

Scope is limited to the zellij runtime blinker plus the daemon-spawn console. Other exec call sites (git/scm/hooks) are untouched.

## Verification

- `GOOS=windows go build ./...`: pass (compiles the Windows-only file with the changes)
- `go build ./...`: pass
- `go test -race ./...`: pass (1551 tests, 73 packages)
- `frontend` `npm run typecheck`: pass

The visible effect (no flashing) cannot be observed in CI or on macOS; it must be verified on a real Windows session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)