### PR TITLE
fix(desktop): package Windows via NSIS instead of Squirrel

### DIFF
--- a/.github/workflows/desktop-testing.yml
+++ b/.github/workflows/desktop-testing.yml
@@ -6,7 +6,7 @@ name: Desktop testing build
 #
 # Per OS the current electron-forge makers produce:
 #   - macOS   → .zip          (the .dmg maker is a follow-up)
-#   - Windows → Setup.exe + .nupkg + RELEASES (Squirrel)
+#   - Windows → NSIS installer (.exe)
 #   - Linux   → .deb and .rpm
 #
 # Each OS builds on its own native runner because build-daemon.mjs compiles the

--- a/.github/workflows/testing-build.yml
+++ b/.github/workflows/testing-build.yml
@@ -6,7 +6,7 @@ name: Testing build (all platforms)
 #
 # Per OS:
 #   Linux   -> .deb
-#   Windows -> Setup.exe (+ .nupkg / RELEASES)
+#   Windows -> NSIS installer (.exe)
 #   macOS   -> .zip (arm64; dmg + signing are follow-ups)
 #
 # Unsigned: macOS is quarantined/Gatekeeper-blocked once downloaded
@@ -29,7 +29,9 @@ jobs:
           - os: ubuntu-latest
             target: "@electron-forge/maker-deb"
           - os: windows-latest
-            target: "@electron-forge/maker-squirrel"
+            # Our custom NSIS maker's `name` (see makers/maker-nsis.ts); forge
+            # `--targets` matches the configured maker instance by this name.
+            target: "nsis"
           - os: macos-latest
             target: "@electron-forge/maker-zip"
     runs-on: ${{ matrix.os }}
@@ -58,10 +60,10 @@ jobs:
         # `npm run make` keeps the premake daemon build; --targets restricts to this
         # platform's maker.
         run: npm run make -- --targets ${{ matrix.target }}
-      # Smoke-install the Squirrel installer on a clean, native x64 Windows runner.
+      # Smoke-install the NSIS installer on a clean, native x64 Windows runner.
       # This is a build-vs-host verdict: if it installs here it proves the artifact
       # is good and a failing user machine is host-side (AV/disk/signing); if it
-      # fails here the build/Squirrel config is wrong. continue-on-error so a failed
+      # fails here the build/NSIS config is wrong. continue-on-error so a failed
       # install never blocks publishing the artifacts. The runner has no real-time
       # AV blocking, so a clean install here does NOT prove SmartScreen/Defender
       # won't reject the unsigned binaries on end-user machines.
@@ -71,33 +73,26 @@ jobs:
         timeout-minutes: 5
         shell: pwsh
         run: |
-          $setup = Get-ChildItem -Path out/make/squirrel.windows -Recurse -Filter '*Setup.exe' | Select-Object -First 1
-          if (-not $setup) { Write-Host '::error::no Setup.exe produced under out/make/squirrel.windows'; exit 1 }
-          Write-Host "Running $($setup.FullName) --silent"
-          $proc = Start-Process -FilePath $setup.FullName -ArgumentList '--silent' -PassThru -Wait
-          Write-Host "Setup.exe exit code: $($proc.ExitCode)"
-          $installDir = Join-Path $env:LOCALAPPDATA 'AgentOrchestrator'
-          # Update.exe writes SquirrelSetup.log into the app root dir; the Setup.exe
-          # bootstrapper only logs to SquirrelTemp for the earliest extraction stage.
-          # Grab whichever exists and copy it into the workspace for upload.
-          $log = @(
-            (Join-Path $installDir 'SquirrelSetup.log'),
-            (Join-Path $env:LOCALAPPDATA 'SquirrelTemp\SquirrelSetup.log')
+          $setup = Get-ChildItem -Path out/make -Recurse -Filter '*.exe' |
+            Where-Object { $_.Name -like '*Setup*' } | Select-Object -First 1
+          if (-not $setup) { $setup = Get-ChildItem -Path out/make -Recurse -Filter '*.exe' | Select-Object -First 1 }
+          if (-not $setup) { Write-Host '::error::no NSIS installer (.exe) produced under out/make'; exit 1 }
+          Write-Host "Running $($setup.FullName) /S (silent)"
+          # electron-builder NSIS (assisted installer): /S installs silently.
+          $proc = Start-Process -FilePath $setup.FullName -ArgumentList '/S' -PassThru -Wait
+          Write-Host "Installer exit code: $($proc.ExitCode)"
+          # Per-user assisted install lands under %LOCALAPPDATA%\Programs; a
+          # per-machine install would land under Program Files.
+          $installDir = @(
+            (Join-Path $env:LOCALAPPDATA 'Programs\Agent Orchestrator'),
+            (Join-Path ${env:ProgramFiles} 'Agent Orchestrator')
           ) | Where-Object { Test-Path $_ } | Select-Object -First 1
-          if ($log) { Copy-Item $log squirrel-setup.log; Write-Host "captured log: $log" } else { Write-Host '::warning::no SquirrelSetup.log found in install dir or SquirrelTemp' }
-          if (Test-Path $installDir) {
+          if ($installDir) {
             Write-Host "INSTALL OK: $installDir created"
             Get-ChildItem $installDir | Select-Object Name | Format-Table -AutoSize
           } else {
-            Write-Host "::warning::INSTALL FAILED: $installDir was not created"
+            Write-Host "::warning::INSTALL: no known install dir found (checked LOCALAPPDATA\Programs and Program Files)"
           }
-      - name: Upload SquirrelSetup.log
-        if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
-        with:
-          name: squirrel-setup-log-${{ github.sha }}
-          path: frontend/squirrel-setup.log
-          if-no-files-found: warn
       - name: Publish to a 0.0.0-testing-<sha> prerelease
         shell: bash
         env:
@@ -114,7 +109,7 @@ jobs:
           # "already exists" which is fine (|| true). Distinct asset names + --clobber
           # make uploads idempotent across re-runs.
           gh release create "$TAG" --prerelease --target "$GITHUB_SHA" --title "$TAG" \
-            --notes "Unsigned testing build (Linux .deb / Windows Setup.exe / macOS .zip). Not signed; for testing only." \
+            --notes "Unsigned testing build (Linux .deb / Windows NSIS .exe / macOS .zip). Not signed; for testing only." \
             || true
           # NUL-delimited to survive spaces in the app name ("Agent Orchestrator-...").
           find out/make -type f -print0 | while IFS= read -r -d '' f; do

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ Thumbs.db
 # electron-forge / vite build output
 .vite/
 dist-electron/
+# electron-builder debug dump, written to the cwd on every NSIS build
+builder-debug.yml
 
 # playwright artifacts
 frontend/test-results/

--- a/frontend/docs/desktop-release.md
+++ b/frontend/docs/desktop-release.md
@@ -32,8 +32,9 @@ checklist.
    - `GITHUB_TOKEN` is provided automatically; the workflow already grants
      `contents: write` to publish the Release.
 3. **(Optional) Windows / Linux** — the `forge.config.ts` makers already include
-   Squirrel (Windows), deb, and rpm. To publish them, add the matching matrix
-   runners to `frontend-release.yml`; Windows signing needs its own certificate.
+   NSIS (Windows, via `makers/maker-nsis.ts`), deb, and rpm. To publish them, add
+   the matching matrix runners to `frontend-release.yml`; Windows code-signing
+   needs its own certificate (still a follow-up, see issue #401).
 
 ## Cutting a release
 

--- a/frontend/forge.config.ts
+++ b/frontend/forge.config.ts
@@ -1,5 +1,6 @@
 import type { ForgeConfig } from "@electron-forge/shared-types";
 import { VitePlugin } from "@electron-forge/plugin-vite";
+import MakerNSIS from "./makers/maker-nsis";
 
 const config: ForgeConfig = {
 	packagerConfig: {
@@ -27,24 +28,25 @@ const config: ForgeConfig = {
 	},
 	rebuildConfig: {},
 	makers: [
-		{
-			name: "@electron-forge/maker-squirrel",
-			config: {
-				name: "AgentOrchestrator",
-				// NuGet requires a non-empty <authors>; without it `nuget pack`
-				// exits 1 and the Squirrel maker fails. Mirror package.json.author.
-				authors: "Agent Orchestrator",
-				setupIcon: "assets/icon.ico",
+		// Windows installer: NSIS via electron-builder (see makers/maker-nsis.ts).
+		// Replaces Squirrel.Windows, which only does per-user installs with no
+		// custom install dir or proper uninstaller (issue #401).
+		new MakerNSIS(
+			{
+				appId: "dev.agent-orchestrator.desktop",
+				productName: "Agent Orchestrator",
+				icon: "assets/icon.ico",
 			},
-		},
+			["win32"],
+		),
 		{ name: "@electron-forge/maker-zip", platforms: ["darwin"], config: {} },
 		{
 			name: "@electron-forge/maker-deb",
 			config: {
 				options: {
-					// Must match packagerConfig.executableName; otherwise the deb
-					// maker looks for `agent-orchestrator-frontend` (the package name)
-					// and fails with "could not find the Electron app binary".
+					// Must match packagerConfig.executableName, or the deb maker
+					// looks for the package name and fails with "could not find
+					// the Electron app binary". (Both are "agent-orchestrator".)
 					bin: "agent-orchestrator",
 					icon: "assets/icon.png",
 					maintainer: "Agent Orchestrator",

--- a/frontend/makers/maker-nsis.test.ts
+++ b/frontend/makers/maker-nsis.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
 // Capture buildForge's args without pulling in electron-builder's real machinery.
-const buildForge = vi.fn<(forge: { dir: string }, options: any) => Promise<string[]>>(
-	async () => ["/out/make/Agent Orchestrator Setup.exe"],
-);
+const buildForge = vi.fn<(forge: { dir: string }, options: any) => Promise<string[]>>(async () => [
+	"/out/make/Agent Orchestrator Setup.exe",
+]);
 vi.mock("app-builder-lib", () => ({ buildForge }));
 
 import MakerNSIS from "./maker-nsis";
@@ -27,10 +27,7 @@ describe("MakerNSIS", () => {
 	});
 
 	it("builds an nsis target for the requested arch and forwards config", async () => {
-		const maker = new MakerNSIS(
-			{ appId: "dev.agent-orchestrator.desktop", icon: "assets/icon.ico" },
-			["win32"],
-		);
+		const maker = new MakerNSIS({ appId: "dev.agent-orchestrator.desktop", icon: "assets/icon.ico" }, ["win32"]);
 		// Forge resolves the (possibly arch-dependent) config before make().
 		await maker.prepareConfig(makeOptions.targetArch);
 		const artifacts = await maker.make(makeOptions);

--- a/frontend/makers/maker-nsis.test.ts
+++ b/frontend/makers/maker-nsis.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Capture buildForge's args without pulling in electron-builder's real machinery.
+const buildForge = vi.fn<(forge: { dir: string }, options: any) => Promise<string[]>>(
+	async () => ["/out/make/Agent Orchestrator Setup.exe"],
+);
+vi.mock("app-builder-lib", () => ({ buildForge }));
+
+import MakerNSIS from "./maker-nsis";
+
+const makeOptions = {
+	dir: "/tmp/app/Agent Orchestrator-win32-x64",
+	makeDir: "/tmp/app/make",
+	appName: "Agent Orchestrator",
+	targetPlatform: "win32" as const,
+	targetArch: "x64" as const,
+	forgeConfig: {} as never,
+	packageJSON: {},
+};
+
+describe("MakerNSIS", () => {
+	it("targets win32 and is supported anywhere (cross-build allowed)", () => {
+		const maker = new MakerNSIS();
+		expect(maker.name).toBe("nsis");
+		expect(maker.defaultPlatforms).toEqual(["win32"]);
+		expect(maker.isSupportedOnCurrentPlatform()).toBe(true);
+	});
+
+	it("builds an nsis target for the requested arch and forwards config", async () => {
+		const maker = new MakerNSIS(
+			{ appId: "dev.agent-orchestrator.desktop", icon: "assets/icon.ico" },
+			["win32"],
+		);
+		// Forge resolves the (possibly arch-dependent) config before make().
+		await maker.prepareConfig(makeOptions.targetArch);
+		const artifacts = await maker.make(makeOptions);
+
+		expect(artifacts).toEqual(["/out/make/Agent Orchestrator Setup.exe"]);
+		const [forgeOptions, options] = buildForge.mock.calls[0];
+		expect(forgeOptions).toEqual({ dir: makeOptions.dir });
+		expect(options.win).toEqual(["nsis:x64"]);
+		expect(options.config.appId).toBe("dev.agent-orchestrator.desktop");
+		// productName falls back to appName when not set on the maker config.
+		expect(options.config.productName).toBe("Agent Orchestrator");
+		expect(options.config.win).toEqual({ icon: "assets/icon.ico" });
+		// A real installer: not Squirrel's silent one-click per-user drop.
+		expect(options.config.nsis.oneClick).toBe(false);
+		expect(options.config.nsis.allowToChangeInstallationDirectory).toBe(true);
+	});
+});

--- a/frontend/makers/maker-nsis.test.ts
+++ b/frontend/makers/maker-nsis.test.ts
@@ -36,6 +36,8 @@ describe("MakerNSIS", () => {
 		const [forgeOptions, options] = buildForge.mock.calls[0];
 		expect(forgeOptions).toEqual({ dir: makeOptions.dir });
 		expect(options.win).toEqual(["nsis:x64"]);
+		// electron-builder must not try to publish; the workflow does that.
+		expect(options.config.publish).toBeNull();
 		expect(options.config.appId).toBe("dev.agent-orchestrator.desktop");
 		// productName falls back to appName when not set on the maker config.
 		expect(options.config.productName).toBe("Agent Orchestrator");

--- a/frontend/makers/maker-nsis.ts
+++ b/frontend/makers/maker-nsis.ts
@@ -44,6 +44,11 @@ export default class MakerNSIS extends MakerBase<MakerNSISConfig> {
 					appId: cfg.appId,
 					productName: cfg.productName ?? appName,
 					directories: { output },
+					// Forge owns publishing (the workflow uploads via `gh release`).
+					// `null` stops electron-builder from inferring a GitHub publish
+					// target from package.json `repository` and trying to upload,
+					// which fails in CI with no GH_TOKEN set.
+					publish: null,
 					...(cfg.icon ? { win: { icon: cfg.icon } } : {}),
 					nsis: {
 						// A real installer, not Squirrel's silent per-user drop.

--- a/frontend/makers/maker-nsis.ts
+++ b/frontend/makers/maker-nsis.ts
@@ -1,0 +1,63 @@
+import path from "node:path";
+import { MakerBase, type MakerOptions } from "@electron-forge/maker-base";
+import type { ForgePlatform } from "@electron-forge/shared-types";
+
+// Electron Forge has no first-party NSIS maker, so we bridge to electron-builder's
+// `buildForge`, the same engine recordly's working Windows installer uses. We drop
+// Squirrel.Windows (per-user only, no custom install dir, fragile updates) for a
+// real NSIS installer: per-user or per-machine, custom install directory, and a
+// proper uninstaller. See https://github.com/aoagents/ReverbCode/issues/401.
+//
+// `buildForge` speaks Forge's legacy v5 function API, which Forge 7's class-based
+// maker loader cannot resolve, so this thin MakerBase subclass adapts it.
+
+export type MakerNSISConfig = {
+	// electron-builder appId; required for a well-formed NSIS installer.
+	appId?: string;
+	// Display name for the installer + Start menu shortcut. Defaults to appName.
+	productName?: string;
+	// Path to the Windows .ico used for the app and installer.
+	icon?: string;
+	// Any extra electron-builder `nsis` options, merged over our defaults.
+	nsis?: Record<string, unknown>;
+};
+
+export default class MakerNSIS extends MakerBase<MakerNSISConfig> {
+	name = "nsis";
+	defaultPlatforms: ForgePlatform[] = ["win32"];
+
+	isSupportedOnCurrentPlatform(): boolean {
+		return true;
+	}
+
+	async make({ dir, targetArch, appName }: MakerOptions): Promise<string[]> {
+		const { buildForge } = await import("app-builder-lib");
+		const cfg = this.config ?? {};
+		// Mirror buildForge's own output layout (<dir>/../make) so artifacts land
+		// where Forge's publisher expects them.
+		const output = path.join(path.dirname(path.resolve(dir)), "make");
+		return buildForge(
+			{ dir },
+			{
+				win: [`nsis:${targetArch}`],
+				config: {
+					appId: cfg.appId,
+					productName: cfg.productName ?? appName,
+					directories: { output },
+					...(cfg.icon ? { win: { icon: cfg.icon } } : {}),
+					nsis: {
+						// A real installer, not Squirrel's silent per-user drop.
+						oneClick: false,
+						perMachine: false,
+						allowToChangeInstallationDirectory: true,
+						createDesktopShortcut: true,
+						createStartMenuShortcut: true,
+						...cfg.nsis,
+					},
+				},
+			},
+		);
+	}
+}
+
+export { MakerNSIS };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,6 @@
 				"@xterm/xterm": "^5.5.0",
 				"class-variance-authority": "^0.7.1",
 				"clsx": "^2.1.1",
-				"electron-squirrel-startup": "^1.0.1",
 				"lucide-react": "^1.17.0",
 				"openapi-fetch": "^0.17.0",
 				"posthog-js": "^1.390.2",
@@ -9281,30 +9280,6 @@
 			"engines": {
 				"node": ">= 10.0.0"
 			}
-		},
-		"node_modules/electron-squirrel-startup": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/electron-squirrel-startup/-/electron-squirrel-startup-1.0.1.tgz",
-			"integrity": "sha512-sTfFIHGku+7PsHLJ7v0dRcZNkALrV+YEozINTW8X1nM//e5O3L+rfYuvSW00lmGHnYmUjARZulD8F2V8ISI9RA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"debug": "^2.2.0"
-			}
-		},
-		"node_modules/electron-squirrel-startup/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/electron-squirrel-startup/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.371",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "agent-orchestrator-frontend",
+	"name": "agent-orchestrator",
 	"version": "0.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "agent-orchestrator-frontend",
+			"name": "agent-orchestrator",
 			"version": "0.0.0",
 			"license": "MIT",
 			"dependencies": {
@@ -38,9 +38,9 @@
 			},
 			"devDependencies": {
 				"@electron-forge/cli": "^7.8.0",
+				"@electron-forge/maker-base": "^7.8.0",
 				"@electron-forge/maker-deb": "^7.8.0",
 				"@electron-forge/maker-rpm": "^7.8.0",
-				"@electron-forge/maker-squirrel": "^7.8.0",
 				"@electron-forge/maker-zip": "^7.8.0",
 				"@electron-forge/plugin-vite": "^7.8.0",
 				"@electron-forge/publisher-github": "^7.8.0",
@@ -53,6 +53,7 @@
 				"@types/react": "^19.2.17",
 				"@types/react-dom": "^19.2.3",
 				"@vitejs/plugin-react": "^6.0.2",
+				"app-builder-lib": "^26.15.3",
 				"electron": "^33.0.0",
 				"jsdom": "^29.1.1",
 				"openapi-typescript": "^7.13.0",
@@ -1264,62 +1265,6 @@
 				"electron-installer-redhat": "^3.2.0"
 			}
 		},
-		"node_modules/@electron-forge/maker-squirrel": {
-			"version": "7.11.2",
-			"resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-7.11.2.tgz",
-			"integrity": "sha512-4CILo57ZDEQH1mJxjhYCSXuv+WaU7oPq67KqiTLEUOEzmiPg9u9/z7FXE34H/Tn5aKWN3dy+ngAETzv6iERCGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@electron-forge/maker-base": "7.11.2",
-				"@electron-forge/shared-types": "7.11.2",
-				"fs-extra": "^10.0.0"
-			},
-			"engines": {
-				"node": ">= 16.4.0"
-			},
-			"optionalDependencies": {
-				"electron-winstaller": "^5.3.0"
-			}
-		},
-		"node_modules/@electron-forge/maker-squirrel/node_modules/fs-extra": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@electron-forge/maker-squirrel/node_modules/jsonfile": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/@electron-forge/maker-squirrel/node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
 		"node_modules/@electron-forge/maker-zip": {
 			"version": "7.11.2",
 			"resolved": "https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-7.11.2.tgz",
@@ -2067,6 +2012,60 @@
 				"node": "*"
 			}
 		},
+		"node_modules/@electron/fuses": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
+			"integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^4.1.1",
+				"fs-extra": "^9.0.1",
+				"minimist": "^1.2.5"
+			},
+			"bin": {
+				"electron-fuses": "dist/bin.js"
+			}
+		},
+		"node_modules/@electron/fuses/node_modules/fs-extra": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"at-least-node": "^1.0.0",
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@electron/fuses/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/@electron/fuses/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
 		"node_modules/@electron/get": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
@@ -2610,6 +2609,27 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/@electron/rebuild": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.4.tgz",
+			"integrity": "sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@malept/cross-spawn-promise": "^2.0.0",
+				"debug": "^4.1.1",
+				"node-abi": "^4.2.0",
+				"node-api-version": "^0.2.1",
+				"node-gyp": "^12.2.0",
+				"read-binary-file-arch": "^1.0.6"
+			},
+			"bin": {
+				"electron-rebuild": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=22.12.0"
+			}
+		},
 		"node_modules/@electron/universal": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz",
@@ -3114,6 +3134,19 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@isaacs/fs-minipass": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+			"integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.4"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -3227,6 +3260,61 @@
 				"node": ">= 12.13.0"
 			}
 		},
+		"node_modules/@malept/flatpak-bundler": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+			"integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"fs-extra": "^9.0.0",
+				"lodash": "^4.17.15",
+				"tmp-promise": "^3.0.2"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@malept/flatpak-bundler/node_modules/fs-extra": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"at-least-node": "^1.0.0",
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@malept/flatpak-bundler/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/@malept/flatpak-bundler/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -3244,6 +3332,19 @@
 			"peerDependencies": {
 				"@emnapi/core": "^1.7.1",
 				"@emnapi/runtime": "^1.7.1"
+			}
+		},
+		"node_modules/@noble/hashes": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+			"integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20.19.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -3685,6 +3786,58 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@peculiar/asn1-schema": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+			"integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/utils": "^2.0.2",
+				"asn1js": "^3.0.10",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/json-schema": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+			"integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@peculiar/utils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+			"integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/webcrypto": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
+			"integrity": "sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.7.0",
+				"@peculiar/json-schema": "^1.1.12",
+				"@peculiar/utils": "^2.0.2",
+				"tslib": "^2.8.1",
+				"webcrypto-core": "^1.9.2"
+			},
+			"engines": {
+				"node": ">=14.18.0"
 			}
 		},
 		"node_modules/@playwright/test": {
@@ -6233,6 +6386,16 @@
 				"assertion-error": "^2.0.1"
 			}
 		},
+		"node_modules/@types/debug": {
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+			"integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/ms": "*"
+			}
+		},
 		"node_modules/@types/deep-eql": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -6251,8 +6414,8 @@
 			"version": "9.0.13",
 			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
 			"integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+			"devOptional": true,
 			"license": "MIT",
-			"optional": true,
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -6280,6 +6443,13 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
+		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/mute-stream": {
 			"version": "0.0.4",
@@ -6741,6 +6911,16 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
+		"node_modules/abbrev": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+			"integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.16.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -6927,6 +7107,161 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/app-builder-lib": {
+			"version": "26.15.3",
+			"resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.3.tgz",
+			"integrity": "sha512-2VnyWkqsP5v5XbBhL3tD5Syx8iNPBYsoU7kY4S2fz7wg8Rj/nztWKCUzGKaFRTv0Xwf3/H058CR1Kvtd/3lRow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@electron/asar": "3.4.1",
+				"@electron/fuses": "^1.8.0",
+				"@electron/get": "^3.0.0",
+				"@electron/notarize": "2.5.0",
+				"@electron/osx-sign": "1.3.3",
+				"@electron/rebuild": "^4.0.4",
+				"@electron/universal": "2.0.3",
+				"@malept/flatpak-bundler": "^0.4.0",
+				"@noble/hashes": "^2.2.0",
+				"@peculiar/webcrypto": "^1.7.1",
+				"@types/fs-extra": "9.0.13",
+				"ajv": "^8.18.0",
+				"asn1js": "^3.0.10",
+				"async-exit-hook": "^2.0.1",
+				"builder-util": "26.15.3",
+				"builder-util-runtime": "9.7.0",
+				"chromium-pickle-js": "^0.2.0",
+				"ci-info": "4.3.1",
+				"debug": "^4.3.4",
+				"dotenv": "^16.4.5",
+				"dotenv-expand": "^11.0.6",
+				"ejs": "^3.1.8",
+				"electron-publish": "26.15.3",
+				"fs-extra": "^10.1.0",
+				"hosted-git-info": "^4.1.0",
+				"isbinaryfile": "^5.0.0",
+				"jiti": "^2.4.2",
+				"js-yaml": "^4.1.0",
+				"json5": "^2.2.3",
+				"lazy-val": "^1.0.5",
+				"minimatch": "^10.2.5",
+				"pkijs": "^3.4.0",
+				"plist": "3.1.0",
+				"proper-lockfile": "^4.1.2",
+				"resedit": "^1.7.0",
+				"semver": "~7.7.3",
+				"tar": "^7.5.7",
+				"temp-file": "^3.4.0",
+				"tiny-async-pool": "1.3.0",
+				"unzipper": "^0.12.3",
+				"which": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"dmg-builder": "26.15.3",
+				"electron-builder-squirrel-windows": "26.15.3"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/@electron/get": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
+			"integrity": "sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1",
+				"env-paths": "^2.2.0",
+				"fs-extra": "^8.1.0",
+				"got": "^11.8.5",
+				"progress": "^2.0.3",
+				"semver": "^6.2.0",
+				"sumchecker": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"optionalDependencies": {
+				"global-agent": "^3.0.0"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/@electron/get/node_modules/fs-extra": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/@electron/get/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/fs-extra/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/fs-extra/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/app-builder-lib/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -6956,6 +7291,21 @@
 				"dequal": "^2.0.3"
 			}
 		},
+		"node_modules/asn1js": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+			"integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"pvtsutils": "^1.3.6",
+				"pvutils": "^1.1.5",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/assertion-error": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -6965,6 +7315,30 @@
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/async": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/async-exit-hook": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+			"integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/at-least-node": {
 			"version": "1.0.0",
@@ -6986,6 +7360,13 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/aws4": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+			"integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/babel-dead-code-elimination": {
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/babel-dead-code-elimination/-/babel-dead-code-elimination-1.0.12.tgz",
@@ -6997,6 +7378,16 @@
 				"@babel/parser": "^7.23.6",
 				"@babel/traverse": "^7.23.7",
 				"@babel/types": "^7.23.6"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/base64-js": {
@@ -7100,6 +7491,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
 		"node_modules/braces": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -7188,6 +7592,94 @@
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/builder-util": {
+			"version": "26.15.3",
+			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.15.3.tgz",
+			"integrity": "sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/debug": "^4.1.6",
+				"builder-util-runtime": "9.7.0",
+				"chalk": "^4.1.2",
+				"cross-spawn": "^7.0.6",
+				"debug": "^4.3.4",
+				"fs-extra": "^10.1.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.0",
+				"js-yaml": "^4.1.0",
+				"sanitize-filename": "^1.6.3",
+				"source-map-support": "^0.5.19",
+				"stat-mode": "^1.0.0",
+				"temp-file": "^3.4.0",
+				"tiny-async-pool": "1.3.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/builder-util-runtime": {
+			"version": "9.7.0",
+			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+			"integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.3.4",
+				"sax": "^1.2.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/builder-util/node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/builder-util/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/builder-util/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/bytestreamjs": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+			"integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=6.0.0"
+			}
 		},
 		"node_modules/cacache": {
 			"version": "16.1.3",
@@ -7451,6 +7943,20 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/caniuse-lite": {
 			"version": "1.0.30001799",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
@@ -7529,6 +8035,16 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
+		"node_modules/chownr": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/chrome-trace-event": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -7537,6 +8053,29 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0"
+			}
+		},
+		"node_modules/chromium-pickle-js": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+			"integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/ci-info": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+			"integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/class-variance-authority": {
@@ -7745,6 +8284,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/commander": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
@@ -7795,6 +8347,13 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/core-js"
 			}
+		},
+		"node_modules/core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/cross-dirname": {
 			"version": "0.1.0",
@@ -8022,6 +8581,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/deprecation": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -8115,6 +8684,61 @@
 				"node": "*"
 			}
 		},
+		"node_modules/dmg-builder": {
+			"version": "26.15.3",
+			"resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.3.tgz",
+			"integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"app-builder-lib": "26.15.3",
+				"builder-util": "26.15.3",
+				"fs-extra": "^10.1.0",
+				"js-yaml": "^4.1.0"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/dmg-builder/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
 		"node_modules/dom-accessibility-api": {
 			"version": "0.5.16",
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -8132,12 +8756,82 @@
 				"@types/trusted-types": "^2.0.7"
 			}
 		},
+		"node_modules/dotenv": {
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+			"integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
+		"node_modules/dotenv-expand": {
+			"version": "11.0.7",
+			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+			"integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dotenv": "^16.4.5"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/duplexer2": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"readable-stream": "^2.0.2"
+			}
+		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/ejs": {
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+			"integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"jake": "^10.8.5"
+			},
+			"bin": {
+				"ejs": "bin/cli.js"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/electron": {
 			"version": "33.4.11",
@@ -8156,6 +8850,19 @@
 			},
 			"engines": {
 				"node": ">= 12.20.55"
+			}
+		},
+		"node_modules/electron-builder-squirrel-windows": {
+			"version": "26.15.3",
+			"resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.3.tgz",
+			"integrity": "sha512-Jc19XPV9y9+2bAdZPkXuVNGNIEFBq9poHC61l8Kv6FdK7DRG3+Ic0rerC0DXOaeHNz8yW0fg/JnF8GQROOF5MA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"app-builder-lib": "26.15.3",
+				"builder-util": "26.15.3",
+				"electron-winstaller": "5.4.0"
 			}
 		},
 		"node_modules/electron-installer-common": {
@@ -8519,6 +9226,62 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/electron-publish": {
+			"version": "26.15.3",
+			"resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.3.tgz",
+			"integrity": "sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/fs-extra": "^9.0.11",
+				"aws4": "^1.13.2",
+				"builder-util": "26.15.3",
+				"builder-util-runtime": "9.7.0",
+				"chalk": "^4.1.2",
+				"form-data": "^4.0.5",
+				"fs-extra": "^10.1.0",
+				"lazy-val": "^1.0.5",
+				"mime": "^2.5.2"
+			}
+		},
+		"node_modules/electron-publish/node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/electron-publish/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/electron-publish/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
 		"node_modules/electron-squirrel-startup": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/electron-squirrel-startup/-/electron-squirrel-startup-1.0.1.tgz",
@@ -8557,7 +9320,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@electron/asar": "^3.2.1",
 				"debug": "^4.1.1",
@@ -8578,7 +9341,7 @@
 			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.1.2",
 				"jsonfile": "^4.0.0",
@@ -8690,7 +9453,6 @@
 			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -8711,6 +9473,35 @@
 			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/es6-error": {
 			"version": "4.1.1",
@@ -9094,6 +9885,46 @@
 			"integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
 			"license": "MIT"
 		},
+		"node_modules/filelist": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+			"integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"minimatch": "^5.0.1"
+			}
+		},
+		"node_modules/filelist/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/filelist/node_modules/brace-expansion": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/filelist/node_modules/minimatch": {
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/filename-reserved-regex": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
@@ -9202,6 +10033,23 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/form-data": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/fs-extra": {
@@ -9372,6 +10220,31 @@
 				"get-folder-size": "bin/get-folder-size"
 			}
 		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/get-nonce": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
@@ -9413,6 +10286,20 @@
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/get-stream": {
 			"version": "5.2.0",
@@ -9585,7 +10472,6 @@
 			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -9650,6 +10536,35 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/hasown": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -9661,6 +10576,19 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/hosted-git-info": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+			"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/html-encoding-sniffer": {
@@ -9682,6 +10610,20 @@
 			"integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
 			"dev": true,
 			"license": "BSD-2-Clause"
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
 		},
 		"node_modules/http2-wrapper": {
 			"version": "1.0.3",
@@ -9963,6 +10905,26 @@
 			"integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
 			"license": "MIT"
 		},
+		"node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/isbinaryfile": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
+			"integrity": "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/gjtorikian/"
+			}
+		},
 		"node_modules/isbot": {
 			"version": "5.1.42",
 			"resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.42.tgz",
@@ -9970,6 +10932,34 @@
 			"license": "Unlicense",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/isexe": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+			"integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/jake": {
+			"version": "10.9.4",
+			"resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+			"integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"async": "^3.2.6",
+				"filelist": "^1.0.4",
+				"picocolors": "^1.1.1"
+			},
+			"bin": {
+				"jake": "bin/cli.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/jest-worker": {
@@ -10029,6 +11019,29 @@
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/js-yaml": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
 		},
 		"node_modules/jsdom": {
 			"version": "29.1.1",
@@ -10158,6 +11171,13 @@
 			"dependencies": {
 				"json-buffer": "3.0.1"
 			}
+		},
+		"node_modules/lazy-val": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
+			"integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lightningcss": {
 			"version": "1.32.0",
@@ -10593,8 +11613,8 @@
 			"version": "4.18.1",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
 			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-			"license": "MIT",
-			"optional": true
+			"devOptional": true,
+			"license": "MIT"
 		},
 		"node_modules/lodash.get": {
 			"version": "4.4.2",
@@ -10765,6 +11785,19 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/lucide-react": {
 			"version": "1.17.0",
 			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.17.0.tgz",
@@ -10915,6 +11948,16 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/mdn-data": {
 			"version": "2.27.1",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -10981,6 +12024,19 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/mime": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+			"integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
 		"node_modules/mime-db": {
 			"version": "1.52.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -11034,6 +12090,22 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/minimist": {
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -11042,6 +12114,16 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/minipass-collect": {
@@ -11193,13 +12275,26 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/minizlib": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
 		"node_modules/mkdirp": {
 			"version": "0.5.6",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
 			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"minimist": "^1.2.6"
 			},
@@ -11265,6 +12360,32 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/node-abi": {
+			"version": "4.31.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.31.0.tgz",
+			"integrity": "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.6.3"
+			},
+			"engines": {
+				"node": ">=22.12.0"
+			}
+		},
+		"node_modules/node-abi/node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/node-api-version": {
 			"version": "0.2.1",
@@ -11335,6 +12456,87 @@
 				"webidl-conversions": "^3.0.0"
 			}
 		},
+		"node_modules/node-gyp": {
+			"version": "12.4.0",
+			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+			"integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"env-paths": "^2.2.0",
+				"exponential-backoff": "^3.1.1",
+				"graceful-fs": "^4.2.6",
+				"nopt": "^9.0.0",
+				"proc-log": "^6.0.0",
+				"semver": "^7.3.5",
+				"tar": "^7.5.4",
+				"tinyglobby": "^0.2.12",
+				"undici": "^6.25.0",
+				"which": "^6.0.0"
+			},
+			"bin": {
+				"node-gyp": "bin/node-gyp.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/node-gyp/node_modules/isexe": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+			"integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/node-gyp/node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/node-gyp/node_modules/undici": {
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+			"integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.17"
+			}
+		},
+		"node_modules/node-gyp/node_modules/which": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+			"integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^4.0.0"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/node-releases": {
 			"version": "2.0.47",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
@@ -11343,6 +12545,22 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/nopt": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+			"integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"abbrev": "^4.0.0"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/normalize-package-data": {
@@ -11784,6 +13002,21 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/pe-library": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
+			"integrity": "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/jet2jet"
+			}
+		},
 		"node_modules/pend": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -11819,6 +13052,37 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/pkijs": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+			"integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@noble/hashes": "1.4.0",
+				"asn1js": "^3.0.6",
+				"bytestreamjs": "^2.0.1",
+				"pvtsutils": "^1.3.6",
+				"pvutils": "^1.1.3",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/pkijs/node_modules/@noble/hashes": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+			"integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/playwright": {
@@ -12005,6 +13269,23 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/proc-log": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+			"integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/progress": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -12036,6 +13317,18 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
 		"node_modules/pump": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -12055,6 +13348,26 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/pvtsutils": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+			"integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/pvutils": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+			"integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/query-selector-shadow-dom": {
@@ -12387,6 +13700,22 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
 		"node_modules/readdirp": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
@@ -12446,6 +13775,24 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resedit": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
+			"integrity": "sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pe-library": "^0.4.1"
+			},
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/jet2jet"
 			}
 		},
 		"node_modules/resolve": {
@@ -12542,7 +13889,7 @@
 			"deprecated": "Rimraf versions prior to v4 are no longer supported",
 			"dev": true,
 			"license": "ISC",
-			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -12640,6 +13987,26 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/sanitize-filename": {
+			"version": "1.6.4",
+			"resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+			"integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
+			"dev": true,
+			"license": "WTFPL OR ISC",
+			"dependencies": {
+				"truncate-utf8-bytes": "^1.0.0"
+			}
+		},
+		"node_modules/sax": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=11.0.0"
+			}
 		},
 		"node_modules/saxes": {
 			"version": "6.0.0",
@@ -12978,6 +14345,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/stat-mode": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
+			"integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/std-env": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
@@ -13156,19 +14533,95 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
+		"node_modules/tar": {
+			"version": "7.5.16",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+			"integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/fs-minipass": "^4.0.0",
+				"chownr": "^3.0.0",
+				"minipass": "^7.1.2",
+				"minizlib": "^3.1.0",
+				"yallist": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/tar/node_modules/yallist": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/temp": {
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
 			"integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"mkdirp": "^0.5.1",
 				"rimraf": "~2.6.2"
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/temp-file": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
+			"integrity": "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"async-exit-hook": "^2.0.1",
+				"fs-extra": "^10.0.0"
+			}
+		},
+		"node_modules/temp-file/node_modules/fs-extra": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/temp-file/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/temp-file/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/terser": {
@@ -13258,6 +14711,26 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/tiny-async-pool": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz",
+			"integrity": "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^5.5.0"
+			}
+		},
+		"node_modules/tiny-async-pool/node_modules/semver": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
 		"node_modules/tiny-each-async": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/tiny-each-async/-/tiny-each-async-2.0.3.tgz",
@@ -13333,8 +14806,8 @@
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
 			"integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+			"devOptional": true,
 			"license": "MIT",
-			"optional": true,
 			"engines": {
 				"node": ">=14.14"
 			}
@@ -13343,8 +14816,8 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
 			"integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+			"devOptional": true,
 			"license": "MIT",
-			"optional": true,
 			"dependencies": {
 				"tmp": "^0.2.0"
 			}
@@ -13409,6 +14882,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/truncate-utf8-bytes": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+			"integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+			"dev": true,
+			"license": "WTFPL",
+			"dependencies": {
+				"utf8-byte-length": "^1.0.1"
 			}
 		},
 		"node_modules/tslib": {
@@ -13518,6 +15001,58 @@
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/unzipper": {
+			"version": "0.12.5",
+			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.5.tgz",
+			"integrity": "sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bluebird": "~3.7.2",
+				"duplexer2": "~0.1.4",
+				"fs-extra": "11.3.1",
+				"graceful-fs": "^4.2.2",
+				"node-int64": "^0.4.0"
+			}
+		},
+		"node_modules/unzipper/node_modules/fs-extra": {
+			"version": "11.3.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+			"integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/unzipper/node_modules/jsonfile": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/unzipper/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/update-browserslist-db": {
@@ -13633,6 +15168,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/utf8-byte-length": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+			"integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+			"dev": true,
+			"license": "(WTFPL OR MIT)"
 		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
@@ -13877,6 +15419,20 @@
 			"integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
 			"license": "Apache-2.0"
 		},
+		"node_modules/webcrypto-core": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
+			"integrity": "sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.7.0",
+				"@peculiar/json-schema": "^1.1.12",
+				"@peculiar/utils": "^2.0.2",
+				"asn1js": "^3.0.10",
+				"tslib": "^2.8.1"
+			}
+		},
 		"node_modules/webidl-conversions": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -13984,6 +15540,22 @@
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/which": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+			"integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^3.1.1"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/why-is-node-running": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,7 +69,6 @@
 		"@xterm/xterm": "^5.5.0",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
-		"electron-squirrel-startup": "^1.0.1",
 		"lucide-react": "^1.17.0",
 		"openapi-fetch": "^0.17.0",
 		"posthog-js": "^1.390.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "agent-orchestrator-frontend",
+	"name": "agent-orchestrator",
 	"productName": "Agent Orchestrator",
 	"version": "0.0.0",
 	"private": true,
@@ -28,9 +28,9 @@
 	},
 	"devDependencies": {
 		"@electron-forge/cli": "^7.8.0",
+		"@electron-forge/maker-base": "^7.8.0",
 		"@electron-forge/maker-deb": "^7.8.0",
 		"@electron-forge/maker-rpm": "^7.8.0",
-		"@electron-forge/maker-squirrel": "^7.8.0",
 		"@electron-forge/maker-zip": "^7.8.0",
 		"@electron-forge/plugin-vite": "^7.8.0",
 		"@electron-forge/publisher-github": "^7.8.0",
@@ -43,6 +43,7 @@
 		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^6.0.2",
+		"app-builder-lib": "^26.15.3",
 		"electron": "^33.0.0",
 		"jsdom": "^29.1.1",
 		"openapi-typescript": "^7.13.0",

--- a/frontend/src/electron-squirrel-startup.d.ts
+++ b/frontend/src/electron-squirrel-startup.d.ts
@@ -1,7 +1,0 @@
-// electron-squirrel-startup ships no types. Its default export is the boolean
-// result of handling any --squirrel-* startup event (true when the app should
-// quit, false on macOS/Linux or a normal launch).
-declare module "electron-squirrel-startup" {
-	const startup: boolean;
-	export default startup;
-}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -12,7 +12,6 @@ import {
 	type OpenDialogOptions,
 } from "electron";
 import { updateElectronApp } from "update-electron-app";
-import squirrelStartup from "electron-squirrel-startup";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
@@ -38,8 +37,9 @@ import { createBrowserViewHost, type BrowserViewHost } from "./main/browser-view
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 declare const MAIN_WINDOW_VITE_NAME: string;
 
-// Windows GUI/Squirrel launches have no attached console, so process.stdout and
-// process.stderr are dead pipes. The daemon-output console.log/console.error calls
+// Windows GUI launches (e.g. from a Start-menu/desktop shortcut) have no attached
+// console, so process.stdout and process.stderr are dead pipes. The daemon-output
+// console.log/console.error calls
 // below then fail with EPIPE, and with no "error" listener that surfaces as an
 // uncaught exception that crashes the main process. Swallow broken-pipe write
 // errors on the std streams: a dropped log line is harmless, the crash is not.
@@ -48,18 +48,6 @@ const ignoreStdStreamError = (err: NodeJS.ErrnoException): void => {
 };
 process.stdout.on("error", ignoreStdStreamError);
 process.stderr.on("error", ignoreStdStreamError);
-
-// Windows Squirrel runs this exe with a --squirrel-{install,updated,uninstall,
-// obsolete} flag during install/update/uninstall. electron-squirrel-startup
-// creates/removes the shortcuts for that event and returns true; we then quit
-// immediately instead of booting the full app. A full launch (window + daemon
-// spawn) would hang the installer, which runs this hook and waits for it to
-// exit — that hang is the Squirrel-side failure. Returns false on macOS/Linux,
-// so this is a no-op there.
-const isSquirrelStartup: boolean = squirrelStartup;
-if (isSquirrelStartup) {
-	app.quit();
-}
 
 // Must run before app ready so the About panel and default-menu role labels use it.
 app.setName("Agent Orchestrator");
@@ -691,9 +679,6 @@ function initAutoUpdates(): void {
 }
 
 app.whenReady().then(() => {
-	// A Squirrel install/update hook already called app.quit() above; do no
-	// startup work (no window, no daemon spawn) so the hook exits promptly.
-	if (isSquirrelStartup) return;
 	registerRendererProtocol();
 	createWindow();
 	void startDaemon();

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -27,6 +27,7 @@
 		"src/**/*.ts",
 		"src/**/*.tsx",
 		"forge.config.ts",
+		"makers/**/*.ts",
 		"vite.main.config.ts",
 		"vite.preload.config.ts",
 		"vite.renderer.config.ts",


### PR DESCRIPTION
## What

Switches Windows desktop packaging from Squirrel.Windows to a real **NSIS** installer. Squirrel is a poor fit: per-user install only, no custom install directory, no proper add/remove-programs uninstaller, fragile updates. NSIS gives per-user or per-machine installs, a custom install dir, and a real uninstaller, matching recordly's working Windows setup.

Verified end-to-end: a clean NSIS install **boots on Windows** (first successful clean-install boot), and the full `testing-build` matrix is green (Windows `nsis` / Linux `deb` / macOS `zip`).

## How

Electron Forge ships no first-party NSIS maker, so this adds a thin `MakerBase` subclass (`frontend/makers/maker-nsis.ts`) that bridges to electron-builder's `buildForge` (the same engine electron-builder uses), scoped to `win32`. It exposes the NSIS knobs the issue calls for (`oneClick:false`, `allowToChangeInstallationDirectory`, per-machine) as an assisted installer, and sets `config.publish = null` so electron-builder doesn't try to upload (the workflow publishes via `gh release`).

- `forge.config.ts`: drop `maker-squirrel`, add the NSIS maker instance.
- `testing-build.yml`: target `nsis`; smoke-install via `/S` under `out/make`; drop Squirrel-only log capture.
- Remove `electron-squirrel-startup` (Squirrel-only install-hook handling) end to end.
- Rename the package `agent-orchestrator-frontend` → `agent-orchestrator` (this repo is the full app, not just a frontend; user-facing naming was already "Agent Orchestrator").
- gitignore electron-builder's `builder-debug.yml` dump.

## Scope

This lands the **NSIS** portion of #401. Explicitly **deferred** to separate follow-ups (issue stays open):
- Bundling `zellij.exe` so a fresh Windows install needs no manual zellij (the issue's primary acceptance criterion).
- An actionable "zellij not found" error at session-create.
- Windows code-signing.

Part of #401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)