### PR TITLE
fix(frontend): restore verification commands

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -5,10 +5,6 @@ name: Frontend
 # vitest.config.ts, and the repo had neither until #171) — this job is the
 # guard against that happening again.
 #
-# Typecheck is intentionally NOT run here yet: forge.config.ts and
-# update-electron-app carry pre-existing type errors. Add `npm run typecheck`
-# once those are fixed.
-
 on:
   push:
     branches: [main]
@@ -36,6 +32,9 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
 
       - name: Run vitest suite
         run: npx vitest run

--- a/frontend/forge.config.ts
+++ b/frontend/forge.config.ts
@@ -1,5 +1,6 @@
 import type { ForgeConfig } from "@electron-forge/shared-types";
 import { VitePlugin } from "@electron-forge/plugin-vite";
+import type { NotaryToolCredentials } from "@electron/notarize/lib/types";
 import MakerNSIS from "./makers/maker-nsis";
 
 const config: ForgeConfig = {
@@ -28,9 +29,8 @@ const config: ForgeConfig = {
 				: undefined,
 		osxNotarize: process.env.AO_NOTARY_PROFILE
 			? ({
-					tool: "notarytool",
 					keychainProfile: process.env.AO_NOTARY_PROFILE,
-				} as unknown as ForgeConfig["packagerConfig"]["osxNotarize"])
+				} satisfies NotaryToolCredentials)
 			: process.env.APPLE_ID
 				? {
 						appleId: process.env.APPLE_ID,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
 	},
 	"scripts": {
 		"build:daemon": "node ./scripts/build-daemon.mjs",
+		"build": "npm run build:daemon && electron-forge package",
 		"dev": "electron-forge start",
 		"dev:web": "VITE_NO_ELECTRON=1 vite --config vite.renderer.config.ts",
 		"prepackage": "npm run build:daemon",


### PR DESCRIPTION
## Summary

Closes #418.

Frontend verification works again on clean checkouts: `npm run typecheck` no longer fails on the Forge notarization config, and `npm run build` now exists as the documented package-build command.

The frontend workflow now runs typecheck before vitest, restoring the TypeScript guard that was previously disabled because of the pre-existing config error.

## Tests

- `cd frontend && npm run typecheck`
- `cd frontend && npm run build`
- `cd frontend && npm test -- --run`
- `git diff --check`
